### PR TITLE
Add stats.js meter to playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "json-loader": "0.5.4",
     "scratch-blocks": "git+https://git@github.com/LLK/scratch-blocks.git",
     "scratch-render": "git+https://git@github.com/LLK/scratch-render.git",
+    "stats.js": "0.16.0",
     "tap": "5.7.1",
     "webpack": "1.13.0",
     "webpack-dev-server": "1.14.1"

--- a/playground/index.html
+++ b/playground/index.html
@@ -725,7 +725,8 @@
           </category>
           <category name="More Blocks" colour="#FF6680"></category>
   </xml>
-
+    <!-- FPS counter -->
+    <script src="../node_modules/stats.js/build/stats.min.js"></script>
     <!-- Syntax highlighter -->
     <script src="../node_modules/highlightjs/highlight.pack.min.js"></script>
     <!-- Scratch Blocks -->

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -29,6 +29,12 @@ window.onload = function() {
     });
     window.workspace = workspace;
 
+    // FPS counter.
+    var stats = new window.Stats();
+    document.getElementById('tab-renderexplorer').appendChild(stats.dom);
+    stats.dom.style.position = 'relative';
+    stats.begin();
+
     // Block events.
     // @todo: Re-enable flyout listening after fixing GH-69.
     workspace.addChangeListener(vm.blockListener);
@@ -87,6 +93,8 @@ window.onload = function() {
 
     // Inform VM of animation frames.
     var animate = function() {
+        stats.end();
+        stats.begin();
         window.vm.animationFrame();
         requestAnimationFrame(animate);
     };


### PR DESCRIPTION
@ericrosenbaum's request.

<img width="484" alt="screen shot 2016-08-11 at 10 54 14 pm" src="https://cloud.githubusercontent.com/assets/120403/17611589/b293daa8-6016-11e6-9e34-0bc574f51354.png">

I put the stats end/begin inside the rAF handler, which I think should correspond to how much time it's taken the browser to get from frame to frame. It seems to be pretty accurate - matches Chrome's built-in FPS meter pretty exactly.
