### PR TITLE
Refactor for block execution

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -16,6 +16,7 @@ Scratch3ControlBlocks.prototype.getPrimitives = function() {
         'control_forever': this.forever,
         'control_wait': this.wait,
         'control_if': this.if,
+        'control_if_else': this.ifElse,
         'control_stop': this.stop
     };
 };
@@ -51,6 +52,19 @@ Scratch3ControlBlocks.prototype.if = function(args, util) {
         util.stackFrame.executed = true;
         if (args.CONDITION) {
             util.startSubstack();
+        }
+    }
+};
+
+Scratch3ControlBlocks.prototype.ifElse = function(args, util) {
+    // Only execute one time. `ifElse` will be returned to
+    // when the substack finishes, but it shouldn't execute again.
+    if (util.stackFrame.executed === undefined) {
+        util.stackFrame.executed = true;
+        if (args.CONDITION) {
+            util.startSubstack(1);
+        } else {
+            util.startSubstack(2);
         }
     }
 };

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -40,7 +40,7 @@ Scratch3ControlBlocks.prototype.wait = function(argValues, util) {
     util.yield();
     util.timeout(function() {
         util.done();
-    }, 1000 * parseFloat(argValues[0]));
+    }, 1000 * argValues.DURATION);
 };
 
 Scratch3ControlBlocks.prototype.stop = function() {

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -22,7 +22,7 @@ Scratch3ControlBlocks.prototype.getPrimitives = function() {
 Scratch3ControlBlocks.prototype.repeat = function(argValues, util) {
     // Initialize loop
     if (util.stackFrame.loopCounter === undefined) {
-        util.stackFrame.loopCounter = parseInt(argValues[0]); // @todo arg
+        util.stackFrame.loopCounter = parseInt(argValues.TIMES);
     }
     // Decrease counter
     util.stackFrame.loopCounter--;

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -15,14 +15,15 @@ Scratch3ControlBlocks.prototype.getPrimitives = function() {
         'control_repeat': this.repeat,
         'control_forever': this.forever,
         'control_wait': this.wait,
+        'control_if': this.if,
         'control_stop': this.stop
     };
 };
 
-Scratch3ControlBlocks.prototype.repeat = function(argValues, util) {
+Scratch3ControlBlocks.prototype.repeat = function(args, util) {
     // Initialize loop
     if (util.stackFrame.loopCounter === undefined) {
-        util.stackFrame.loopCounter = parseInt(argValues.TIMES);
+        util.stackFrame.loopCounter = parseInt(args.TIMES);
     }
     // Decrease counter
     util.stackFrame.loopCounter--;
@@ -32,15 +33,26 @@ Scratch3ControlBlocks.prototype.repeat = function(argValues, util) {
     }
 };
 
-Scratch3ControlBlocks.prototype.forever = function(argValues, util) {
+Scratch3ControlBlocks.prototype.forever = function(args, util) {
     util.startSubstack();
 };
 
-Scratch3ControlBlocks.prototype.wait = function(argValues, util) {
+Scratch3ControlBlocks.prototype.wait = function(args, util) {
     util.yield();
     util.timeout(function() {
         util.done();
-    }, 1000 * argValues.DURATION);
+    }, 1000 * args.DURATION);
+};
+
+Scratch3ControlBlocks.prototype.if = function(args, util) {
+    // Only execute one time. `if` will be returned to
+    // when the substack finishes, but it shouldn't execute again.
+    if (util.stackFrame.executed === undefined) {
+        util.stackFrame.executed = true;
+        if (args.CONDITION) {
+            util.startSubstack();
+        }
+    }
 };
 
 Scratch3ControlBlocks.prototype.stop = function() {

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -27,17 +27,8 @@ Scratch3EventBlocks.prototype.whenBroadcastReceived = function() {
     // No-op
 };
 
-Scratch3EventBlocks.prototype.broadcast = function(argValues, util) {
-    util.startHats(function(hat) {
-        if (hat.opcode === 'event_whenbroadcastreceived') {
-            var shadows = hat.fields.CHOICE.blocks;
-            for (var sb in shadows) {
-                var shadowblock = shadows[sb];
-                return shadowblock.fields.CHOICE.value === argValues[0];
-            }
-        }
-        return false;
-    });
+Scratch3EventBlocks.prototype.broadcast = function() {
+    // @todo
 };
 
 module.exports = Scratch3EventBlocks;

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -13,17 +13,26 @@ function Scratch3OperatorsBlocks(runtime) {
 Scratch3OperatorsBlocks.prototype.getPrimitives = function() {
     return {
         'math_number': this.number,
-        'math_add': this.add
+        'text': this.text,
+        'math_add': this.add,
+        'logic_equals': this.equals
     };
 };
 
-
-Scratch3OperatorsBlocks.prototype.number = function(args) {
+Scratch3OperatorsBlocks.prototype.number = function (args) {
     return Number(args.NUM);
 };
 
-Scratch3OperatorsBlocks.prototype.add = function(args) {
+Scratch3OperatorsBlocks.prototype.text = function (args) {
+    return String(args.TEXT);
+};
+
+Scratch3OperatorsBlocks.prototype.add = function (args) {
     return args.NUM1 + args.NUM2;
+};
+
+Scratch3OperatorsBlocks.prototype.equals = function (args) {
+    return args.VALUE1 == args.VALUE2;
 };
 
 module.exports = Scratch3OperatorsBlocks;

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -1,0 +1,29 @@
+function Scratch3OperatorsBlocks(runtime) {
+    /**
+     * The runtime instantiating this block package.
+     * @type {Runtime}
+     */
+    this.runtime = runtime;
+}
+
+/**
+ * Retrieve the block primitives implemented by this package.
+ * @return {Object.<string, Function>} Mapping of opcode to Function.
+ */
+Scratch3OperatorsBlocks.prototype.getPrimitives = function() {
+    return {
+        'math_number': this.number,
+        'math_add': this.add
+    };
+};
+
+
+Scratch3OperatorsBlocks.prototype.number = function(args) {
+    return Number(args.NUM);
+};
+
+Scratch3OperatorsBlocks.prototype.add = function(args) {
+    return args.NUM1 + args.NUM2;
+};
+
+module.exports = Scratch3OperatorsBlocks;

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -23,6 +23,13 @@ function Blocks () {
 }
 
 /**
+ * Blockly inputs that represent statements/substacks
+ * are prefixed with this string.
+ * @const{string}
+ */
+Blocks.SUBSTACK_INPUT_PREFIX = 'SUBSTACK';
+
+/**
  * Provide an object with metadata for the requested block ID.
  * @param {!string} blockId ID of block we have stored.
  * @return {?Object} Metadata about the block, if it exists.
@@ -60,7 +67,7 @@ Blocks.prototype.getSubstack = function (id, substackNum) {
     if (typeof block === 'undefined') return null;
     if (!substackNum) substackNum = 1;
 
-    var inputName = 'SUBSTACK';
+    var inputName = Blocks.SUBSTACK_INPUT_PREFIX;
     if (substackNum > 1) {
         inputName += substackNum;
     }
@@ -78,6 +85,34 @@ Blocks.prototype.getSubstack = function (id, substackNum) {
 Blocks.prototype.getOpcode = function (id) {
     if (typeof this._blocks[id] === 'undefined') return null;
     return this._blocks[id].opcode;
+};
+
+/**
+ * Get all fields and their values for a block.
+ * @param {?string} id ID of block to query.
+ * @return {!Object} All fields and their values.
+ */
+Blocks.prototype.getFields = function (id) {
+    if (typeof this._blocks[id] === 'undefined') return null;
+    return this._blocks[id].fields;
+};
+
+/**
+ * Get all non-substack inputs for a block.
+ * @param {?string} id ID of block to query.
+ * @return {!Object} All non-substack inputs and their associated blocks.
+ */
+Blocks.prototype.getInputs = function (id) {
+    if (typeof this._blocks[id] === 'undefined') return null;
+    var inputs = {};
+    for (var input in this._blocks[id].inputs) {
+        // Ignore blocks prefixed with substack prefix.
+        if (input.substring(0, Blocks.SUBSTACK_INPUT_PREFIX.length)
+            != Blocks.SUBSTACK_INPUT_PREFIX) {
+            inputs[input] = this._blocks[id].inputs[input];
+        }
+    }
+    return inputs;
 };
 
 // ---------------------------------------------------------------------

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -1,0 +1,154 @@
+var Thread = require('./thread');
+var YieldTimers = require('../util/yieldtimers.js');
+
+var execute = function (sequencer, thread, blockId) {
+    var runtime = sequencer.runtime;
+
+    // Save the yield timer ID, in case a primitive makes a new one
+    // @todo hack - perhaps patch this to allow more than one timer per
+    // primitive, for example...
+    var oldYieldTimerId = YieldTimers.timerId;
+
+    var opcode = runtime.blocks.getOpcode(blockId);
+
+    // Push the current block to the stack
+    thread.stack.push(blockId);
+    // Push an empty stack frame, if we need one.
+    // Might not, if we just popped the stack.
+    if (thread.stack.length > thread.stackFrames.length) {
+        thread.stackFrames.push({});
+    }
+    var currentStackFrame = thread.stackFrames[thread.stackFrames.length - 1];
+
+    /**
+     * A callback for the primitive to indicate its thread should yield.
+     * @type {Function}
+     */
+    var threadYieldCallback = function () {
+        thread.status = Thread.STATUS_YIELD;
+    };
+
+    /**
+     * A callback for the primitive to indicate its thread is finished
+     * @type {Function}
+     */
+    var threadDoneCallback = function () {
+        thread.status = Thread.STATUS_DONE;
+        // Refresh nextBlock in case it has changed during a yield.
+        thread.nextBlock = runtime.blocks.getNextBlock(blockId);
+        // Pop the stack and stack frame
+        thread.stack.pop();
+        thread.stackFrames.pop();
+        // Stop showing run feedback in the editor.
+        runtime.glowBlock(blockId, false);
+    };
+
+    /**
+     * A callback for the primitive to start hats.
+     * @todo very hacked...
+     * Provide a callback that is passed in a block and returns true
+     * if it is a hat that should be triggered.
+     * @param {Function} callback Provided callback.
+     */
+    var startHats = function(callback) {
+        var stacks = runtime.blocks.getStacks();
+        for (var i = 0; i < stacks.length; i++) {
+            var stack = stacks[i];
+            var stackBlock = runtime.blocks.getBlock(stack);
+            var result = callback(stackBlock);
+            if (result) {
+                // Check if the stack is already running
+                var stackRunning = false;
+
+                for (var j = 0; j < runtime.threads.length; j++) {
+                    if (runtime.threads[j].topBlock == stack) {
+                        stackRunning = true;
+                        break;
+                    }
+                }
+                if (!stackRunning) {
+                    runtime._pushThread(stack);
+                }
+            }
+        }
+    };
+
+    /**
+     * Record whether we have switched stack,
+     * to avoid proceeding the thread automatically.
+     * @type {boolean}
+     */
+    var switchedStack = false;
+    /**
+     * A callback for a primitive to start a substack.
+     * @type {Function}
+     */
+    var threadStartSubstack = function () {
+        // Set nextBlock to the start of the substack
+        var substack = runtime.blocks.getSubstack(blockId);
+        if (substack && substack.value) {
+            thread.nextBlock = substack.value;
+        } else {
+            thread.nextBlock = null;
+        }
+        switchedStack = true;
+    };
+
+    var argValues = {};
+
+    // Start showing run feedback in the editor.
+    runtime.glowBlock(blockId, true);
+
+    if (!opcode) {
+        console.warn('Could not get opcode for block: ' + blockId);
+        console.groupEnd();
+        return;
+    }
+
+    var blockFunction = runtime.getOpcodeFunction(opcode);
+    if (!blockFunction) {
+        console.warn('Could not get implementation for opcode: ' + opcode);
+        console.groupEnd();
+        return;
+    }
+
+    if (sequencer.DEBUG_BLOCK_CALLS) {
+        console.groupCollapsed('Executing: ' + opcode);
+        console.log('with arguments: ', argValues);
+        console.log('and stack frame: ', currentStackFrame);
+    }
+    var blockFunctionReturnValue = null;
+    try {
+        // @todo deal with the return value
+        blockFunctionReturnValue = blockFunction(argValues, {
+            yield: threadYieldCallback,
+            done: threadDoneCallback,
+            timeout: YieldTimers.timeout,
+            stackFrame: currentStackFrame,
+            startSubstack: threadStartSubstack,
+            startHats: startHats
+        });
+    }
+    catch(e) {
+        console.error(
+            'Exception calling block function for opcode: ' +
+            opcode + '\n' + e);
+    } finally {
+        // Update if the thread has set a yield timer ID
+        // @todo hack
+        if (YieldTimers.timerId > oldYieldTimerId) {
+            thread.yieldTimerId = YieldTimers.timerId;
+        }
+        if (thread.status === Thread.STATUS_RUNNING && !switchedStack) {
+            // Thread executed without yielding - move to done
+            threadDoneCallback();
+        }
+        if (sequencer.DEBUG_BLOCK_CALLS) {
+            console.log('ending stack frame: ', currentStackFrame);
+            console.log('returned: ', blockFunctionReturnValue);
+            console.groupEnd();
+        }
+    }
+};
+
+module.exports = execute;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -86,6 +86,8 @@ var execute = function (sequencer, thread, blockId) {
             console.log('returned: ', primitiveReturnValue);
             console.groupEnd();
         }
+        // Pop the stack and stack frame
+        thread.popStack();
         return primitiveReturnValue;
     }
 };

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -1,7 +1,7 @@
 var Thread = require('./thread');
 var YieldTimers = require('../util/yieldtimers.js');
 
-var execute = function (sequencer, thread, blockId) {
+var execute = function (sequencer, thread, blockId, isInput) {
     var runtime = sequencer.runtime;
 
     // Save the yield timer ID, in case a primitive makes a new one
@@ -33,12 +33,16 @@ var execute = function (sequencer, thread, blockId) {
      * @type {Function}
      */
     var threadDoneCallback = function () {
-        thread.status = Thread.STATUS_DONE;
-        // Refresh nextBlock in case it has changed during a yield.
-        thread.nextBlock = runtime.blocks.getNextBlock(blockId);
         // Pop the stack and stack frame
         thread.stack.pop();
         thread.stackFrames.pop();
+        // If we're not executing an input sub-block,
+        // mark the thread as done and proceed to the next block.
+        if (!isInput) {
+            thread.status = Thread.STATUS_DONE;
+            // Refresh nextBlock in case it has changed during a yield.
+            thread.nextBlock = runtime.blocks.getNextBlock(blockId);
+        }
         // Stop showing run feedback in the editor.
         runtime.glowBlock(blockId, false);
     };

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -26,7 +26,7 @@ var execute = function (sequencer, thread, blockId) {
     // Add all fields on this block to the argValues.
     var fields = runtime.blocks.getFields(blockId);
     for (var fieldName in fields) {
-        argValues[fieldName] = fields[fieldName];
+        argValues[fieldName] = fields[fieldName].value;
     }
 
     // Recursively evaluate input blocks.

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -98,7 +98,23 @@ var execute = function (sequencer, thread, blockId, isInput) {
         switchedStack = true;
     };
 
+    // Generate values for arguments (inputs).
     var argValues = {};
+
+    // Add all fields on this block to the argValues.
+    var fields = runtime.blocks.getFields(blockId);
+    for (var fieldName in fields) {
+        argValues[fieldName] = fields[fieldName];
+    }
+
+    // Recursively evaluate input blocks.
+    var inputs = runtime.blocks.getInputs(blockId);
+    for (var inputName in inputs) {
+        var input = inputs[inputName];
+        var inputBlockId = input.block;
+        var result = execute(sequencer, thread, inputBlockId, true);
+        argValues[input.name] = result;
+    }
 
     // Start showing run feedback in the editor.
     runtime.glowBlock(blockId, true);

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -60,7 +60,7 @@ var execute = function (sequencer, thread, blockId) {
     try {
         // @todo deal with the return value
         primitiveReturnValue = blockFunction(argValues, {
-            yield: thread.yield,
+            yield: thread.yield.bind(thread),
             done: function() {
                 sequencer.proceedThread(thread, blockId);
             },

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -69,8 +69,8 @@ var execute = function (sequencer, thread) {
             },
             timeout: YieldTimers.timeout,
             stackFrame: currentStackFrame,
-            startSubstack: function () {
-                sequencer.stepToSubstack(thread);
+            startSubstack: function (substackNum) {
+                sequencer.stepToSubstack(thread, substackNum);
             }
         });
     }

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -43,14 +43,12 @@ var execute = function (sequencer, thread) {
 
     if (!opcode) {
         console.warn('Could not get opcode for block: ' + currentBlockId);
-        console.groupEnd();
         return;
     }
 
     var blockFunction = runtime.getOpcodeFunction(opcode);
     if (!blockFunction) {
         console.warn('Could not get implementation for opcode: ' + opcode);
-        console.groupEnd();
         return;
     }
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -122,6 +122,7 @@ Runtime.prototype.getOpcodeFunction = function (opcode) {
 Runtime.prototype._pushThread = function (id) {
     this.emit(Runtime.STACK_GLOW_ON, id);
     var thread = new Thread(id);
+    thread.pushStack(id);
     this.threads.push(thread);
 };
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -6,6 +6,7 @@ var util = require('util');
 var defaultBlockPackages = {
     'scratch3_control': require('../blocks/scratch3_control'),
     'scratch3_event': require('../blocks/scratch3_event'),
+    'scratch3_operators': require('../blocks/scratch3_operators'),
     'wedo2': require('../blocks/wedo2')
 };
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -233,6 +233,9 @@ Runtime.prototype._step = function () {
  * @param {boolean} isGlowing True to turn on glow; false to turn off.
  */
 Runtime.prototype.glowBlock = function (blockId, isGlowing) {
+    if (!this.blocks.getBlock(blockId)) {
+        return;
+    }
     if (isGlowing) {
         this.emit(Runtime.BLOCK_GLOW_ON, blockId);
     } else {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -121,8 +121,6 @@ Sequencer.prototype.stepToSubstack = function (thread, currentBlockId) {
 Sequencer.prototype.proceedThread = function (thread, currentBlockId) {
     // Stop showing run feedback in the editor.
     this.runtime.glowBlock(currentBlockId, false);
-    // Pop the stack and stack frame
-    thread.popStack();
     // Mark the thread as done and proceed to the next block.
     thread.status = Thread.STATUS_DONE;
     // Refresh nextBlock in case it has changed during a yield.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -104,11 +104,17 @@ Sequencer.prototype.startThread = function (thread) {
 /**
  * Step a thread into a block's substack.
  * @param {!Thread} thread Thread object to step to substack.
- * @param {string} currentBlockId Block which owns a substack to step to.
+ * @param {Number} substackNum Which substack to step to (i.e., 1, 2).
  */
-Sequencer.prototype.stepToSubstack = function (thread) {
+Sequencer.prototype.stepToSubstack = function (thread, substackNum) {
+    if (!substackNum) {
+        substackNum = 1;
+    }
     var currentBlockId = thread.peekStack();
-    var substackId = this.runtime.blocks.getSubstack(currentBlockId);
+    var substackId = this.runtime.blocks.getSubstack(
+        currentBlockId,
+        substackNum
+    );
     if (substackId) {
         // Push substack ID to the thread's stack.
         thread.pushStack(substackId);
@@ -121,7 +127,6 @@ Sequencer.prototype.stepToSubstack = function (thread) {
 /**
  * Finish stepping a thread and proceed it to the next block.
  * @param {!Thread} thread Thread object to proceed.
- * @param {string} currentBlockId Block we are finished with.
  */
 Sequencer.prototype.proceedThread = function (thread) {
     var currentBlockId = thread.peekStack();

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -88,11 +88,6 @@ Sequencer.prototype.startThread = function (thread) {
     // Start showing run feedback in the editor.
     this.runtime.glowBlock(currentBlockId, true);
 
-    // Push the current block to the stack, if executing for the first time.
-    if (thread.peekStack() != currentBlockId) {
-        thread.pushStack(currentBlockId);
-    }
-
     // Execute the current block
     execute(this, thread);
 

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -1,6 +1,7 @@
 var Timer = require('../util/timer');
 var Thread = require('./thread');
 var YieldTimers = require('../util/yieldtimers.js');
+var execute = require('./execute.js');
 
 function Sequencer (runtime) {
     /**
@@ -95,11 +96,6 @@ Sequencer.prototype.stepThreads = function (threads) {
  * @param {!Thread} thread Thread object to step
  */
 Sequencer.prototype.stepThread = function (thread) {
-    // Save the yield timer ID, in case a primitive makes a new one
-    // @todo hack - perhaps patch this to allow more than one timer per
-    // primitive, for example...
-    var oldYieldTimerId = YieldTimers.timerId;
-
     // Save the current block and set the nextBlock.
     // If the primitive would like to do control flow,
     // it can overwrite nextBlock.
@@ -110,159 +106,7 @@ Sequencer.prototype.stepThread = function (thread) {
     }
     thread.nextBlock = this.runtime.blocks.getNextBlock(currentBlock);
 
-    var opcode = this.runtime.blocks.getOpcode(currentBlock);
-
-    // Push the current block to the stack
-    thread.stack.push(currentBlock);
-    // Push an empty stack frame, if we need one.
-    // Might not, if we just popped the stack.
-    if (thread.stack.length > thread.stackFrames.length) {
-        thread.stackFrames.push({});
-    }
-    var currentStackFrame = thread.stackFrames[thread.stackFrames.length - 1];
-
-    /**
-     * A callback for the primitive to indicate its thread should yield.
-     * @type {Function}
-     */
-    var threadYieldCallback = function () {
-        thread.status = Thread.STATUS_YIELD;
-    };
-
-    /**
-     * A callback for the primitive to indicate its thread is finished
-     * @type {Function}
-     */
-    var instance = this;
-    var threadDoneCallback = function () {
-        thread.status = Thread.STATUS_DONE;
-        // Refresh nextBlock in case it has changed during a yield.
-        thread.nextBlock = instance.runtime.blocks.getNextBlock(currentBlock);
-        // Pop the stack and stack frame
-        thread.stack.pop();
-        thread.stackFrames.pop();
-        // Stop showing run feedback in the editor.
-        instance.runtime.glowBlock(currentBlock, false);
-    };
-
-    /**
-     * A callback for the primitive to start hats.
-     * @todo very hacked...
-     * Provide a callback that is passed in a block and returns true
-     * if it is a hat that should be triggered.
-     * @param {Function} callback Provided callback.
-     */
-    var startHats = function(callback) {
-        var stacks = instance.runtime.blocks.getStacks();
-        for (var i = 0; i < stacks.length; i++) {
-            var stack = stacks[i];
-            var stackBlock = instance.runtime.blocks.getBlock(stack);
-            var result = callback(stackBlock);
-            if (result) {
-                // Check if the stack is already running
-                var stackRunning = false;
-
-                for (var j = 0; j < instance.runtime.threads.length; j++) {
-                    if (instance.runtime.threads[j].topBlock == stack) {
-                        stackRunning = true;
-                        break;
-                    }
-                }
-                if (!stackRunning) {
-                    instance.runtime._pushThread(stack);
-                }
-            }
-        }
-    };
-
-    /**
-     * Record whether we have switched stack,
-     * to avoid proceeding the thread automatically.
-     * @type {boolean}
-     */
-    var switchedStack = false;
-    /**
-     * A callback for a primitive to start a substack.
-     * @type {Function}
-     */
-    var threadStartSubstack = function () {
-        // Set nextBlock to the start of the substack
-        var substack = instance.runtime.blocks.getSubstack(currentBlock);
-        if (substack && substack.value) {
-            thread.nextBlock = substack.value;
-        } else {
-            thread.nextBlock = null;
-        }
-        switchedStack = true;
-    };
-
-    // @todo extreme hack to get the single argument value for prototype
-    var argValues = [];
-    var blockInputs = this.runtime.blocks.getBlock(currentBlock).fields;
-    for (var bi in blockInputs) {
-        var outer = blockInputs[bi];
-        for (var b in outer.blocks) {
-            var block = outer.blocks[b];
-            var fields = block.fields;
-            for (var f in fields) {
-                var field = fields[f];
-                argValues.push(field.value);
-            }
-        }
-    }
-
-    // Start showing run feedback in the editor.
-    this.runtime.glowBlock(currentBlock, true);
-
-    if (!opcode) {
-        console.warn('Could not get opcode for block: ' + currentBlock);
-    }
-    else {
-        var blockFunction = this.runtime.getOpcodeFunction(opcode);
-        if (!blockFunction) {
-            console.warn('Could not get implementation for opcode: ' + opcode);
-        }
-        else {
-            if (Sequencer.DEBUG_BLOCK_CALLS) {
-                console.groupCollapsed('Executing: ' + opcode);
-                console.log('with arguments: ', argValues);
-                console.log('and stack frame: ', currentStackFrame);
-            }
-            var blockFunctionReturnValue = null;
-            try {
-                // @todo deal with the return value
-                blockFunctionReturnValue = blockFunction(argValues, {
-                    yield: threadYieldCallback,
-                    done: threadDoneCallback,
-                    timeout: YieldTimers.timeout,
-                    stackFrame: currentStackFrame,
-                    startSubstack: threadStartSubstack,
-                    startHats: startHats
-                });
-            }
-            catch(e) {
-                console.error(
-                    'Exception calling block function for opcode: ' +
-                    opcode + '\n' + e);
-            } finally {
-                // Update if the thread has set a yield timer ID
-                // @todo hack
-                if (YieldTimers.timerId > oldYieldTimerId) {
-                    thread.yieldTimerId = YieldTimers.timerId;
-                }
-                if (thread.status === Thread.STATUS_RUNNING && !switchedStack) {
-                    // Thread executed without yielding - move to done
-                    threadDoneCallback();
-                }
-                if (Sequencer.DEBUG_BLOCK_CALLS) {
-                    console.log('ending stack frame: ', currentStackFrame);
-                    console.log('returned: ', blockFunctionReturnValue);
-                    console.groupEnd();
-                }
-            }
-        }
-    }
-
+    execute(this, thread, currentBlock, false);
 };
 
 module.exports = Sequencer;

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -44,6 +44,8 @@ Sequencer.prototype.stepThreads = function (threads) {
            this.timer.timeElapsed() < Sequencer.WORK_TIME) {
         // New threads at the end of the iteration.
         var newThreads = [];
+        // Reset yielding thread count.
+        numYieldingThreads = 0;
         // Attempt to run each thread one time
         for (var i = 0; i < threads.length; i++) {
             var activeThread = threads[i];
@@ -53,6 +55,8 @@ Sequencer.prototype.stepThreads = function (threads) {
             } else if (activeThread.status === Thread.STATUS_YIELD) {
                 // Yield-mode thread: check if the time has passed.
                 if (!YieldTimers.resolve(activeThread.yieldTimerId)) {
+                    // Thread is still yielding
+                    // if YieldTimers.resolve returns false.
                     numYieldingThreads++;
                 }
             } else if (activeThread.status === Thread.STATUS_DONE) {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -81,7 +81,9 @@ Sequencer.prototype.stepThreads = function (threads) {
  */
 Sequencer.prototype.startThread = function (thread) {
     var currentBlockId = thread.peekStack();
-    if (!currentBlockId || !this.runtime.blocks.getBlock(currentBlockId)) {
+    if (!currentBlockId) {
+        // A "null block" - empty substack. Pop the stack.
+        thread.popStack();
         thread.status = Thread.STATUS_DONE;
         return;
     }

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -38,6 +38,12 @@ function Thread (firstBlock) {
      * @type {number}
      */
     this.yieldTimerId = -1;
+
+    /**
+     * Whether the thread has switched stack in the course of execution.
+     * @type {boolean}
+     */
+    this.switchedStack = false;
 }
 
 /**
@@ -61,5 +67,42 @@ Thread.STATUS_YIELD = 1;
  * @const
  */
 Thread.STATUS_DONE = 2;
+
+/**
+ * Push stack and update stack frames appropriately.
+ * @param {string} blockId Block ID to push to stack.
+ */
+Thread.prototype.pushStack = function (blockId) {
+    this.stack.push(blockId);
+    // Push an empty stack frame, if we need one.
+    // Might not, if we just popped the stack.
+    if (this.stack.length > this.stackFrames.length) {
+        this.stackFrames.push({});
+    }
+};
+
+/**
+ * Pop last block on the stack and its stack frame.
+ * @returns {string} Block ID popped from the stack.
+ */
+Thread.prototype.popStack = function () {
+    this.stackFrames.pop();
+    return this.stack.pop();
+};
+
+/**
+ * Get last stack frame.
+ * @return {?Object} Last stack frame stored on this thread.
+ */
+Thread.prototype.getLastStackFrame = function () {
+    return this.stackFrames[this.stackFrames.length - 1];
+};
+
+/**
+ * Yields the thread.
+ */
+Thread.prototype.yield = function () {
+    this.status = Thread.STATUS_YIELD;
+};
 
 module.exports = Thread;

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -9,11 +9,7 @@ function Thread (firstBlock) {
      * @type {!string}
      */
     this.topBlock = firstBlock;
-    /**
-     * ID of next block that the thread will execute, or null if none.
-     * @type {?string}
-     */
-    this.nextBlock = firstBlock;
+
     /**
      * Stack for the thread. When the sequencer enters a control structure,
      * the block is pushed onto the stack so we know where to exit.
@@ -38,12 +34,6 @@ function Thread (firstBlock) {
      * @type {number}
      */
     this.yieldTimerId = -1;
-
-    /**
-     * Whether the thread has switched stack in the course of execution.
-     * @type {boolean}
-     */
-    this.switchedStack = false;
 }
 
 /**
@@ -83,7 +73,7 @@ Thread.prototype.pushStack = function (blockId) {
 
 /**
  * Pop last block on the stack and its stack frame.
- * @returns {string} Block ID popped from the stack.
+ * @return {string} Block ID popped from the stack.
  */
 Thread.prototype.popStack = function () {
     this.stackFrames.pop();
@@ -91,10 +81,19 @@ Thread.prototype.popStack = function () {
 };
 
 /**
- * Get last stack frame.
+ * Get top stack item.
+ * @return {?string} Block ID on top of stack.
+ */
+Thread.prototype.peekStack = function () {
+    return this.stack[this.stack.length - 1];
+};
+
+
+/**
+ * Get top stack frame.
  * @return {?Object} Last stack frame stored on this thread.
  */
-Thread.prototype.getLastStackFrame = function () {
+Thread.prototype.peekStackFrame = function () {
     return this.stackFrames[this.stackFrames.length - 1];
 };
 


### PR DESCRIPTION
This code is a pretty big divergence from the old code. It's probably not comparing to the old code - just look at the new code.

Here are notable changes:
- All logic as far as "what block to execute next" is now the responsibility of the thread's stack. I added some helper functions to the Thread module to deal with the stack.

The basic framework is:
1. The current block running is the top block on the stack. The only way `execute` knows how to run a block is by inspecting the top of the stack.
2. To execute a substack or an input block (such as the add block in an argument), push it to the stack and call `execute` again (see execute.js:39).
3. When finished with executing a block, pop the stack, and push the block's next block onto the stack (see `sequencer. proceedThread`). When no "next block" is found, try popping the stack.
- Return values are provided by the return value of the primitive. These are fed into `argValues` in execution, as well as field values. I've implemented math_number, math_add, etc., which you can drag into `wait`, `repeat,` etc., as inputs.
- Changed primitives to take a named arguments object instead of a list of arguments. This matches Blockly more closely, and I find it quite nice, but we could do an ordered list instead...

Some code that I think this is correctly running:

<img width="482" alt="screen shot 2016-06-09 at 5 19 47 pm" src="https://cloud.githubusercontent.com/assets/120403/15946824/829cb630-2e66-11e6-8f51-83256b0a59ab.png">

I like this structure quite a bit more than the "classic Scratch" structure myself. But I think it could be up for debate. 

I think it's also very important that we get these pieces right, so more than happy have very thorough reviews and to make lots of adjustments/renames/changes.
