### PR TITLE
Handling empty fields

### DIFF
--- a/src/engine/adapter.js
+++ b/src/engine/adapter.js
@@ -100,9 +100,17 @@ function domToBlock (blockDOM, blocks, isTopBlock) {
         case 'field':
             // Add the field to this block.
             var fieldName = xmlChild.attribs.name;
+            var fieldData = '';
+            if (xmlChild.children.length > 0 && xmlChild.children[0].data) {
+                fieldData = xmlChild.children[0].data;
+            } else {
+                // If the child of the field with a data property
+                // doesn't exist, set the data to an empty string.
+                fieldData = '';
+            }
             block.fields[fieldName] = {
                 name: fieldName,
-                value: xmlChild.children[0].data
+                value: fieldData
             };
             break;
         case 'value':

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -53,5 +53,11 @@
         "xml": {
             "outerHTML": "></xml>"
         }
+    },
+    "createemptyfield": {
+        "name": "block",
+        "xml": {
+            "outerHTML":  "<block type='operator_equals' id='l^H_{8[DDyDW?m)HIt@b' x='100' y='362'><value name='OPERAND1'><shadow type='text' id='Ud@4y]bc./]uv~te?brb'><field name='TEXT'></field></shadow></value><value name='OPERAND2'><shadow type='text' id='p8[y..,[K;~G,k7]N;08'><field name='TEXT'></field></shadow></value></block>"
+        }
     }
 }

--- a/test/unit/adapter.js
+++ b/test/unit/adapter.js
@@ -165,3 +165,10 @@ test('create with invalid xml', function (t) {
     t.equal(result.length, 0);
     t.end();
 });
+
+test('create with empty field', function (t) {
+    var result = adapter(events.createemptyfield);
+    t.ok(Array.isArray(result));
+    t.equal(result.length, 3);
+    t.end();
+});


### PR DESCRIPTION
Previously, when XML events came in with empty fields (no text/etc.), the adapter crashed as it tried to look for `xmlChild.children[0].data`. This checks that the property exists (if it doesn't, set the value to an empty string) and adds a tiny regression test.
