### PR TITLE
VM "I/O devices"; clock, mouse as demo

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -88,6 +88,24 @@ window.onload = function() {
         workspace.reportValue(data.id, data.value);
     });
 
+    // Feed mouse events as VM I/O events.
+    document.addEventListener('mousemove', function (e) {
+        var rect = canvas.getBoundingClientRect();
+        var coordinates = {
+            x: e.clientX - rect.left - rect.width / 2,
+            y: e.clientY - rect.top - rect.height / 2
+        };
+        window.vm.postIOData('mouse', coordinates);
+    });
+    canvas.addEventListener('mousedown', function (e) {
+        window.vm.postIOData('mouse', {isDown: true});
+        e.preventDefault();
+    });
+    canvas.addEventListener('mouseup', function (e) {
+        window.vm.postIOData('mouse', {isDown: false});
+        e.preventDefault();
+    });
+
     // Run threads
     vm.start();
 

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -1,0 +1,43 @@
+function Scratch3SensingBlocks(runtime) {
+    /**
+     * The runtime instantiating this block package.
+     * @type {Runtime}
+     */
+    this.runtime = runtime;
+}
+
+/**
+ * Retrieve the block primitives implemented by this package.
+ * @return {Object.<string, Function>} Mapping of opcode to Function.
+ */
+Scratch3SensingBlocks.prototype.getPrimitives = function() {
+    return {
+        'sensing_timer': this.getTimer,
+        'sensing_resettimer': this.resetTimer,
+        'sensing_mousex': this.getMouseX,
+        'sensing_mousey': this.getMouseY,
+        'sensing_mousedown': this.getMouseDown
+    };
+};
+
+Scratch3SensingBlocks.prototype.getTimer = function (args, util) {
+    return util.ioQuery('clock', 'projectTimer');
+};
+
+Scratch3SensingBlocks.prototype.resetTimer = function (args, util) {
+    util.ioQuery('clock', 'resetProjectTimer');
+};
+
+Scratch3SensingBlocks.prototype.getMouseX = function (args, util) {
+    return util.ioQuery('mouse', 'getX');
+};
+
+Scratch3SensingBlocks.prototype.getMouseY = function (args, util) {
+    return util.ioQuery('mouse', 'getY');
+};
+
+Scratch3SensingBlocks.prototype.getMouseDown = function (args, util) {
+    return util.ioQuery('mouse', 'getIsDown');
+};
+
+module.exports = Scratch3SensingBlocks;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -77,7 +77,14 @@ var execute = function (sequencer, thread) {
         startBranch: function (branchNum) {
             sequencer.stepToBranch(thread, branchNum);
         },
-        target: target
+        target: target,
+        ioQuery: function (device, func, args) {
+            // Find the I/O device and execute the query/function call.
+            if (runtime.ioDevices[device] && runtime.ioDevices[device][func]) {
+                var devObject = runtime.ioDevices[device];
+                return devObject[func].call(devObject, args);
+            }
+        }
     });
 
     // Deal with any reported value.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -3,12 +3,17 @@ var Sequencer = require('./sequencer');
 var Thread = require('./thread');
 var util = require('util');
 
+// Virtual I/O devices.
+var Clock = require('../io/clock');
+var Mouse = require('../io/mouse');
+
 var defaultBlockPackages = {
     'scratch3_control': require('../blocks/scratch3_control'),
     'scratch3_event': require('../blocks/scratch3_event'),
     'scratch3_looks': require('../blocks/scratch3_looks'),
     'scratch3_motion': require('../blocks/scratch3_motion'),
-    'scratch3_operators': require('../blocks/scratch3_operators')
+    'scratch3_operators': require('../blocks/scratch3_operators'),
+    'scratch3_sensing': require('../blocks/scratch3_sensing')
 };
 
 /**
@@ -43,6 +48,11 @@ function Runtime (targets) {
      */
     this._primitives = {};
     this._registerBlockPackages();
+
+    this.ioDevices = {
+        'clock': new Clock(),
+        'mouse': new Mouse()
+    };
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,17 @@ VirtualMachine.prototype.animationFrame = function () {
     this.runtime.animationFrame();
 };
 
+/**
+ * Post I/O data to the virtual devices.
+ * @param {?string} device Name of virtual I/O device.
+ * @param {Object} data Any data object to post to the I/O device.
+ */
+VirtualMachine.prototype.postIOData = function (device, data) {
+    if (this.runtime.ioDevices[device]) {
+        this.runtime.ioDevices[device].postData(data);
+    }
+};
+
 /*
  * Worker handlers: for all public methods available above,
  * we must also provide a message handler in case the VM is run
@@ -139,6 +150,9 @@ if (ENV_WORKER) {
             break;
         case 'animationFrame':
             self.vmInstance.animationFrame();
+            break;
+        case 'postIOData':
+            self.vmInstance.postIOData(messageData.device, messageData.data);
             break;
         default:
             if (e.data.id == 'RendererConnected') {

--- a/src/io/clock.js
+++ b/src/io/clock.js
@@ -1,0 +1,16 @@
+var Timer = require('../util/timer');
+
+function Clock () {
+    this._projectTimer = new Timer();
+    this._projectTimer.start();
+}
+
+Clock.prototype.projectTimer = function () {
+    return this._projectTimer.timeElapsed() / 1000;
+};
+
+Clock.prototype.resetProjectTimer = function () {
+    this._projectTimer.start();
+};
+
+module.exports = Clock;

--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -1,0 +1,33 @@
+var MathUtil = require('../util/math-util');
+
+function Mouse () {
+    this._x = 0;
+    this._y = 0;
+    this._isDown = false;
+}
+
+Mouse.prototype.postData = function(data) {
+    if (data.x) {
+        this._x = data.x;
+    }
+    if (data.y) {
+        this._y = data.y;
+    }
+    if (typeof data.isDown !== 'undefined') {
+        this._isDown = data.isDown;
+    }
+};
+
+Mouse.prototype.getX = function () {
+    return MathUtil.clamp(this._x, -240, 240);
+};
+
+Mouse.prototype.getY = function () {
+    return MathUtil.clamp(-this._y, -180, 180);
+};
+
+Mouse.prototype.getIsDown = function () {
+    return this._isDown;
+};
+
+module.exports = Mouse;

--- a/src/worker.js
+++ b/src/worker.js
@@ -51,6 +51,14 @@ VirtualMachine.prototype.getPlaygroundData = function () {
     this.vmWorker.postMessage({method: 'getPlaygroundData'});
 };
 
+VirtualMachine.prototype.postIOData = function (device, data) {
+    this.vmWorker.postMessage({
+        method: 'postIOData',
+        device: device,
+        data: data
+    });
+};
+
 VirtualMachine.prototype.start = function () {
     this.vmWorker.postMessage({method: 'start'});
 };


### PR DESCRIPTION
Not necessarily intended to be a full/finished implementation of these features, but an idea/demo for a new abstraction, and a test of it with two cases.

I wondered how we want to represent and provide sensor/device/I/O data to the blocks/extensions.

This is one way, coded here:
- Every type of "I/O device" (mouse, keyboard, clock/timer, microphone, video?, ...renderer?? ...more?) is registered with the VM.
- VM has a standardized way of getting data in and out for them. For now, you can see that illustrated in `postIOData`, through which the playground sends mouse X, mouse Y, and mouse down state to the Mouse object registered with the VM.
- Blocks get a utility "query" function to make any kind of query/request to any of the I/O devices.

Feels pretty organized, would give blocks a lot of power if we can expose (selected?) I/O devices to extensions etc.

Too much abstraction? Too little? Thoughts?
