### PR TITLE
Better glows

### DIFF
--- a/src/engine/adapter.js
+++ b/src/engine/adapter.js
@@ -31,7 +31,7 @@ function domToBlocks (blocksDOM) {
         }
         var tagName = block.name.toLowerCase();
         if (tagName == 'block' || tagName == 'shadow') {
-            domToBlock(block, blocks, true);
+            domToBlock(block, blocks, true, null);
         }
     }
     // Flatten blocks object into a list.
@@ -48,8 +48,9 @@ function domToBlocks (blocksDOM) {
  * @param {Element} blockDOM DOM tree for an individual block.
  * @param {Object} blocks Collection of blocks to add to.
  * @param {Boolean} isTopBlock Whether blocks at this level are "top blocks."
+ * @param {?string} parent Parent block ID.
  */
-function domToBlock (blockDOM, blocks, isTopBlock) {
+function domToBlock (blockDOM, blocks, isTopBlock, parent) {
     // Block skeleton.
     var block = {
         id: blockDOM.attribs.id, // Block ID
@@ -58,6 +59,7 @@ function domToBlock (blockDOM, blocks, isTopBlock) {
         fields: {}, // Fields on this block and their values.
         next: null, // Next block in the stack, if one exists.
         topLevel: isTopBlock, // If this block starts a stack.
+        parent: parent, // Parent block ID, if available.
         shadow: blockDOM.name == 'shadow', // If this represents a shadow/slot.
         x: blockDOM.attribs.x, // X position of script, if top-level.
         y: blockDOM.attribs.y // Y position of script, if top-level.
@@ -113,10 +115,10 @@ function domToBlock (blockDOM, blocks, isTopBlock) {
         case 'value':
         case 'statement':
             // Recursively generate block structure for input block.
-            domToBlock(childBlockNode, blocks, false);
+            domToBlock(childBlockNode, blocks, false, block.id);
             if (childShadowNode && childBlockNode != childShadowNode) {
                 // Also generate the shadow block.
-                domToBlock(childShadowNode, blocks, false);
+                domToBlock(childShadowNode, blocks, false, block.id);
             }
             // Link this block's input to the child block.
             var inputName = xmlChild.attribs.name;
@@ -132,7 +134,7 @@ function domToBlock (blockDOM, blocks, isTopBlock) {
                 continue;
             }
             // Recursively generate block structure for next block.
-            domToBlock(childBlockNode, blocks, false);
+            domToBlock(childBlockNode, blocks, false, block.id);
             // Link next block to this block.
             block.next = childBlockNode.attribs.id;
             break;

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -115,6 +115,20 @@ Blocks.prototype.getInputs = function (id) {
     return inputs;
 };
 
+/**
+ * Get the top-level script for a given block.
+ * @param {?string} id ID of block to query.
+ * @return {?string} ID of top-level script block.
+ */
+Blocks.prototype.getTopLevelScript = function (id) {
+    if (typeof this._blocks[id] === 'undefined') return null;
+    var block = this._blocks[id];
+    while (block.parent !== null) {
+        block = this._blocks[block.parent];
+    }
+    return block.id;
+};
+
 // ---------------------------------------------------------------------
 
 /**
@@ -237,6 +251,7 @@ Blocks.prototype.moveBlock = function (e) {
             // This block was connected to the old parent's next connection.
             oldParent.next = null;
         }
+        this._blocks[e.id].parent = null;
     }
 
     // Has the block become a top-level block?
@@ -256,6 +271,7 @@ Blocks.prototype.moveBlock = function (e) {
             // Moved to the new parent's next connection.
             this._blocks[e.newParent].next = e.id;
         }
+        this._blocks[e.id].parent = e.newParent;
     }
 };
 

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -41,6 +41,7 @@ var execute = function (sequencer, thread) {
         }
         // Skip through the block.
         // (either hat with no predicate, or missing op).
+        thread.requestScriptGlowInFrame = true;
         return;
     }
 
@@ -109,6 +110,12 @@ var execute = function (sequencer, thread) {
             }
         }
     });
+
+    if (typeof primitiveReportedValue === 'undefined') {
+        // No value reported - potentially a command block.
+        // Edge-activated hats don't request a glow; all commands do.
+        thread.requestScriptGlowInFrame = true;
+    }
 
     /**
      * Handle any reported value from the primitive, either directly returned

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -383,7 +383,6 @@ Runtime.prototype._updateScriptGlows = function () {
         if (thread.requestScriptGlowInFrame && target == this._editingTarget) {
             var blockForThread = thread.peekStack() || thread.topBlock;
             var script = target.blocks.getTopLevelScript(blockForThread);
-            console.log(script);
             requestedGlowsThisFrame.push(script);
         }
     }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -60,25 +60,25 @@ function Runtime () {
 }
 
 /**
- * Event name for glowing a stack
+ * Event name for glowing a script.
  * @const {string}
  */
-Runtime.STACK_GLOW_ON = 'STACK_GLOW_ON';
+Runtime.SCRIPT_GLOW_ON = 'STACK_GLOW_ON';
 
 /**
- * Event name for unglowing a stack
+ * Event name for unglowing a script.
  * @const {string}
  */
-Runtime.STACK_GLOW_OFF = 'STACK_GLOW_OFF';
+Runtime.SCRIPT_GLOW_OFF = 'STACK_GLOW_OFF';
 
 /**
- * Event name for glowing a block
+ * Event name for glowing a block.
  * @const {string}
  */
 Runtime.BLOCK_GLOW_ON = 'BLOCK_GLOW_ON';
 
 /**
- * Event name for unglowing a block
+ * Event name for unglowing a block.
  * @const {string}
  */
 Runtime.BLOCK_GLOW_OFF = 'BLOCK_GLOW_OFF';
@@ -196,7 +196,6 @@ Runtime.prototype.clearEdgeActivatedValues = function () {
  */
 Runtime.prototype._pushThread = function (id) {
     var thread = new Thread(id);
-    this.glowScript(id, true);
     thread.pushStack(id);
     this.threads.push(thread);
     return thread;
@@ -209,7 +208,6 @@ Runtime.prototype._pushThread = function (id) {
 Runtime.prototype._removeThread = function (thread) {
     var i = this.threads.indexOf(thread);
     if (i > -1) {
-        this.glowScript(thread.topBlock, false);
         this.threads.splice(i, 1);
     }
 };
@@ -341,11 +339,6 @@ Runtime.prototype.stopAll = function () {
     var threadsCopy = this.threads.slice();
     while (threadsCopy.length > 0) {
         var poppedThread = threadsCopy.pop();
-        // Unglow any blocks on this thread's stack.
-        for (var i = 0; i < poppedThread.stack.length; i++) {
-            this.glowBlock(poppedThread.stack[i], false);
-        }
-        // Actually remove the thread.
         this._removeThread(poppedThread);
     }
 };
@@ -388,9 +381,9 @@ Runtime.prototype.glowBlock = function (blockId, isGlowing) {
  */
 Runtime.prototype.glowScript = function (topBlockId, isGlowing) {
     if (isGlowing) {
-        this.emit(Runtime.STACK_GLOW_ON, topBlockId);
+        this.emit(Runtime.SCRIPT_GLOW_ON, topBlockId);
     } else {
-        this.emit(Runtime.STACK_GLOW_OFF, topBlockId);
+        this.emit(Runtime.SCRIPT_GLOW_OFF, topBlockId);
     }
 };
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -379,9 +379,10 @@ Runtime.prototype._updateScriptGlows = function () {
     // Find all scripts that should be glowing.
     for (var i = 0; i < this.threads.length; i++) {
         var thread = this.threads[i];
-        if (thread.requestScriptGlowInFrame &&
-            this.targetForThread(thread) == this._editingTarget) {
-            requestedGlowsThisFrame.push(thread.topBlock);
+        var target = this.targetForThread(thread);
+        if (thread.requestScriptGlowInFrame && target == this._editingTarget) {
+            var script = target.blocks.getTopLevelScript(thread.peekStack());
+            requestedGlowsThisFrame.push(script);
         }
     }
     // Compare to previous frame.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -381,7 +381,9 @@ Runtime.prototype._updateScriptGlows = function () {
         var thread = this.threads[i];
         var target = this.targetForThread(thread);
         if (thread.requestScriptGlowInFrame && target == this._editingTarget) {
-            var script = target.blocks.getTopLevelScript(thread.peekStack());
+            var blockForThread = thread.peekStack() || thread.topBlock;
+            var script = target.blocks.getTopLevelScript(blockForThread);
+            console.log(script);
             requestedGlowsThisFrame.push(script);
         }
     }

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -28,6 +28,12 @@ function Thread (firstBlock) {
      * @type {number}
      */
     this.status = 0; /* Thread.STATUS_RUNNING */
+
+    /**
+     * Whether the thread requests its script to glow during this frame.
+     * @type {boolean}
+     */
+    this.requestScriptGlowInFrame = false;
 }
 
 /**

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -112,6 +112,7 @@ function parseScripts (scripts, blocks) {
             parsedBlockList[0].x = scriptX * 1.1;
             parsedBlockList[0].y = scriptY * 1.1;
             parsedBlockList[0].topLevel = true;
+            parsedBlockList[0].parent = null;
         }
         // Flatten children and create add the blocks.
         var convertedBlocks = flatten(parsedBlockList);
@@ -136,6 +137,7 @@ function parseBlockList (blockList) {
         var block = blockList[i];
         var parsedBlock = parseBlock(block);
         if (previousBlock) {
+            parsedBlock.parent = previousBlock.id;
             previousBlock.next = parsedBlock.id;
         }
         previousBlock = parsedBlock;
@@ -214,6 +216,9 @@ function parseBlock (sb2block) {
                     // Single block occupies the input.
                     innerBlocks = [parseBlock(providedArg)];
                 }
+                for (var j = 0; j < innerBlocks.length; j++) {
+                    innerBlocks[j].parent = activeBlock.id;
+                }
                 // Obscures any shadow.
                 shadowObscured = true;
                 activeBlock.inputs[expectedArg.inputName].block = (
@@ -268,6 +273,7 @@ function parseBlock (sb2block) {
                 fields: fields,
                 next: null,
                 topLevel: false,
+                parent: activeBlock.id,
                 shadow: true
             });
             activeBlock.inputs[expectedArg.inputName].shadow = inputUid;

--- a/src/index.js
+++ b/src/index.js
@@ -31,11 +31,11 @@ function VirtualMachine () {
      */
     instance.editingTarget = null;
     // Runtime emits are passed along as VM emits.
-    instance.runtime.on(Runtime.STACK_GLOW_ON, function (id) {
-        instance.emit(Runtime.STACK_GLOW_ON, {id: id});
+    instance.runtime.on(Runtime.SCRIPT_GLOW_ON, function (id) {
+        instance.emit(Runtime.SCRIPT_GLOW_ON, {id: id});
     });
-    instance.runtime.on(Runtime.STACK_GLOW_OFF, function (id) {
-        instance.emit(Runtime.STACK_GLOW_OFF, {id: id});
+    instance.runtime.on(Runtime.SCRIPT_GLOW_OFF, function (id) {
+        instance.emit(Runtime.SCRIPT_GLOW_OFF, {id: id});
     });
     instance.runtime.on(Runtime.BLOCK_GLOW_ON, function (id) {
         instance.emit(Runtime.BLOCK_GLOW_ON, {id: id});
@@ -233,11 +233,11 @@ if (ENV_WORKER) {
         }
     };
     // Bind runtime's emitted events to postmessages.
-    self.vmInstance.runtime.on(Runtime.STACK_GLOW_ON, function (id) {
-        self.postMessage({method: Runtime.STACK_GLOW_ON, id: id});
+    self.vmInstance.runtime.on(Runtime.SCRIPT_GLOW_ON, function (id) {
+        self.postMessage({method: Runtime.SCRIPT_GLOW_ON, id: id});
     });
-    self.vmInstance.runtime.on(Runtime.STACK_GLOW_OFF, function (id) {
-        self.postMessage({method: Runtime.STACK_GLOW_OFF, id: id});
+    self.vmInstance.runtime.on(Runtime.SCRIPT_GLOW_OFF, function (id) {
+        self.postMessage({method: Runtime.SCRIPT_GLOW_OFF, id: id});
     });
     self.vmInstance.runtime.on(Runtime.BLOCK_GLOW_ON, function (id) {
         self.postMessage({method: Runtime.BLOCK_GLOW_ON, id: id});

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ VirtualMachine.prototype.loadProject = function (json) {
     // Update the VM user's knowledge of targets and blocks on the workspace.
     this.emitTargetsUpdate();
     this.emitWorkspaceUpdate();
+    this.runtime.setEditingTarget(this.editingTarget);
 };
 
 /**
@@ -135,6 +136,7 @@ VirtualMachine.prototype.setEditingTarget = function (targetId) {
         // Emit appropriate UI updates.
         this.emitTargetsUpdate();
         this.emitWorkspaceUpdate();
+        this.runtime.setEditingTarget(target);
     }
 };
 


### PR DESCRIPTION
This should fix #116 and also possibly #15, an improvement over Scratch 2.0.

Features:
- Appropriately glow only scripts that are on the current editing target (i.e., that scratch-blocks knows about), and update script glows when target is switched.
- Tracks and refreshes glows on a per-frame basis. Should guarantee that a desired glow is visible for at least one frame (e.g., clicking "move 10 steps" will always glow for a frame - previously it would just send glow/unglow at the same time and rely on the browser's slowness).
- Doesn't glow edge-triggered hat blocks unless that script actually executed a command block during the frame, preventing the "flashiness."
- The improvement over Scratch 2.0 and 1.4: glowing follows the script of execution. Did this by tracking the parent in the blocks representation and looking it up when determining glows.
  ![glows](https://cloud.githubusercontent.com/assets/120403/18314731/3cedaa64-74e2-11e6-928a-1094ecf510f4.gif)

This prevents the weirdness here, where even though the "forever" isn't highlighted, the cat is spinning:
<img width="837" alt="screen shot 2016-09-07 at 10 03 28 am" src="https://cloud.githubusercontent.com/assets/120403/18314760/5f111d7e-74e2-11e6-91c0-6e67644b3f9f.png">
