### PR TITLE
Move blockListener to blocks.js; combine flyout listener

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -20,9 +20,10 @@ window.onload = function() {
     });
     window.workspace = workspace;
 
-    // @todo: Also bind to flyout events.
     // Block events.
     workspace.addChangeListener(vm.blockListener);
+    var flyoutWorkspace = workspace.toolbox_.flyout_.workspace_;
+    flyoutWorkspace.addChangeListener(vm.flyoutBlockListener);
 
     var explorer = document.getElementById('blockexplorer');
     workspace.addChangeListener(function() {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ var util = require('util');
 
 var Blocks = require('./engine/blocks');
 var Runtime = require('./engine/runtime');
-var adapter = require('./engine/adapter');
 
 /**
  * Handles connections between blocks, stage, and extensions.
@@ -20,83 +19,15 @@ function VirtualMachine () {
     instance.runtime = new Runtime(instance.blocks);
 
     /**
-     * Event listener for blocks. Handles validation and serves as a generic
-     * adapter between the blocks and the runtime interface.
-     *
-     * @param {Object} Blockly "block" event
+     * Event listeners for scratch-blocks.
      */
-    instance.blockListener = function (e) {
-        // Validate event
-        if (typeof e !== 'object') return;
-        if (typeof e.blockId !== 'string') return;
+    instance.blockListener = (
+        instance.blocks.generateBlockListener(false, instance.runtime)
+    );
 
-        // UI event: clicked stacks toggle in the runtime.
-        if (e.element === 'stackclick') {
-            instance.runtime.toggleStack(e.blockId);
-            return;
-        }
-
-        // Block create/update/destroy
-        switch (e.type) {
-        case 'create':
-            var newBlocks = adapter(e);
-            // A create event can create many blocks. Add them all.
-            for (var i = 0; i < newBlocks.length; i++) {
-                instance.blocks.createBlock(newBlocks[i], false);
-            }
-            break;
-        case 'change':
-            instance.blocks.changeBlock({
-                id: e.blockId,
-                element: e.element,
-                name: e.name,
-                value: e.newValue
-            });
-            break;
-        case 'move':
-            instance.blocks.moveBlock({
-                id: e.blockId,
-                oldParent: e.oldParentId,
-                oldInput: e.oldInputName,
-                newParent: e.newParentId,
-                newInput: e.newInputName
-            });
-            break;
-        case 'delete':
-            instance.blocks.deleteBlock({
-                id: e.blockId
-            });
-            break;
-        }
-    };
-
-    instance.flyoutBlockListener = function (e) {
-        switch (e.type) {
-        case 'create':
-            var newBlocks = adapter(e);
-            // A create event can create many blocks. Add them all.
-            for (var i = 0; i < newBlocks.length; i++) {
-                instance.blocks.createBlock(newBlocks[i], true);
-            }
-            break;
-        case 'change':
-            instance.blocks.changeBlock({
-                id: e.blockId,
-                element: e.element,
-                name: e.name,
-                value: e.newValue
-            });
-            break;
-        case 'delete':
-            instance.blocks.deleteBlock({
-                id: e.blockId
-            });
-            break;
-        case 'stackclick':
-            instance.runtime.toggleStack(e.blockId);
-            break;
-        }
-    };
+    instance.flyoutBlockListener = (
+        instance.blocks.generateBlockListener(true, instance.runtime)
+    );
 }
 
 /**


### PR DESCRIPTION
Fixes #59.

Consolidate block listener and flyout block listener implementations by generating functions for them. Move this code into the blocks module, and add the flyout listener to the VM playground.
