### PR TITLE
Clones

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -145,7 +145,9 @@ Scratch3ControlBlocks.prototype.createClone = function (args, util) {
         return;
     }
     var newClone = cloneTarget.cloneClone();
-    this.runtime.targets.push(newClone);
+    if (newClone) {
+        this.runtime.targets.push(newClone);
+    }
 };
 
 Scratch3ControlBlocks.prototype.deleteClone = function (args, util) {

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -23,7 +23,8 @@ Scratch3ControlBlocks.prototype.getPrimitives = function() {
         'control_if_else': this.ifElse,
         'control_stop': this.stop,
         'control_create_clone_of_menu': this.createCloneMenu,
-        'control_create_clone_of': this.createClone
+        'control_create_clone_of': this.createClone,
+        'control_delete_this_clone': this.deleteClone
     };
 };
 
@@ -145,7 +146,10 @@ Scratch3ControlBlocks.prototype.createClone = function (args, util) {
     }
     var newClone = cloneTarget.cloneClone();
     this.runtime.targets.push(newClone);
-    util.startHats('control_start_as_clone', null, newClone);
+};
+
+Scratch3ControlBlocks.prototype.deleteClone = function (args, util) {
+    this.runtime.disposeTarget(util.target);
 };
 
 module.exports = Scratch3ControlBlocks;

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -150,6 +150,7 @@ Scratch3ControlBlocks.prototype.createClone = function (args, util) {
 
 Scratch3ControlBlocks.prototype.deleteClone = function (args, util) {
     this.runtime.disposeTarget(util.target);
+    this.runtime.stopForTarget(util.target);
 };
 
 module.exports = Scratch3ControlBlocks;

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -21,7 +21,17 @@ Scratch3ControlBlocks.prototype.getPrimitives = function() {
         'control_wait': this.wait,
         'control_if': this.if,
         'control_if_else': this.ifElse,
-        'control_stop': this.stop
+        'control_stop': this.stop,
+        'control_create_clone_of_menu': this.createCloneMenu,
+        'control_create_clone_of': this.createClone
+    };
+};
+
+Scratch3ControlBlocks.prototype.getHats = function () {
+    return {
+        'control_start_as_clone': {
+            restartExistingThreads: false
+        }
     };
 };
 
@@ -116,6 +126,26 @@ Scratch3ControlBlocks.prototype.ifElse = function(args, util) {
 Scratch3ControlBlocks.prototype.stop = function() {
     // @todo - don't use this.runtime
     this.runtime.stopAll();
+};
+
+// @todo (GH-146): remove.
+Scratch3ControlBlocks.prototype.createCloneMenu = function (args) {
+    return args.CLONE_OPTION;
+};
+
+Scratch3ControlBlocks.prototype.createClone = function (args, util) {
+    var cloneTarget;
+    if (args.CLONE_OPTION == '_myself_') {
+        cloneTarget = util.target;
+    } else {
+        cloneTarget = this.runtime.getSpriteTargetByName(args.CLONE_OPTION);
+    }
+    if (!cloneTarget) {
+        return;
+    }
+    var newClone = cloneTarget.cloneClone();
+    this.runtime.targets.push(newClone);
+    util.startHats('control_start_as_clone', null, newClone);
 };
 
 module.exports = Scratch3ControlBlocks;

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -144,7 +144,7 @@ Scratch3ControlBlocks.prototype.createClone = function (args, util) {
     if (!cloneTarget) {
         return;
     }
-    var newClone = cloneTarget.cloneClone();
+    var newClone = cloneTarget.makeClone();
     if (newClone) {
         this.runtime.targets.push(newClone);
     }

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -23,8 +23,7 @@ Scratch3EventBlocks.prototype.getPrimitives = function() {
 Scratch3EventBlocks.prototype.getHats = function () {
     return {
         'event_whenflagclicked': {
-            restartExistingThreads: true,
-            skipClones: true
+            restartExistingThreads: true
         },
         'event_whenkeypressed': {
             restartExistingThreads: false

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -23,7 +23,8 @@ Scratch3EventBlocks.prototype.getPrimitives = function() {
 Scratch3EventBlocks.prototype.getHats = function () {
     return {
         'event_whenflagclicked': {
-            restartExistingThreads: true
+            restartExistingThreads: true,
+            skipClones: true
         },
         'event_whenkeypressed': {
             restartExistingThreads: false

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -16,7 +16,7 @@ var isPromise = function (value) {
  */
 var execute = function (sequencer, thread) {
     var runtime = sequencer.runtime;
-    var target = runtime.targetForThread(thread);
+    var target = thread.target;
 
     // Current block to execute is the one on the top of the stack.
     var currentBlockId = thread.peekStack();

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -194,11 +194,13 @@ Runtime.prototype.clearEdgeActivatedValues = function () {
 
 /**
  * Create a thread and push it to the list of threads.
- * @param {!string} id ID of block that starts the stack
+ * @param {!string} id ID of block that starts the stack.
+ * @param {!Target} target Target to run thread on.
  * @return {!Thread} The newly created thread.
  */
-Runtime.prototype._pushThread = function (id) {
+Runtime.prototype._pushThread = function (id, target) {
     var thread = new Thread(id);
+    thread.setTarget(target);
     thread.pushStack(id);
     this.threads.push(thread);
     return thread;
@@ -237,7 +239,8 @@ Runtime.prototype.toggleScript = function (topBlockId) {
         }
     }
     // Otherwise add it.
-    this._pushThread(topBlockId);
+    // @todo: Don't directly reference `self.vmInstance.`
+    this._pushThread(topBlockId, self.vmInstance.editingTarget);
 };
 
 /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -249,8 +249,7 @@ Runtime.prototype.toggleScript = function (topBlockId) {
         }
     }
     // Otherwise add it.
-    // @todo: Don't directly reference `self.vmInstance.`
-    this._pushThread(topBlockId, self.vmInstance.editingTarget);
+    this._pushThread(topBlockId, this._editingTarget);
 };
 
 /**
@@ -434,7 +433,7 @@ Runtime.prototype._updateScriptGlows = function () {
     // Find all scripts that should be glowing.
     for (var i = 0; i < this.threads.length; i++) {
         var thread = this.threads[i];
-        var target = this.targetForThread(thread);
+        var target = thread.target;
         if (thread.requestScriptGlowInFrame && target == this._editingTarget) {
             var blockForThread = thread.peekStack() || thread.topBlock;
             var script = target.blocks.getTopLevelScript(blockForThread);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -288,13 +288,6 @@ Runtime.prototype.startHats = function (requestedHatOpcode,
             // Not the right hat.
             return;
         }
-        // Look up metadata for the relevant hat.
-        var hatMeta = instance._hats[requestedHatOpcode];
-        // Should the hat be skipped because it's a clone target?
-        if (hatMeta.skipClones &&
-            target.hasOwnProperty('isOriginal') && !target.isOriginal) {
-            return;
-        }
         // Match any requested fields.
         // For example: ensures that broadcasts match.
         // This needs to happen before the block is evaluated
@@ -310,6 +303,8 @@ Runtime.prototype.startHats = function (requestedHatOpcode,
                 }
             }
         }
+        // Look up metadata for the relevant hat.
+        var hatMeta = instance._hats[requestedHatOpcode];
         if (hatMeta.restartExistingThreads) {
             // If `restartExistingThreads` is true, we should stop
             // any existing threads starting with the top block.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -60,6 +60,11 @@ function Runtime () {
 
     this._scriptGlowsPreviousFrame = [];
     this._editingTarget = null;
+    /**
+     * Currently known number of clones.
+     * @type {number}
+     */
+    this._cloneCounter = 0;
 }
 
 /**
@@ -102,6 +107,11 @@ util.inherits(Runtime, EventEmitter);
  */
 Runtime.THREAD_STEP_INTERVAL = 1000 / 60;
 
+/**
+ * How many clones can be created at a time.
+ * @const {number}
+ */
+Runtime.MAX_CLONES = 300;
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
@@ -529,6 +539,22 @@ Runtime.prototype.getSpriteTargetByName = function (spriteName) {
             return target;
         }
     }
+};
+
+/**
+ * Update the clone counter to track how many clones are created.
+ * @param {number} changeAmount How many clones have been created/destroyed.
+ */
+Runtime.prototype.changeCloneCounter = function (changeAmount) {
+    this._cloneCounter += changeAmount;
+};
+
+/**
+ * Return whether there are clones available.
+ * @return {boolean} True until the number of clones hits Runtime.MAX_CLONES.
+ */
+Runtime.prototype.clonesAvailable = function () {
+    return this._cloneCounter < Runtime.MAX_CLONES;
 };
 
 /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -337,18 +337,47 @@ Runtime.prototype.startHats = function (requestedHatOpcode,
 };
 
 /**
+ * Dispose of a target.
+ * @param {!Target} target Target to dispose of.
+ */
+Runtime.prototype.disposeTarget = function (target) {
+    // Allow target to do dispose actions.
+    target.dispose();
+    // Remove from list of targets.
+    var index = this.targets.indexOf(target);
+    if (index > -1) {
+        this.targets.splice(index, 1);
+    }
+    // Stop any threads on the target.
+    for (var i = 0; i < this.threads.length; i++) {
+        if (this.threads[i].target == target) {
+            this._removeThread(this.threads[i]);
+        }
+    }
+};
+
+/**
  * Start all threads that start with the green flag.
  */
 Runtime.prototype.greenFlag = function () {
+    this.stopAll();
     this.ioDevices.clock.resetProjectTimer();
     this.clearEdgeActivatedValues();
     this.startHats('event_whenflagclicked');
 };
 
 /**
- * Stop "everything"
+ * Stop "everything."
  */
 Runtime.prototype.stopAll = function () {
+    // Dispose all clones.
+    for (var i = 0; i < this.targets.length; i++) {
+        if (this.targets[i].hasOwnProperty('isOriginal') &&
+            !this.targets[i].isOriginal) {
+            this.disposeTarget(this.targets[i]);
+        }
+    }
+    // Dispose all threads.
     var threadsCopy = this.threads.slice();
     while (threadsCopy.length > 0) {
         var poppedThread = threadsCopy.pop();

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -348,6 +348,13 @@ Runtime.prototype.disposeTarget = function (target) {
     if (index > -1) {
         this.targets.splice(index, 1);
     }
+};
+
+/**
+ * Stop any threads acting on the target.
+ * @param {!Target} target Target to stop threads for.
+ */
+Runtime.prototype.stopForTarget = function (target) {
     // Stop any threads on the target.
     for (var i = 0; i < this.threads.length; i++) {
         if (this.threads[i].target == target) {
@@ -371,12 +378,16 @@ Runtime.prototype.greenFlag = function () {
  */
 Runtime.prototype.stopAll = function () {
     // Dispose all clones.
+    var newTargets = [];
     for (var i = 0; i < this.targets.length; i++) {
         if (this.targets[i].hasOwnProperty('isOriginal') &&
             !this.targets[i].isOriginal) {
-            this.disposeTarget(this.targets[i]);
+            this.targets[i].dispose();
+        } else {
+            newTargets.push(this.targets[i]);
         }
     }
+    this.targets = newTargets;
     // Dispose all threads.
     var threadsCopy = this.threads.slice();
     while (threadsCopy.length > 0) {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -111,7 +111,7 @@ Sequencer.prototype.stepToBranch = function (thread, branchNum) {
         branchNum = 1;
     }
     var currentBlockId = thread.peekStack();
-    var branchId = this.runtime.targetForThread(thread).blocks.getBranch(
+    var branchId = thread.target.blocks.getBranch(
         currentBlockId,
         branchNum
     );
@@ -155,8 +155,7 @@ Sequencer.prototype.proceedThread = function (thread) {
     // Pop from the stack - finished this level of execution.
     thread.popStack();
     // Push next connected block, if there is one.
-    var nextBlockId = (this.runtime.targetForThread(thread).
-        blocks.getNextBlock(currentBlockId));
+    var nextBlockId = thread.target.blocks.getNextBlock(currentBlockId);
     if (nextBlockId) {
         thread.pushStack(nextBlockId);
     }

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -37,4 +37,12 @@ Target.prototype.getName = function () {
     return this.id;
 };
 
+/**
+ * Call to destroy a target.
+ * @abstract
+ */
+Target.prototype.dispose = function () {
+
+};
+
 module.exports = Target;

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -30,6 +30,12 @@ function Thread (firstBlock) {
     this.status = 0; /* Thread.STATUS_RUNNING */
 
     /**
+     * Target of this thread.
+     * @type {?Target}
+     */
+    this.target = null;
+
+    /**
      * Whether the thread requests its script to glow during this frame.
      * @type {boolean}
      */
@@ -143,6 +149,22 @@ Thread.prototype.atStackTop = function () {
  */
 Thread.prototype.setStatus = function (status) {
     this.status = status;
+};
+
+/**
+ * Set thread target.
+ * @param {?Target} target Target for this thread.
+ */
+Thread.prototype.setTarget = function (target) {
+    this.target = target;
+};
+
+/**
+ * Get thread target.
+ * @return {?Target} Target for this thread, if available.
+ */
+Thread.prototype.getTarget = function () {
+    return this.target;
 };
 
 module.exports = Thread;

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -40,7 +40,7 @@ function parseScratchObject (object, runtime, topLevel) {
     // Blocks container for this object.
     var blocks = new Blocks();
     // @todo: For now, load all Scratch objects (stage/sprites) as a Sprite.
-    var sprite = new Sprite(blocks);
+    var sprite = new Sprite(blocks, runtime);
     // Sprite/stage name from JSON.
     if (object.hasOwnProperty('objName')) {
         sprite.name = object.objName;

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,10 @@ VirtualMachine.prototype.setEditingTarget = function (targetId) {
 VirtualMachine.prototype.emitTargetsUpdate = function () {
     this.emit('targetsUpdate', {
         // [[target id, human readable target name], ...].
-        targetList: this.runtime.targets.map(function(target) {
+        targetList: this.runtime.targets.filter(function (target) {
+            // Don't report clones.
+            return !target.hasOwnProperty('isOriginal') || target.isOriginal;
+        }).map(function(target) {
             return [target.id, target.getName()];
         }),
         // Currently editing target id.

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -31,8 +31,6 @@ function Clone(sprite, runtime) {
      * @type {?Number}
      */
     this.drawableID = null;
-
-    this.initDrawable();
 }
 util.inherits(Clone, Target);
 
@@ -324,7 +322,6 @@ Clone.prototype.makeClone = function () {
     }
     this.runtime.changeCloneCounter(1);
     var newClone = this.sprite.createClone();
-    newClone.isOriginal = false;
     newClone.x = this.x;
     newClone.y = this.y;
     newClone.direction = this.direction;
@@ -332,6 +329,8 @@ Clone.prototype.makeClone = function () {
     newClone.size = this.size;
     newClone.currentCostume = this.currentCostume;
     newClone.effects = JSON.parse(JSON.stringify(this.effects));
+    newClone.initDrawable();
+    newClone.updateAllDrawableProperties();
     return newClone;
 };
 

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -5,10 +5,12 @@ var Target = require('../engine/target');
 /**
  * Clone (instance) of a sprite.
  * @param {!Sprite} sprite Reference to the sprite.
+ * @param {Runtime} runtime Reference to the runtime.
  * @constructor
  */
-function Clone(sprite) {
+function Clone(sprite, runtime) {
     Target.call(this, sprite.blocks);
+    this.runtime = runtime;
     /**
      * Reference to the sprite that this is a clone of.
      * @type {!Sprite}

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -338,6 +338,9 @@ Clone.prototype.makeClone = function () {
  * Dispose of this clone, destroying any run-time properties.
  */
 Clone.prototype.dispose = function () {
+    if (this.isOriginal) { // Don't allow a non-clone to delete itself.
+        return;
+    }
     this.runtime.changeCloneCounter(-1);
     if (this.renderer && this.drawableID !== null) {
         this.renderer.destroyDrawable(this.drawableID);

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -46,6 +46,13 @@ Clone.prototype.initDrawable = function () {
 
 // Clone-level properties.
 /**
+ * Whether this represents an "original" clone, i.e., created by the editor
+ * and not clone blocks. In interface terms, this true for a "sprite."
+ * @type {boolean}
+ */
+Clone.prototype.isOriginal = true;
+
+/**
  * Whether this clone represents the Scratch stage.
  * @type {boolean}
  */

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -318,6 +318,10 @@ Clone.prototype.colorIsTouchingColor = function (targetRgb, maskRgb) {
  * @return {!Clone} New clone object.
  */
 Clone.prototype.makeClone = function () {
+    if (!this.runtime.clonesAvailable()) {
+        return; // Hit max clone limit.
+    }
+    this.runtime.changeCloneCounter(1);
     var newClone = this.sprite.createClone();
     newClone.isOriginal = false;
     newClone.x = this.x;
@@ -334,6 +338,7 @@ Clone.prototype.makeClone = function () {
  * Dispose of this clone, destroying any run-time properties.
  */
 Clone.prototype.dispose = function () {
+    this.runtime.changeCloneCounter(-1);
     if (this.renderer && this.drawableID !== null) {
         this.renderer.destroyDrawable(this.drawableID);
     }

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -44,6 +44,12 @@ Clone.prototype.initDrawable = function () {
         this.drawableID = this.renderer.createDrawable();
         this.updateAllDrawableProperties();
     }
+    // If we're a clone, start the hats.
+    if (!this.isOriginal) {
+        this.runtime.startHats(
+            'control_start_as_clone', null, this
+        );
+    }
 };
 
 // Clone-level properties.
@@ -322,6 +328,15 @@ Clone.prototype.makeClone = function () {
     newClone.currentCostume = this.currentCostume;
     newClone.effects = JSON.parse(JSON.stringify(this.effects));
     return newClone;
+};
+
+/**
+ * Dispose of this clone, destroying any run-time properties.
+ */
+Clone.prototype.dispose = function () {
+    if (this.renderer && this.drawableID !== null) {
+        this.renderer.destroyDrawable(this.drawableID);
+    }
 };
 
 module.exports = Clone;

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -315,6 +315,7 @@ Clone.prototype.colorIsTouchingColor = function (targetRgb, maskRgb) {
 
 /**
  * Make a clone of this clone, copying any run-time properties.
+ * If we've hit the global clone limit, returns null.
  * @return {!Clone} New clone object.
  */
 Clone.prototype.makeClone = function () {

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -305,4 +305,21 @@ Clone.prototype.colorIsTouchingColor = function (targetRgb, maskRgb) {
     return false;
 };
 
+/**
+ * Make a clone of this clone, copying any run-time properties.
+ * @return {!Clone} New clone object.
+ */
+Clone.prototype.makeClone = function () {
+    var newClone = this.sprite.createClone();
+    newClone.isOriginal = false;
+    newClone.x = this.x;
+    newClone.y = this.y;
+    newClone.direction = this.direction;
+    newClone.visible = this.visible;
+    newClone.size = this.size;
+    newClone.currentCostume = this.currentCostume;
+    newClone.effects = JSON.parse(JSON.stringify(this.effects));
+    return newClone;
+};
+
 module.exports = Clone;

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -5,9 +5,11 @@ var Blocks = require('../engine/blocks');
  * Sprite to be used on the Scratch stage.
  * All clones of a sprite have shared blocks, shared costumes, shared variables.
  * @param {?Blocks} blocks Shared blocks object for all clones of sprite.
+ * @param {Runtime} runtime Reference to the runtime.
  * @constructor
  */
-function Sprite (blocks) {
+function Sprite (blocks, runtime) {
+    this.runtime = runtime;
     if (!blocks) {
         // Shared set of blocks for all clones.
         blocks = new Blocks();
@@ -43,7 +45,7 @@ function Sprite (blocks) {
  * @returns {!Clone} Newly created clone.
  */
 Sprite.prototype.createClone = function () {
-    var newClone = new Clone(this);
+    var newClone = new Clone(this, this.runtime);
     this.clones.push(newClone);
     return newClone;
 };

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -46,7 +46,12 @@ function Sprite (blocks, runtime) {
  */
 Sprite.prototype.createClone = function () {
     var newClone = new Clone(this, this.runtime);
+    newClone.isOriginal = this.clones.length == 0;
     this.clones.push(newClone);
+    if (newClone.isOriginal) {
+        newClone.initDrawable();
+        newClone.updateAllDrawableProperties();
+    }
     return newClone;
 };
 


### PR DESCRIPTION
A couple of quirks here to make this work:
- Moving `target` to be a property of `Thread`. Why? Previously `targetForThread` worked by searching all targets' blocks to see if the thread's top block was inside that target. But, now multiple targets may include the same blocks (if a clone is made). So, we can just associate the target with the thread instead, and two threads can be running on the same blocks (but different target clones).
- Added a property used to indicate if a target is "original", i.e., not a clone of an existing clone. That way, you can do things like, when you hit the stop button, remove all clones (but not the original sprites). Or, don't show the clones in the editor's list of sprites.
- I ended up passing `runtime` to Sprite and Clone. This is a little unfortunate. The reason being is we can't start new clones' hats ("when this clone started") until the drawable is initialized. Otherwise, you could do something like when this clone started -> delete this clone (which needs to wait for the drawable to finish being created in order to destroy it)...thoughts on this would be great as I don't love this solution.

Demo:
![sep-06-2016 16-26-33](https://cloud.githubusercontent.com/assets/120403/18289747/b8c0ced0-744e-11e6-8c41-4fb3c6640f0c.gif)
(The squirrel shows up because the renderer momentarily renders a fallback sprite while the real one is possibly coming from the server - something to fix over there, probably).
