### PR TITLE
Create a new input if one doesn't exist

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -249,9 +249,15 @@ Blocks.prototype.moveBlock = function (e) {
         if (e.newInput !== undefined) {
             // Moved to the new parent's input.
             // Don't obscure the shadow block.
-            var newInput = this._blocks[e.newParent].inputs[e.newInput];
-            newInput.name = e.newInput;
-            newInput.block = e.id;
+            var oldShadow = null;
+            if (this._blocks[e.newParent].inputs.hasOwnProperty(e.newInput)) {
+                oldShadow = this._blocks[e.newParent].inputs[e.newInput].shadow;
+            }
+            this._blocks[e.newParent].inputs[e.newInput] = {
+                name: e.newInput,
+                block: e.id,
+                shadow: oldShadow
+            };
         } else {
             // Moved to the new parent's next connection.
             this._blocks[e.newParent].next = e.id;

--- a/test/unit/blocks.js
+++ b/test/unit/blocks.js
@@ -291,6 +291,67 @@ test('move', function (t) {
     t.end();
 });
 
+test('move into empty', function (t) {
+    var b = new Blocks();
+    b.createBlock({
+        id: 'foo',
+        opcode: 'TEST_BLOCK',
+        next: null,
+        fields: {},
+        inputs: {},
+        topLevel: true
+    });
+    b.createBlock({
+        id: 'bar',
+        opcode: 'TEST_BLOCK',
+        next: null,
+        fields: {},
+        inputs: {},
+        topLevel: true
+    });
+    b.moveBlock({
+        id: 'bar',
+        newInput: 'fooInput',
+        newParent: 'foo'
+    });
+    t.equal(b._blocks['foo'].inputs['fooInput'].block, 'bar');
+    t.end();
+});
+
+test('move no obscure shadow', function (t) {
+    var b = new Blocks();
+    b.createBlock({
+        id: 'foo',
+        opcode: 'TEST_BLOCK',
+        next: null,
+        fields: {},
+        inputs: {
+            'fooInput': {
+                name: 'fooInput',
+                block: 'x',
+                shadow: 'y'
+            }
+        },
+        topLevel: true
+    });
+    b.createBlock({
+        id: 'bar',
+        opcode: 'TEST_BLOCK',
+        next: null,
+        fields: {},
+        inputs: {},
+        topLevel: true
+    });
+    b.moveBlock({
+        id: 'bar',
+        newInput: 'fooInput',
+        newParent: 'foo'
+    });
+    t.equal(b._blocks['foo'].inputs['fooInput'].block, 'bar');
+    t.equal(b._blocks['foo'].inputs['fooInput'].shadow, 'y');
+    t.end();
+});
+
 test('change', function (t) {
     var b = new Blocks();
     b.createBlock({


### PR DESCRIPTION
Originally changed this in #135 to fix obscuring a pre-existing shadow block. But, `moveBlock` potentially needs to create a new input object if one doesn't exist. Instead of trying to set properties on a (possibly non-existent) input, this will always copy the old shadow property.

Also adds two tests to make sure the behavior is right.
