### PR TITLE
Filling out operators and fixing up casting to look like Scratch

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -102,10 +102,7 @@ Scratch3OperatorsBlocks.prototype.random = function (args) {
 };
 
 Scratch3OperatorsBlocks.prototype.join = function (args) {
-    return Cast.toString(
-        Cast.toString(args.STRING1) +
-        Cast.toString(args.STRING2)
-    );
+    return Cast.toString(args.STRING1) + Cast.toString(args.STRING2);
 };
 
 Scratch3OperatorsBlocks.prototype.letterOf = function (args) {

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -27,7 +27,14 @@ Scratch3OperatorsBlocks.prototype.getPrimitives = function() {
         'operator_and': this.and,
         'operator_or': this.or,
         'operator_not': this.not,
-        'operator_random': this.random
+        'operator_random': this.random,
+        'operator_join': this.join,
+        'operator_letter_of': this.letterOf,
+        'operator_length': this.length,
+        'operator_mod': this.mod,
+        'operator_round': this.round,
+        'operator_mathop_menu': this.mathopMenu,
+        'operator_mathop': this.mathop
     };
 };
 
@@ -95,6 +102,63 @@ Scratch3OperatorsBlocks.prototype.random = function (args) {
         return low + parseInt(Math.random() * ((high + 1) - low));
     }
     return (Math.random() * (high - low)) + low;
+};
+
+Scratch3OperatorsBlocks.prototype.join = function (args) {
+    return String(String(args.STRING1) + String(args.STRING2));
+};
+
+Scratch3OperatorsBlocks.prototype.letterOf = function (args) {
+    var index = Number(args.LETTER) - 1;
+    var str = String(args.STRING);
+    // Out of bounds?
+    if (index < 0 || index >= str.length) {
+        return '';
+    }
+    return str.charAt(index);
+};
+
+Scratch3OperatorsBlocks.prototype.length = function (args) {
+    return String(args.STRING).length;
+};
+
+Scratch3OperatorsBlocks.prototype.mod = function (args) {
+    var n = Number(args.NUM1);
+    var modulus = Number(args.NUM2);
+    var result = n % modulus;
+    // Scratch mod is kept positive.
+    if (result / modulus < 0) result += modulus;
+    return result;
+};
+
+Scratch3OperatorsBlocks.prototype.round = function (args) {
+    return Math.round(Number(args.NUM));
+};
+
+Scratch3OperatorsBlocks.prototype.mathopMenu = function (args) {
+    return args.OPERATOR;
+};
+
+Scratch3OperatorsBlocks.prototype.mathop = function (args) {
+    var operator = String(args.OPERATOR).toLowerCase();
+    var n = Number(args.NUM);
+    switch (operator) {
+    case 'abs': return Math.abs(n);
+    case 'floor': return Math.floor(n);
+    case 'ceiling': return Math.ceil(n);
+    case 'sqrt': return Math.sqrt(n);
+    case 'sin': return Math.sin((Math.PI * n) / 180);
+    case 'cos': return Math.cos((Math.PI * n) / 180);
+    case 'tan': return Math.tan((Math.PI * n) / 180);
+    case 'asin': return (Math.asin(n) * 180) / Math.PI;
+    case 'acos': return (Math.acos(n) * 180) / Math.PI;
+    case 'atan': return (Math.atan(n) * 180) / Math.PI;
+    case 'ln': return Math.log(n);
+    case 'log': return Math.log(n) / Math.LN10;
+    case 'e ^': return Math.exp(n);
+    case '10 ^': return Math.pow(10, n);
+    }
+    return 0;
 };
 
 module.exports = Scratch3OperatorsBlocks;

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -1,3 +1,5 @@
+var Cast = require('../util/cast.js');
+
 function Scratch3OperatorsBlocks(runtime) {
     /**
      * The runtime instantiating this block package.
@@ -39,56 +41,51 @@ Scratch3OperatorsBlocks.prototype.getPrimitives = function() {
 };
 
 Scratch3OperatorsBlocks.prototype.number = function (args) {
-    var num = Number(args.NUM);
-    if (num !== num) {
-        // NaN
-        return 0;
-    }
-    return num;
+    return Cast.toNumber(args.NUM);
 };
 
 Scratch3OperatorsBlocks.prototype.text = function (args) {
-    return String(args.TEXT);
+    return Cast.toString(args.TEXT);
 };
 
 Scratch3OperatorsBlocks.prototype.add = function (args) {
-    return args.NUM1 + args.NUM2;
+    return Cast.toNumber(args.NUM1) + Cast.toNumber(args.NUM2);
 };
 
 Scratch3OperatorsBlocks.prototype.subtract = function (args) {
-    return args.NUM1 - args.NUM2;
+    return Cast.toNumber(args.NUM1) - Cast.toNumber(args.NUM2);
 };
 
 Scratch3OperatorsBlocks.prototype.multiply = function (args) {
-    return args.NUM1 * args.NUM2;
+    return Cast.toNumber(args.NUM1) * Cast.toNumber(args.NUM2);
 };
 
 Scratch3OperatorsBlocks.prototype.divide = function (args) {
-    return args.NUM1 / args.NUM2;
+    return Cast.toNumber(args.NUM1) / Cast.toNumber(args.NUM2);
 };
 
 Scratch3OperatorsBlocks.prototype.lt = function (args) {
-    return Boolean(args.OPERAND1 < args.OPERAND2);
+    return Cast.compare(args.OPERAND1, args.OPERAND2) < 0;
 };
 
 Scratch3OperatorsBlocks.prototype.equals = function (args) {
-    return Boolean(args.OPERAND1 == args.OPERAND2);
+    return Cast.compare(args.OPERAND1, args.OPERAND2) == 0;
 };
 
 Scratch3OperatorsBlocks.prototype.gt = function (args) {
-    return Boolean(args.OPERAND1 > args.OPERAND2);
+    return Cast.compare(args.OPERAND1, args.OPERAND2) > 0;
 };
 
 Scratch3OperatorsBlocks.prototype.and = function (args) {
-    return Boolean(args.OPERAND1 && args.OPERAND2);
+    return Cast.toBoolean(args.OPERAND1 && args.OPERAND2);
 };
 
 Scratch3OperatorsBlocks.prototype.or = function (args) {
-    return Boolean(args.OPERAND1 || args.OPERAND2);
+    return Cast.toBoolean(args.OPERAND1 || args.OPERAND2);
 };
 
 Scratch3OperatorsBlocks.prototype.not = function (args) {
-    return Boolean(!args.OPERAND);
+    return Cast.toBoolean(!args.OPERAND);
 };
 
 Scratch3OperatorsBlocks.prototype.random = function (args) {
@@ -105,12 +102,15 @@ Scratch3OperatorsBlocks.prototype.random = function (args) {
 };
 
 Scratch3OperatorsBlocks.prototype.join = function (args) {
-    return String(String(args.STRING1) + String(args.STRING2));
+    return Cast.toString(
+        Cast.toString(args.STRING1) +
+        Cast.toString(args.STRING2)
+    );
 };
 
 Scratch3OperatorsBlocks.prototype.letterOf = function (args) {
-    var index = Number(args.LETTER) - 1;
-    var str = String(args.STRING);
+    var index = Cast.toNumber(args.LETTER) - 1;
+    var str = Cast.toString(args.STRING);
     // Out of bounds?
     if (index < 0 || index >= str.length) {
         return '';
@@ -119,12 +119,12 @@ Scratch3OperatorsBlocks.prototype.letterOf = function (args) {
 };
 
 Scratch3OperatorsBlocks.prototype.length = function (args) {
-    return String(args.STRING).length;
+    return Cast.toString(args.STRING).length;
 };
 
 Scratch3OperatorsBlocks.prototype.mod = function (args) {
-    var n = Number(args.NUM1);
-    var modulus = Number(args.NUM2);
+    var n = Cast.toNumber(args.NUM1);
+    var modulus = Cast.toNumber(args.NUM2);
     var result = n % modulus;
     // Scratch mod is kept positive.
     if (result / modulus < 0) result += modulus;
@@ -132,7 +132,7 @@ Scratch3OperatorsBlocks.prototype.mod = function (args) {
 };
 
 Scratch3OperatorsBlocks.prototype.round = function (args) {
-    return Math.round(Number(args.NUM));
+    return Math.round(Cast.toNumber(args.NUM));
 };
 
 Scratch3OperatorsBlocks.prototype.mathopMenu = function (args) {
@@ -140,8 +140,8 @@ Scratch3OperatorsBlocks.prototype.mathopMenu = function (args) {
 };
 
 Scratch3OperatorsBlocks.prototype.mathop = function (args) {
-    var operator = String(args.OPERATOR).toLowerCase();
-    var n = Number(args.NUM);
+    var operator = Cast.toString(args.OPERATOR).toLowerCase();
+    var n = Cast.toNumber(args.NUM);
     switch (operator) {
     case 'abs': return Math.abs(n);
     case 'floor': return Math.floor(n);

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -1,0 +1,88 @@
+function Cast () {}
+
+/**
+ * @fileoverview
+ * Utilities for casting and comparing Scratch data-types.
+ * Scratch behaves slightly differently from JavaScript in many respects,
+ * and these differences should be encapsulated below.
+ * For example, in Scratch, add(1, join("hello", world")) -> 1.
+ * This is because "hello world" is cast to 0.
+ * In JavaScript, 1 + Number("hello" + "world") would give you NaN.
+ * Use when coercing a value before computation.
+ */
+
+/**
+ * Scratch cast to number.
+ * Treats NaN as 0.
+ * In Scratch 2.0, this is captured by `interp.numArg.`
+ * @param {*} value Value to cast to number.
+ * @return {number} The Scratch-casted number value.
+ */
+Cast.toNumber = function (value) {
+    var n = Number(value);
+    if (isNaN(n)) {
+        // Scratch treats NaN as 0, when needed as a number.
+        // E.g., 0 + NaN -> 0.
+        return 0;
+    }
+    return n;
+};
+
+/**
+ * Scratch cast to boolean.
+ * In Scratch 2.0, this is captured by `interp.boolArg.`
+ * Treats some string values differently from JavaScript.
+ * @param {*} value Value to cast to boolean.
+ * @return {boolean} The Scratch-casted boolean value.
+ */
+Cast.toBoolean = function (value) {
+    // Already a boolean?
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        // These specific strings are treated as false in Scratch.
+        if ((value == '') ||
+            (value == '0') ||
+            (value.toLowerCase() == 'false')) {
+            return false;
+        }
+        // All other strings treated as true.
+        return true;
+    }
+    // Coerce other values and numbers.
+    return Boolean(value);
+};
+
+/**
+ * Scratch cast to string.
+ * @param {*} value Value to cast to string.
+ * @return {string} The Scratch-casted string value.
+ */
+Cast.toString = function (value) {
+    return String(value);
+};
+
+/**
+ * Compare two values, using Scratch cast, case-insensitive string compare, etc.
+ * In Scratch 2.0, this is captured by `interp.compare.`
+ * @param {*} v1 First value to compare.
+ * @param {*} v2 Second value to compare.
+ * @returns {Number} Negative number if v1 < v2; 0 if equal; positive otherwise.
+ */
+Cast.compare = function (v1, v2) {
+    var n1 = Number(v1);
+    var n2 = Number(v2);
+    if (isNaN(n1) || isNaN(n2)) {
+        // At least one argument can't be converted to a number.
+        // Scratch compares strings as case insensitive.
+        var s1 = String(v1).toLowerCase();
+        var s2 = String(v2).toLowerCase();
+        return s1.localeCompare(s2);
+    } else {
+        // Compare as numbers.
+        return n1 - n2;
+    }
+};
+
+module.exports = Cast;


### PR DESCRIPTION
The first commit finishes implementing the remaining operators, including string join, letter of, string length, mod, round, and the math functions.

The second commit adds a set of utilities for casting and comparing values the way Scratch does. E.g., it will properly coerce numbers, booleans, and strings to each other, when asked. I modified the operator blocks to use these utility functions, and combining them should more or less give the same execution result as Scratch 2.0, minus unknown quirks.

I've tried to document what's going on. Some of them are a little undocumented/mysterious in the 2.0 codebase. E.g., the 2.0 implementation of `compare` also includes (what I think is) a cache of lowercased values, not sure if we actually need this or if it was an unneeded optimization. Similarly, 2.0 simplifies `isNaN` using the `n != n` trick. I took this out for now but I imagine we could add it back in if profiling says isNaN is very slow.
