### PR TITLE
Hat blocks

### DIFF
--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -71,14 +71,10 @@ Scratch3EventBlocks.prototype.broadcastAndWait = function (args, util) {
         }
     }
     // We've run before; check if the wait is still going on.
-    var waiting = false;
-    for (var i = 0; i < util.stackFrame.triggeredThreads.length; i++) {
-        var thread = util.stackFrame.triggeredThreads[i];
-        var activeThreads = this.runtime.threads;
-        if (activeThreads.indexOf(thread) > -1) { // @todo: A cleaner way?
-            waiting = true;
-        }
-    }
+    var instance = this;
+    var waiting = util.stackFrame.triggeredThreads.some(function(thread) {
+        return instance.runtime.isActiveThread(thread);
+    });
     if (waiting) {
         util.yieldFrame();
     }

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -1,5 +1,3 @@
-var Thread = require('../engine/thread');
-
 function Scratch3EventBlocks(runtime) {
     /**
      * The runtime instantiating this block package.

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -34,7 +34,7 @@ Scratch3EventBlocks.prototype.getHats = function () {
         },*/
         'event_whengreaterthan': {
             restartExistingThreads: false,
-            edgeTriggered: true
+            edgeActivated: true
         },
         'event_whenbroadcastreceived': {
             restartExistingThreads: true
@@ -51,28 +51,28 @@ Scratch3EventBlocks.prototype.hatGreaterThanPredicate = function (args, util) {
 };
 
 Scratch3EventBlocks.prototype.broadcast = function(args, util) {
-    util.triggerHats('event_whenbroadcastreceived', {
+    util.startHats('event_whenbroadcastreceived', {
         'BROADCAST_OPTION': args.BROADCAST_OPTION
     });
 };
 
 Scratch3EventBlocks.prototype.broadcastAndWait = function (args, util) {
-    // Have we run before, triggering threads?
-    if (!util.stackFrame.triggeredThreads) {
-        // No - trigger hats for this broadcast.
-        util.stackFrame.triggeredThreads = util.triggerHats(
+    // Have we run before, starting threads?
+    if (!util.stackFrame.startedThreads) {
+        // No - start hats for this broadcast.
+        util.stackFrame.startedThreads = util.startHats(
             'event_whenbroadcastreceived', {
                 'BROADCAST_OPTION': args.BROADCAST_OPTION
             }
         );
-        if (util.stackFrame.triggeredThreads.length == 0) {
+        if (util.stackFrame.startedThreads.length == 0) {
             // Nothing was started.
             return;
         }
     }
     // We've run before; check if the wait is still going on.
     var instance = this;
-    var waiting = util.stackFrame.triggeredThreads.some(function(thread) {
+    var waiting = util.stackFrame.startedThreads.some(function(thread) {
         return instance.runtime.isActiveThread(thread);
     });
     if (waiting) {

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -76,7 +76,8 @@ Scratch3EventBlocks.prototype.broadcastAndWait = function (args, util) {
     var waiting = false;
     for (var i = 0; i < util.stackFrame.triggeredThreads.length; i++) {
         var thread = util.stackFrame.triggeredThreads[i];
-        if (thread.status !== Thread.STATUS_DONE) {
+        var activeThreads = this.runtime.threads;
+        if (activeThreads.indexOf(thread) > -1) { // @todo: A cleaner way?
             waiting = true;
         }
     }

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -35,23 +35,13 @@ var execute = function (sequencer, thread) {
     // Hats are implemented slightly differently from regular blocks.
     // If they have an associated block function, it's treated as a predicate;
     // if not, execution will proceed right through it (as a no-op).
-    if (isHat) {
-        var nextBlock = target.blocks.getNextBlock(currentBlockId);
-        if (!nextBlock) {
-            // Hat with no next block - don't try to evaluate it.
-            sequencer.retireThread(thread);
-            return;
-        }
-        if (!blockFunction) {
-            // No predicate for the hat - just continue to next block.
-            sequencer.proceedThread(thread);
-            return;
-        }
-    } else {
-        if (!blockFunction) {
+    if (!blockFunction) {
+        if (!isHat) {
             console.warn('Could not get implementation for opcode: ' + opcode);
-            return;
         }
+        // Skip through the block.
+        // (either hat with no predicate, or missing op).
+        return;
     }
 
     // Generate values for arguments (inputs).

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -96,9 +96,9 @@ var execute = function (sequencer, thread) {
         startBranch: function (branchNum) {
             sequencer.stepToBranch(thread, branchNum);
         },
-        triggerHats: function(requestedHat, opt_matchFields, opt_target) {
+        startHats: function(requestedHat, opt_matchFields, opt_target) {
             return (
-                runtime.triggerHats(requestedHat, opt_matchFields, opt_target)
+                runtime.startHats(requestedHat, opt_matchFields, opt_target)
             );
         },
         ioQuery: function (device, func, args) {
@@ -119,19 +119,19 @@ var execute = function (sequencer, thread) {
         thread.pushReportedValue(resolvedValue);
         if (isHat) {
             // Hat predicate was evaluated.
-            if (runtime.getIsEdgeTriggeredHat(opcode)) {
-                // If this is an edge-triggered hat, only proceed if
+            if (runtime.getIsEdgeActivatedHat(opcode)) {
+                // If this is an edge-activated hat, only proceed if
                 // the value is true and used to be false.
-                var oldEdgeValue = runtime.updateEdgeTriggeredValue(
+                var oldEdgeValue = runtime.updateEdgeActivatedValue(
                     currentBlockId,
                     resolvedValue
                 );
-                var edgeWasTriggered = !oldEdgeValue && resolvedValue;
-                if (!edgeWasTriggered) {
+                var edgeWasActivated = !oldEdgeValue && resolvedValue;
+                if (!edgeWasActivated) {
                     sequencer.retireThread(thread);
                 }
             } else {
-                // Not an edge-triggered hat: retire the thread
+                // Not an edge-activated hat: retire the thread
                 // if predicate was false.
                 if (!resolvedValue) {
                     sequencer.retireThread(thread);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -152,7 +152,7 @@ Runtime.prototype.getOpcodeFunction = function (opcode) {
  * @return {Boolean} True if the op is known to be a hat.
  */
 Runtime.prototype.getIsHat = function (opcode) {
-    return opcode in this._hats;
+    return this._hats.hasOwnProperty(opcode);
 };
 
 /**
@@ -161,7 +161,8 @@ Runtime.prototype.getIsHat = function (opcode) {
  * @return {Boolean} True if the op is known to be a edge-triggered hat.
  */
 Runtime.prototype.getIsEdgeTriggeredHat = function (opcode) {
-    return opcode in this._hats && this._hats[opcode].edgeTriggered;
+    return this._hats.hasOwnProperty(opcode) &&
+        this._hats[opcode].edgeTriggered;
 };
 
 /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -350,8 +350,8 @@ Runtime.prototype._step = function () {
         }
     }
     var inactiveThreads = this.sequencer.stepThreads(this.threads);
-    for (var j = 0; j < inactiveThreads.length; j++) {
-        this._removeThread(inactiveThreads[j]);
+    for (var i = 0; i < inactiveThreads.length; i++) {
+        this._removeThread(inactiveThreads[i]);
     }
 };
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -212,6 +212,15 @@ Runtime.prototype._removeThread = function (thread) {
 };
 
 /**
+ * Return whether a thread is currently active/running.
+ * @param {?Thread} thread Thread object to check.
+ * @return {Boolean} True if the thread is active/running.
+ */
+Runtime.prototype.isActiveThread = function (thread) {
+    return this.threads.indexOf(thread) > -1;
+};
+
+/**
  * Toggle a script.
  * @param {!string} topBlockId ID of block that starts the script.
  */

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -204,7 +204,6 @@ Runtime.prototype._pushThread = function (id) {
  * @param {?Thread} thread Thread object to remove from actives
  */
 Runtime.prototype._removeThread = function (thread) {
-    thread.setStatus(Thread.STATUS_DONE);
     var i = this.threads.indexOf(thread);
     if (i > -1) {
         this.glowScript(thread.topBlock, false);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -135,12 +135,14 @@ Runtime.prototype.getOpcodeFunction = function (opcode) {
 /**
  * Create a thread and push it to the list of threads.
  * @param {!string} id ID of block that starts the stack
+ * @return {!Thread} The newly created thread.
  */
 Runtime.prototype._pushThread = function (id) {
-    this.emit(Runtime.STACK_GLOW_ON, id);
     var thread = new Thread(id);
+    this.glowScript(id, true);
     thread.pushStack(id);
     this.threads.push(thread);
+    return thread;
 };
 
 /**
@@ -150,7 +152,7 @@ Runtime.prototype._pushThread = function (id) {
 Runtime.prototype._removeThread = function (thread) {
     var i = this.threads.indexOf(thread);
     if (i > -1) {
-        this.emit(Runtime.STACK_GLOW_OFF, thread.topBlock);
+        this.glowScript(thread.topBlock, false);
         this.threads.splice(i, 1);
     }
 };
@@ -231,6 +233,19 @@ Runtime.prototype.glowBlock = function (blockId, isGlowing) {
         this.emit(Runtime.BLOCK_GLOW_ON, blockId);
     } else {
         this.emit(Runtime.BLOCK_GLOW_OFF, blockId);
+    }
+};
+
+/**
+ * Emit feedback for script glowing.
+ * @param {?string} topBlockId ID for the top block to update glow
+ * @param {boolean} isGlowing True to turn on glow; false to turn off.
+ */
+Runtime.prototype.glowScript = function (topBlockId, isGlowing) {
+    if (isGlowing) {
+        this.emit(Runtime.STACK_GLOW_ON, topBlockId);
+    } else {
+        this.emit(Runtime.STACK_GLOW_OFF, topBlockId);
     }
 };
 

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -166,4 +166,14 @@ Sequencer.prototype.proceedThread = function (thread) {
     }
 };
 
+/**
+ * Retire a thread in the middle, without considering further blocks.
+ * @param {!Thread} thread Thread object to retire.
+ */
+Sequencer.prototype.retireThread = function (thread) {
+    thread.stack = [];
+    thread.stackFrame = [];
+    thread.setStatus(Thread.STATUS_DONE);
+};
+
 module.exports = Sequencer;

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -124,6 +124,14 @@ Thread.prototype.pushReportedValue = function (value) {
 };
 
 /**
+ * Whether the current execution of a thread is at the top of the stack.
+ * @return {Boolean} True if execution is at top of the stack.
+ */
+Thread.prototype.atStackTop = function () {
+    return this.peekStack() === this.topBlock;
+};
+
+/**
  * Set thread status.
  * @param {number} status Enum representing thread status.
  */


### PR DESCRIPTION
Here's my best first shot at implementing hat blocks in a generic way. It's a little treacherous, but hopefully not too much more treacherous than Scratch 2.0.

Features:
- One function that does most of the work (`runtime.triggerHats`)
- Edge-triggered hats (with predicate) and event-triggered hats (with predicate if you want).
- Predicate evaluation can do arbitrary expressions.
- Ability to have hats restart running threads (e.g., for green flag and broadcasts), or not (e.g., for when key pressed when implemented).
- Field matching, especially for "broadcast." (thought about having this be a predicate evaluation, but that seemed ugly, since "broadcast and wait" needs to track threads it triggered somehow...)
- What I think are working/matching implementations of broadcast, broadcast and wait, green flag, and "when timer > _" blocks. I think with this framework, the rest of the hats (including both kinds of Scratch 2.0 extension hats?) should be possible.

Thoughts welcome especially on how to make it less treacherous.
