### PR TITLE
Stage, costumes, backdrops

### DIFF
--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -29,10 +29,9 @@ Scratch3EventBlocks.prototype.getHats = function () {
         'event_whenthisspriteclicked': {
             restartExistingThreads: true
         },
-		/*
         'event_whenbackdropswitchesto': {
             restartExistingThreads: true
-        },*/
+        },
         'event_whengreaterthan': {
             restartExistingThreads: false,
             edgeActivated: true

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -20,6 +20,7 @@ Scratch3LooksBlocks.prototype.getPrimitives = function() {
         'looks_thinkforsecs': this.sayforsecs,
         'looks_show': this.show,
         'looks_hide': this.hide,
+        'looks_backdrops': this.backdropMenu,
         'looks_costume': this.costumeMenu,
         'looks_switchcostumeto': this.switchCostume,
         'looks_switchbackdropto': this.switchBackdrop,
@@ -81,6 +82,11 @@ Scratch3LooksBlocks.prototype.costumeMenu = function (args) {
     return args.COSTUME;
 };
 
+// @todo(GH-146): Remove.
+Scratch3LooksBlocks.prototype.backdropMenu = function (args) {
+    return args.BACKDROP;
+};
+
 Scratch3LooksBlocks.prototype.switchCostume = function (args, util) {
     var requestedCostume = args.COSTUME;
     if (typeof requestedCostume === 'number') {
@@ -105,7 +111,7 @@ Scratch3LooksBlocks.prototype.switchCostume = function (args, util) {
 Scratch3LooksBlocks.prototype.switchBackdrop = function (args, util) {
     // Patch the target to be the stage; then treat as a costume.
     util.target = this.runtime.getTargetForStage();
-    this.switchCostume(args, util);
+    this.switchCostume({COSTUME: args.BACKDROP}, util);
 };
 
 Scratch3LooksBlocks.prototype.nextCostume = function (args, util) {

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -29,7 +29,8 @@ Scratch3LooksBlocks.prototype.getPrimitives = function() {
         'looks_cleargraphiceffects': this.clearEffects,
         'looks_changesizeby': this.changeSize,
         'looks_setsizeto': this.setSize,
-        'looks_size': this.getSize
+        'looks_size': this.getSize,
+        'looks_costumeorder': this.getCostumeIndex
     };
 };
 
@@ -128,6 +129,10 @@ Scratch3LooksBlocks.prototype.setSize = function (args, util) {
 
 Scratch3LooksBlocks.prototype.getSize = function (args, util) {
     return util.target.size;
+};
+
+Scratch3LooksBlocks.prototype.getCostumeIndex = function (args, util) {
+    return util.target.currentCostume;
 };
 
 module.exports = Scratch3LooksBlocks;

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -110,8 +110,17 @@ Scratch3LooksBlocks.prototype.switchCostume = function (args, util) {
 
 Scratch3LooksBlocks.prototype.switchBackdrop = function (args, util) {
     // Patch the target to be the stage; then treat as a costume.
-    util.target = this.runtime.getTargetForStage();
+    var stage = this.runtime.getTargetForStage();
+    util.target = stage;
+    var oldBackdrop = stage.currentCostume;
     this.switchCostume({COSTUME: args.BACKDROP}, util);
+    if (stage.currentCostume !== oldBackdrop) {
+        // Backdrop changed - fire hats.
+        var backdropName = stage.sprite.costumes[stage.currentCostume].name;
+        this.runtime.startHats('event_whenbackdropswitchesto', {
+            'BACKDROP': backdropName
+        });
+    }
 };
 
 Scratch3LooksBlocks.prototype.nextCostume = function (args, util) {

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -22,7 +22,9 @@ Scratch3LooksBlocks.prototype.getPrimitives = function() {
         'looks_hide': this.hide,
         'looks_costume': this.costumeMenu,
         'looks_switchcostumeto': this.switchCostume,
+        'looks_switchbackdropto': this.switchBackdrop,
         'looks_nextcostume': this.nextCostume,
+        'looks_nextbackdrop': this.nextBackdrop,
         'looks_effectmenu': this.effectMenu,
         'looks_changeeffectby': this.changeEffect,
         'looks_seteffectto': this.setEffect,
@@ -30,7 +32,9 @@ Scratch3LooksBlocks.prototype.getPrimitives = function() {
         'looks_changesizeby': this.changeSize,
         'looks_setsizeto': this.setSize,
         'looks_size': this.getSize,
-        'looks_costumeorder': this.getCostumeIndex
+        'looks_costumeorder': this.getCostumeIndex,
+        'looks_backdroporder': this.getBackdropIndex,
+        'looks_backdropname': this.getBackdropName
     };
 };
 
@@ -98,8 +102,20 @@ Scratch3LooksBlocks.prototype.switchCostume = function (args, util) {
     }
 };
 
+Scratch3LooksBlocks.prototype.switchBackdrop = function (args, util) {
+    // Patch the target to be the stage; then treat as a costume.
+    util.target = this.runtime.getTargetForStage();
+    this.switchCostume(args, util);
+};
+
 Scratch3LooksBlocks.prototype.nextCostume = function (args, util) {
     util.target.setCostume(util.target.currentCostume + 1);
+};
+
+Scratch3LooksBlocks.prototype.nextBackdrop = function (args, util) {
+    // Patch the target to be the stage; then treat as a costume.
+    util.target = this.runtime.getTargetForStage();
+    this.nextCostume(args, util);
 };
 
 Scratch3LooksBlocks.prototype.effectMenu = function (args) {
@@ -129,6 +145,16 @@ Scratch3LooksBlocks.prototype.setSize = function (args, util) {
 
 Scratch3LooksBlocks.prototype.getSize = function (args, util) {
     return util.target.size;
+};
+
+Scratch3LooksBlocks.prototype.getBackdropIndex = function () {
+    var stage = this.runtime.getTargetForStage();
+    return stage.currentCostume;
+};
+
+Scratch3LooksBlocks.prototype.getBackdropName = function () {
+    var stage = this.runtime.getTargetForStage();
+    return stage.sprite.costumes[stage.currentCostume].name;
 };
 
 Scratch3LooksBlocks.prototype.getCostumeIndex = function (args, util) {

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -155,7 +155,7 @@ Scratch3LooksBlocks.prototype.getSize = function (args, util) {
 
 Scratch3LooksBlocks.prototype.getBackdropIndex = function () {
     var stage = this.runtime.getTargetForStage();
-    return stage.currentCostume;
+    return stage.currentCostume + 1;
 };
 
 Scratch3LooksBlocks.prototype.getBackdropName = function () {
@@ -164,7 +164,7 @@ Scratch3LooksBlocks.prototype.getBackdropName = function () {
 };
 
 Scratch3LooksBlocks.prototype.getCostumeIndex = function (args, util) {
-    return util.target.currentCostume;
+    return util.target.currentCostume + 1;
 };
 
 module.exports = Scratch3LooksBlocks;

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -1,3 +1,5 @@
+var Cast = require('../util/cast');
+
 function Scratch3LooksBlocks(runtime) {
     /**
      * The runtime instantiating this block package.
@@ -18,6 +20,9 @@ Scratch3LooksBlocks.prototype.getPrimitives = function() {
         'looks_thinkforsecs': this.sayforsecs,
         'looks_show': this.show,
         'looks_hide': this.hide,
+        'looks_costume': this.costumeMenu,
+        'looks_switchcostumeto': this.switchCostume,
+        'looks_nextcostume': this.nextCostume,
         'looks_effectmenu': this.effectMenu,
         'looks_changeeffectby': this.changeEffect,
         'looks_seteffectto': this.setEffect,
@@ -64,6 +69,36 @@ Scratch3LooksBlocks.prototype.show = function (args, util) {
 
 Scratch3LooksBlocks.prototype.hide = function (args, util) {
     util.target.setVisible(false);
+};
+
+// @todo(GH-146): Remove.
+Scratch3LooksBlocks.prototype.costumeMenu = function (args) {
+    return args.COSTUME;
+};
+
+Scratch3LooksBlocks.prototype.switchCostume = function (args, util) {
+    var requestedCostume = args.COSTUME;
+    if (typeof requestedCostume === 'number') {
+        util.target.setCostume(requestedCostume - 1);
+    } else {
+        var costumeIndex = util.target.getCostumeIndexByName(requestedCostume);
+        if (costumeIndex > -1) {
+            util.target.setCostume(costumeIndex);
+        } else if (costumeIndex == 'previous costume') {
+            util.target.setCostume(util.target.currentCostume - 1);
+        } else if (costumeIndex == 'next costume') {
+            util.target.setCostume(util.target.currentCostume + 1);
+        } else {
+            var forcedNumber = Cast.toNumber(requestedCostume);
+            if (!isNaN(forcedNumber)) {
+                util.target.setCostume(forcedNumber - 1);
+            }
+        }
+    }
+};
+
+Scratch3LooksBlocks.prototype.nextCostume = function (args, util) {
+    util.target.setCostume(util.target.currentCostume + 1);
 };
 
 Scratch3LooksBlocks.prototype.effectMenu = function (args) {

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -88,7 +88,6 @@ Scratch3LooksBlocks.prototype.hide = function (args, util) {
  */
 Scratch3LooksBlocks.prototype._setCostumeOrBackdrop = function (target,
         requestedCostume, opt_zeroIndex) {
-    var oldCostume = target.currentCostume;
     if (typeof requestedCostume === 'number') {
         target.setCostume(opt_zeroIndex ?
             requestedCostume : requestedCostume - 1);
@@ -110,9 +109,8 @@ Scratch3LooksBlocks.prototype._setCostumeOrBackdrop = function (target,
             }
         }
     }
-    if (oldCostume !== target.currentCostume &&
-        target == this.runtime.getTargetForStage()) {
-        // Costume switched and we're the stage - start hats.
+    if (target == this.runtime.getTargetForStage()) {
+        // Target is the stage - start hats.
         var newName = target.sprite.costumes[target.currentCostume].name;
         return this.runtime.startHats('event_whenbackdropswitchesto', {
             'BACKDROP': newName

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -435,23 +435,6 @@ Runtime.prototype.getTargetById = function (targetId) {
 };
 
 /**
- * Get a sprite target by its name.
- * Finds the first "original" (non-cloned-by-block) sprite.
- * @param {string} spriteName Name of sprite to find.
- * @return {?Target} The sprite target, if found.
- */
-Runtime.prototype.getTargetForSpriteName = function (spriteName) {
-    for (var i = 0; i < this.targets.length; i++) {
-        var target = this.targets[i];
-        if (target.isOriginalSprite &&
-            target.sprite &&
-            target.sprite.name == spriteName) {
-            return target;
-        }
-    }
-};
-
-/**
  * Get a target representing the Scratch stage, if one exists.
  * @return {?Target} The target, if found.
  */

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -435,6 +435,36 @@ Runtime.prototype.getTargetById = function (targetId) {
 };
 
 /**
+ * Get a sprite target by its name.
+ * Finds the first "original" (non-cloned-by-block) sprite.
+ * @param {string} spriteName Name of sprite to find.
+ * @return {?Target} The sprite target, if found.
+ */
+Runtime.prototype.getTargetForSpriteName = function (spriteName) {
+    for (var i = 0; i < this.targets.length; i++) {
+        var target = this.targets[i];
+        if (target.isOriginalSprite &&
+            target.sprite &&
+            target.sprite.name == spriteName) {
+            return target;
+        }
+    }
+};
+
+/**
+ * Get a target representing the Scratch stage, if one exists.
+ * @return {?Target} The target, if found.
+ */
+Runtime.prototype.getTargetForStage = function () {
+    for (var i = 0; i < this.targets.length; i++) {
+        var target = this.targets[i];
+        if (target.isStage) {
+            return target;
+        }
+    }
+};
+
+/**
  * Handle an animation frame from the main thread.
  */
 Runtime.prototype.animationFrame = function () {

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -20,7 +20,8 @@ var specMap = require('./sb2specmap');
 function sb2import (json, runtime) {
     parseScratchObject(
         JSON.parse(json),
-        runtime
+        runtime,
+        true
     );
 }
 
@@ -28,8 +29,9 @@ function sb2import (json, runtime) {
  * Parse a single "Scratch object" and create all its in-memory VM objects.
  * @param {!Object} object From-JSON "Scratch object:" sprite, stage, watcher.
  * @param {!Runtime} runtime Runtime object to load all structures into.
+ * @param {boolean} topLevel Whether this is the top-level object (stage).
  */
-function parseScratchObject (object, runtime) {
+function parseScratchObject (object, runtime, topLevel) {
     if (!object.hasOwnProperty('objName')) {
         // Watcher/monitor - skip this object until those are implemented in VM.
         // @todo
@@ -84,10 +86,11 @@ function parseScratchObject (object, runtime) {
     if (object.currentCostumeIndex) {
         target.currentCostume = object.currentCostumeIndex;
     }
+    target.isStage = topLevel;
     // The stage will have child objects; recursively process them.
     if (object.children) {
         for (var j = 0; j < object.children.length; j++) {
-            parseScratchObject(object.children[j], runtime);
+            parseScratchObject(object.children[j], runtime, false);
         }
     }
 }

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -113,6 +113,9 @@ Clone.prototype.effects = {
  * @param {!number} y New Y coordinate of clone, in Scratch coordinates.
  */
 Clone.prototype.setXY = function (x, y) {
+    if (this.isStage) {
+        return;
+    }
     this.x = x;
     this.y = y;
     if (this.renderer) {
@@ -127,6 +130,9 @@ Clone.prototype.setXY = function (x, y) {
  * @param {!number} direction New direction of clone.
  */
 Clone.prototype.setDirection = function (direction) {
+    if (this.isStage) {
+        return;
+    }
     // Keep direction between -179 and +180.
     this.direction = MathUtil.wrapClamp(direction, -179, 180);
     if (this.renderer) {
@@ -142,6 +148,9 @@ Clone.prototype.setDirection = function (direction) {
  * @param {?string} message Message to put in say bubble.
  */
 Clone.prototype.setSay = function (type, message) {
+    if (this.isStage) {
+        return;
+    }
     // @todo: Render to stage.
     if (!type || !message) {
         console.log('Clearing say bubble');
@@ -155,6 +164,9 @@ Clone.prototype.setSay = function (type, message) {
  * @param {!boolean} visible True if the sprite should be shown.
  */
 Clone.prototype.setVisible = function (visible) {
+    if (this.isStage) {
+        return;
+    }
     this.visible = visible;
     if (this.renderer) {
         this.renderer.updateDrawableProperties(this.drawableID, {
@@ -168,6 +180,9 @@ Clone.prototype.setVisible = function (visible) {
  * @param {!number} size Size of clone, from 5 to 535.
  */
 Clone.prototype.setSize = function (size) {
+    if (this.isStage) {
+        return;
+    }
     // Keep size between 5% and 535%.
     this.size = MathUtil.clamp(size, 5, 535);
     if (this.renderer) {

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -202,12 +202,29 @@ Clone.prototype.clearEffects = function () {
  * @param {number} index New index of costume.
  */
 Clone.prototype.setCostume = function (index) {
-    this.currentCostume = index;
+    // Keep the costume index within possible values.
+    this.currentCostume = MathUtil.wrapClamp(
+        index, 0, this.sprite.costumes.length - 1
+    );
     if (this.renderer) {
         this.renderer.updateDrawableProperties(this.drawableID, {
             skin: this.sprite.costumes[this.currentCostume].skin
         });
     }
+};
+
+/**
+ * Get a costume index of this clone, by name of the costume.
+ * @param {?string} costumeName Name of a costume.
+ * @return {number} Index of the named costume, or -1 if not present.
+ */
+Clone.prototype.getCostumeIndexByName = function (costumeName) {
+    for (var i = 0; i < this.sprite.costumes.length; i++) {
+        if (this.sprite.costumes[i].name == costumeName) {
+            return i;
+        }
+    }
+    return -1;
 };
 
 /**

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -57,13 +57,6 @@ Clone.prototype.initDrawable = function () {
 Clone.prototype.isStage = false;
 
 /**
- * Whether this clone represents an "original sprite," i.e.,
- * created by the editor, not by cloning blocks.
- * @type {boolean}
- */
-Clone.prototype.isOriginalSprite = true;
-
-/**
  * Scratch X coordinate. Currently should range from -240 to 240.
  * @type {Number}
  */

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -51,6 +51,19 @@ Clone.prototype.initDrawable = function () {
 
 // Clone-level properties.
 /**
+ * Whether this clone represents the Scratch stage.
+ * @type {boolean}
+ */
+Clone.prototype.isStage = false;
+
+/**
+ * Whether this clone represents an "original sprite," i.e.,
+ * created by the editor, not by cloning blocks.
+ * @type {boolean}
+ */
+Clone.prototype.isOriginalSprite = true;
+
+/**
  * Scratch X coordinate. Currently should range from -240 to 240.
  * @type {Number}
  */


### PR DESCRIPTION
Distinguish the stage from other clones (`isStage`) and set it in the SB2 importer. Add a method to runtime to get the stage. Disables some properties from being set on the stage (position, rotation, size).

Implements these blocks:
<img width="467" alt="screen shot 2016-09-06 at 2 16 21 pm" src="https://cloud.githubusercontent.com/assets/120403/18285495/a95074e4-743c-11e6-915e-5d916d209132.png">
