### PR TITLE
Implement 'current' block

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -16,7 +16,9 @@ Scratch3SensingBlocks.prototype.getPrimitives = function() {
         'sensing_resettimer': this.resetTimer,
         'sensing_mousex': this.getMouseX,
         'sensing_mousey': this.getMouseY,
-        'sensing_mousedown': this.getMouseDown
+        'sensing_mousedown': this.getMouseDown,
+        'sensing_current': this.current,
+        'sensing_currentmenu': this.currentMenu
     };
 };
 
@@ -38,6 +40,30 @@ Scratch3SensingBlocks.prototype.getMouseY = function (args, util) {
 
 Scratch3SensingBlocks.prototype.getMouseDown = function (args, util) {
     return util.ioQuery('mouse', 'getIsDown');
+};
+
+Scratch3SensingBlocks.prototype.current = function (args, util) {
+    var date = new Date();
+    switch (args.CURRENTMENU) {
+    case 'year':
+        return date.getFullYear();
+    case 'month':
+        return date.getMonth();
+    case 'date':
+        return date.getDate();
+    case 'dayofweek':
+        return date.getDay();
+    case 'hour':
+        return date.getHours();
+    case 'minute':
+        return date.getMinutes();
+    case 'second':
+        return date.getSeconds();
+    }
+};
+
+Scratch3SensingBlocks.prototype.currentMenu = function (args) {
+    return args.CURRENTMENU.toLowerCase();
 };
 
 module.exports = Scratch3SensingBlocks;

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -42,23 +42,16 @@ Scratch3SensingBlocks.prototype.getMouseDown = function (args, util) {
     return util.ioQuery('mouse', 'getIsDown');
 };
 
-Scratch3SensingBlocks.prototype.current = function (args, util) {
+Scratch3SensingBlocks.prototype.current = function (args) {
     var date = new Date();
     switch (args.CURRENTMENU) {
-    case 'year':
-        return date.getFullYear();
-    case 'month':
-        return date.getMonth();
-    case 'date':
-        return date.getDate();
-    case 'dayofweek':
-        return date.getDay();
-    case 'hour':
-        return date.getHours();
-    case 'minute':
-        return date.getMinutes();
-    case 'second':
-        return date.getSeconds();
+    case 'year': return date.getFullYear();
+    case 'month': return date.getMonth() + 1; // getMonth is zero-based
+    case 'date': return date.getDate();
+    case 'dayofweek': return date.getDay();
+    case 'hour': return date.getHours();
+    case 'minute': return date.getMinutes();
+    case 'second': return date.getSeconds();
     }
 };
 

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -48,7 +48,7 @@ Scratch3SensingBlocks.prototype.current = function (args) {
     case 'year': return date.getFullYear();
     case 'month': return date.getMonth() + 1; // getMonth is zero-based
     case 'date': return date.getDate();
-    case 'dayofweek': return date.getDay();
+    case 'dayofweek': return date.getDay() + 1; // getDay is zero-based, Sun=0
     case 'hour': return date.getHours();
     case 'minute': return date.getMinutes();
     case 'second': return date.getSeconds();


### PR DESCRIPTION
Input on implementing a "milliseconds" option? Wouldn't be too hard (though it would require a pull request to scratch-blocks as well, to add the option to the menu).

EDIT: [scratch-flash implementation](https://github.com/LLK/scratch-flash/blob/3c1671b38e692637974c676064d140bc04957e36/src/scratch/ScratchRuntime.as#L987-L1000)
