### PR TITLE
Shadow improvements

### DIFF
--- a/src/engine/adapter.js
+++ b/src/engine/adapter.js
@@ -114,11 +114,16 @@ function domToBlock (blockDOM, blocks, isTopBlock) {
         case 'statement':
             // Recursively generate block structure for input block.
             domToBlock(childBlockNode, blocks, false);
+            if (childShadowNode && childBlockNode != childShadowNode) {
+                // Also generate the shadow block.
+                domToBlock(childShadowNode, blocks, false);
+            }
             // Link this block's input to the child block.
             var inputName = xmlChild.attribs.name;
             block.inputs[inputName] = {
                 name: inputName,
-                block: childBlockNode.attribs.id
+                block: childBlockNode.attribs.id,
+                shadow: childShadowNode ? childShadowNode.attribs.id : null
             };
             break;
         case 'next':

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -166,6 +166,10 @@ Blocks.prototype.blocklyListen = function (e, isFlyout, opt_runtime) {
         });
         break;
     case 'delete':
+        // Don't accept delete events for shadow blocks being obscured.
+        if (this._blocks[e.blockId].shadow) {
+            return;
+        }
         this.deleteBlock({
             id: e.blockId
         });
@@ -181,9 +185,13 @@ Blocks.prototype.blocklyListen = function (e, isFlyout, opt_runtime) {
  * @param {boolean} opt_isFlyoutBlock Whether the block is in the flyout.
  */
 Blocks.prototype.createBlock = function (block, opt_isFlyoutBlock) {
-    // Create new block
+    // Does the block already exist?
+    // Could happen, e.g., for an unobscured shadow.
+    if (this._blocks.hasOwnProperty(block.id)) {
+        return;
+    }
+    // Create new block.
     this._blocks[block.id] = block;
-
     // Push block id to scripts array.
     // Blocks are added as a top-level stack if they are marked as a top-block
     // (if they were top-level XML in the event) and if they are not
@@ -239,11 +247,11 @@ Blocks.prototype.moveBlock = function (e) {
         this._deleteScript(e.id);
         // Otherwise, try to connect it in its new place.
         if (e.newInput !== undefined) {
-             // Moved to the new parent's input.
-            this._blocks[e.newParent].inputs[e.newInput] = {
-                name: e.newInput,
-                block: e.id
-            };
+            // Moved to the new parent's input.
+            // Don't obscure the shadow block.
+            var newInput = this._blocks[e.newParent].inputs[e.newInput];
+            newInput.name = e.newInput;
+            newInput.block = e.id;
         } else {
             // Moved to the new parent's next connection.
             this._blocks[e.newParent].next = e.id;
@@ -271,6 +279,11 @@ Blocks.prototype.deleteBlock = function (e) {
         // If it's null, the block in this input moved away.
         if (block.inputs[input].block !== null) {
             this.deleteBlock({id: block.inputs[input].block});
+        }
+        // Delete obscured shadow blocks.
+        if (block.inputs[input].shadow !== null &&
+            block.inputs[input].shadow !== block.inputs[input].block) {
+            this.deleteBlock({id: block.inputs[input].shadow});
         }
     }
 

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -332,9 +332,16 @@ Blocks.prototype.blockToXML = function (blockId) {
     for (var input in block.inputs) {
         var blockInput = block.inputs[input];
         // Only encode a value tag if the value input is occupied.
-        if (blockInput.block) {
-            xmlString += '<value name="' + blockInput.name + '">' +
-                this.blockToXML(blockInput.block) + '</value>';
+        if (blockInput.block || blockInput.shadow) {
+            xmlString += '<value name="' + blockInput.name + '">';
+            if (blockInput.block) {
+                xmlString += this.blockToXML(blockInput.block);
+            }
+            if (blockInput.shadow && blockInput.shadow != blockInput.block) {
+                // Obscured shadow.
+                xmlString += this.blockToXML(blockInput.shadow);
+            }
+            xmlString += '</value>';
         }
     }
     // Add any fields on this block.

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -266,6 +266,10 @@ function parseBlock (sb2block) {
                 shadow: true
             });
             activeBlock.inputs[expectedArg.inputName].shadow = inputUid;
+            // If no block occupying the input, alias the block to the shadow.
+            if (!activeBlock.inputs[expectedArg.inputName].block) {
+                activeBlock.inputs[expectedArg.inputName].block = inputUid;
+            }
         } else if (expectedArg.type == 'field') {
             // Add as a field on this block.
             activeBlock.fields[expectedArg.fieldName] = {

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -183,6 +183,7 @@ function parseBlock (sb2block) {
         opcode: blockMetadata.opcode, // Converted, e.g. "motion_movesteps".
         inputs: {}, // Inputs to this block and the blocks they point to.
         fields: {}, // Fields on this block and their values.
+        next: null, // Next block.
         shadow: false, // No shadow blocks in an SB2 by default.
         children: [] // Store any generated children, flattened in `flatten`.
     };

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -59,5 +59,11 @@
         "xml": {
             "outerHTML":  "<block type='operator_equals' id='l^H_{8[DDyDW?m)HIt@b' x='100' y='362'><value name='OPERAND1'><shadow type='text' id='Ud@4y]bc./]uv~te?brb'><field name='TEXT'></field></shadow></value><value name='OPERAND2'><shadow type='text' id='p8[y..,[K;~G,k7]N;08'><field name='TEXT'></field></shadow></value></block>"
         }
+    },
+    "createobscuredshadow": {
+        "name": "block",
+        "xml": {
+            "outerHTML": "<block type='operator_add' id='D;MqidqmaN}Dft)y#Bf`' x='80' y='98'><value name='NUM1'><shadow type='math_number' id='F[IFAdLbq8!q25+Nio@i'><field name='NUM'></field></shadow><block type='sensing_answer' id='D~ZQ|BYb1)xw4)8ziI%.'></block</value><value name='NUM2'><shadow type='math_number' id='|Sjv4!*X6;wj?QaCE{-9'><field name='NUM'></field></shadow></value></block>"
+        }
     }
 }

--- a/test/unit/adapter.js
+++ b/test/unit/adapter.js
@@ -142,6 +142,13 @@ test('create with next connection', function (t) {
     t.end();
 });
 
+test('create with obscured shadow', function (t) {
+    var result = adapter(events.createobscuredshadow);
+    t.ok(Array.isArray(result));
+    t.equal(result.length, 4);
+    t.end();
+});
+
 test('create with invalid block xml', function (t) {
     // Entirely invalid block XML
     var result = adapter(events.createinvalid);

--- a/test/unit/adapter.js
+++ b/test/unit/adapter.js
@@ -55,7 +55,9 @@ test('create with branch', function (t) {
     t.equal(result[0].topLevel, true);
     // In branch
     var branchBlockId = result[0].inputs['SUBSTACK']['block'];
+    var branchShadowId = result[0].inputs['SUBSTACK']['shadow'];
     t.type(branchBlockId, 'string');
+    t.equal(branchShadowId, null);
     // Find actual branch block
     var branchBlock = null;
     for (var i = 0; i < result.length; i++) {
@@ -83,6 +85,10 @@ test('create with two branches', function (t) {
     var secondBranchBlockId = result[0].inputs['SUBSTACK2']['block'];
     t.type(firstBranchBlockId, 'string');
     t.type(secondBranchBlockId, 'string');
+    var firstBranchShadowBlockId = result[0].inputs['SUBSTACK']['shadow'];
+    var secondBranchShadowBlockId = result[0].inputs['SUBSTACK2']['shadow'];
+    t.equal(firstBranchShadowBlockId, null);
+    t.equal(secondBranchShadowBlockId, null);
     // Find actual branch blocks
     var firstBranchBlock = null;
     var secondBranchBlock = null;

--- a/test/unit/blocks.js
+++ b/test/unit/blocks.js
@@ -130,7 +130,8 @@ test('getBranch', function (t) {
         inputs: {
             SUBSTACK: {
                 name: 'SUBSTACK',
-                block: 'foo2'
+                block: 'foo2',
+                shadow: null
             }
         },
         topLevel: true
@@ -164,11 +165,13 @@ test('getBranch2', function (t) {
         inputs: {
             SUBSTACK: {
                 name: 'SUBSTACK',
-                block: 'foo2'
+                block: 'foo2',
+                shadow: null
             },
             SUBSTACK2: {
                 name: 'SUBSTACK2',
-                block: 'foo3'
+                block: 'foo3',
+                shadow: null
             }
         },
         topLevel: true
@@ -417,7 +420,7 @@ test('delete inputs', function (t) {
             input1: {
                 name: 'input1',
                 block: 'foo2',
-                shadow: null
+                shadow: 'foo2'
             },
             SUBSTACK: {
                 name: 'SUBSTACK',
@@ -436,6 +439,14 @@ test('delete inputs', function (t) {
         topLevel: false
     });
     b.createBlock({
+        id: 'foo5',
+        opcode: 'TEST_OBSCURED_SHADOW',
+        next: null,
+        fields: {},
+        inputs: {},
+        topLevel: false
+    });
+    b.createBlock({
         id: 'foo3',
         opcode: 'TEST_BLOCK',
         next: null,
@@ -444,7 +455,7 @@ test('delete inputs', function (t) {
             subinput: {
                 name: 'subinput',
                 block: 'foo4',
-                shadow: null
+                shadow: 'foo5'
             }
         },
         topLevel: false
@@ -464,6 +475,7 @@ test('delete inputs', function (t) {
     t.type(b._blocks['foo2'], 'undefined');
     t.type(b._blocks['foo3'], 'undefined');
     t.type(b._blocks['foo4'], 'undefined');
+    t.type(b._blocks['foo5'], 'undefined');
     t.equal(b._scripts.indexOf('foo'), -1);
     t.equal(Object.keys(b._blocks).length, 0);
     t.equal(b._scripts.length, 0);

--- a/test/unit/blocks.js
+++ b/test/unit/blocks.js
@@ -416,11 +416,13 @@ test('delete inputs', function (t) {
         inputs: {
             input1: {
                 name: 'input1',
-                block: 'foo2'
+                block: 'foo2',
+                shadow: null
             },
             SUBSTACK: {
                 name: 'SUBSTACK',
-                block: 'foo3'
+                block: 'foo3',
+                shadow: null
             }
         },
         topLevel: true
@@ -441,7 +443,8 @@ test('delete inputs', function (t) {
         inputs: {
             subinput: {
                 name: 'subinput',
-                block: 'foo4'
+                block: 'foo4',
+                shadow: null
             }
         },
         topLevel: false


### PR DESCRIPTION
Here's an implementation of #122.

With these:
- Obscured shadows are not lost on serializing/reloading workspaces. The values are also preserved across switching sprites.
- SB2s generate obscured shadows as expected (and they're filled in with Scratch 2.0-like default values, e.g., "10", "", etc.), so no more "blank spaces" under a block.

![shadow-demo](https://cloud.githubusercontent.com/assets/120403/18214356/a18e4c2e-711a-11e6-875a-e254d554bbf6.gif)

And a couple of small tests.
