### PR TITLE
More color utilities, touching color, color touching color

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -1,3 +1,5 @@
+var Cast = require('../util/cast');
+
 function Scratch3SensingBlocks(runtime) {
     /**
      * The runtime instantiating this block package.
@@ -12,6 +14,9 @@ function Scratch3SensingBlocks(runtime) {
  */
 Scratch3SensingBlocks.prototype.getPrimitives = function() {
     return {
+        'colour_picker': this.colorPicker,
+        'sensing_touchingcolor': this.touchingColor,
+        'sensing_coloristouchingcolor': this.colorTouchingColor,
         'sensing_timer': this.getTimer,
         'sensing_resettimer': this.resetTimer,
         'sensing_mousex': this.getMouseX,
@@ -22,6 +27,21 @@ Scratch3SensingBlocks.prototype.getPrimitives = function() {
         'sensing_current': this.current,
         'sensing_currentmenu': this.currentMenu
     };
+};
+
+Scratch3SensingBlocks.prototype.colorPicker = function (args) {
+    return args.COLOUR;
+};
+
+Scratch3SensingBlocks.prototype.touchingColor = function (args, util) {
+    var color = Cast.toRgbColor(args.COLOR);
+    return util.target.isTouchingColor(color);
+};
+
+Scratch3SensingBlocks.prototype.colorTouchingColor = function (args, util) {
+    var maskColor = Cast.toRgbColor(args.COLOR);
+    var targetColor = Cast.toRgbColor(args.COLOR2);
+    return util.target.colorIsTouchingColor(targetColor, maskColor);
 };
 
 Scratch3SensingBlocks.prototype.getTimer = function (args, util) {

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -34,13 +34,13 @@ Scratch3SensingBlocks.prototype.colorPicker = function (args) {
 };
 
 Scratch3SensingBlocks.prototype.touchingColor = function (args, util) {
-    var color = Cast.toRgbColor(args.COLOR);
+    var color = Cast.toRgbColorList(args.COLOR);
     return util.target.isTouchingColor(color);
 };
 
 Scratch3SensingBlocks.prototype.colorTouchingColor = function (args, util) {
-    var maskColor = Cast.toRgbColor(args.COLOR);
-    var targetColor = Cast.toRgbColor(args.COLOR2);
+    var maskColor = Cast.toRgbColorList(args.COLOR);
+    var targetColor = Cast.toRgbColorList(args.COLOR2);
     return util.target.colorIsTouchingColor(targetColor, maskColor);
 };
 

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -250,7 +250,7 @@ function parseBlock (sb2block) {
                 }
             } else if (expectedArg.inputOp == 'colour_picker') {
                 // Convert SB2 color to hex.
-                fieldValue = Color.scratchColorToHex(providedArg);
+                fieldValue = Color.decimalToHex(providedArg);
                 fieldName = 'COLOUR';
                 if (shadowObscured) {
                     fieldValue = '#990000';

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -235,4 +235,33 @@ Clone.prototype.getName = function () {
     return this.sprite.name;
 };
 
+/**
+ * Return whether the clone is touching a color.
+ * @param {Object} rgb {r: R, g: G, b: B}, values between 0-255.
+ * @return {Promise.<Boolean>} True iff the clone is touching the color.
+ */
+Clone.prototype.isTouchingColor = function (rgb) {
+    if (this.renderer) {
+        return this.renderer.isTouchingColor(this.drawableID, rgb);
+    }
+    return false;
+};
+
+/**
+ * Return whether the clone's color is touching a color.
+ * @param {Object} targetRgb {r: R, g: G, b: B}, values between 0-255.
+ * @param {Object} maskRgb {r: R, g: G, b: B}, values between 0-255.
+ * @return {Promise.<Boolean>} True iff the clone's color is touching the color.
+ */
+Clone.prototype.colorIsTouchingColor = function (targetRgb, maskRgb) {
+    if (this.renderer) {
+        return this.renderer.isTouchingColor(
+            this.drawableID,
+            targetRgb,
+            maskRgb
+        );
+    }
+    return false;
+};
+
 module.exports = Clone;

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -237,7 +237,7 @@ Clone.prototype.getName = function () {
 
 /**
  * Return whether the clone is touching a color.
- * @param {Object} rgb {r: R, g: G, b: B}, values between 0-255.
+ * @param {Array.<number>} rgb [r,g,b], values between 0-255.
  * @return {Promise.<Boolean>} True iff the clone is touching the color.
  */
 Clone.prototype.isTouchingColor = function (rgb) {
@@ -249,8 +249,8 @@ Clone.prototype.isTouchingColor = function (rgb) {
 
 /**
  * Return whether the clone's color is touching a color.
- * @param {Object} targetRgb {r: R, g: G, b: B}, values between 0-255.
- * @param {Object} maskRgb {r: R, g: G, b: B}, values between 0-255.
+ * @param {Object} targetRgb {Array.<number>} [r,g,b], values between 0-255.
+ * @param {Object} maskRgb {Array.<number>} [r,g,b], values between 0-255.
  * @return {Promise.<Boolean>} True iff the clone's color is touching the color.
  */
 Clone.prototype.colorIsTouchingColor = function (targetRgb, maskRgb) {

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -68,20 +68,14 @@ Cast.toString = function (value) {
 /**
  * Cast any Scratch argument to an RGB color object.
  * @param {*} value Value to convert to RGB color object.
- * @return {Object} {r: R, g: G, b: B}, values between 0-1.
+ * @return {Object} {r: R, g: G, b: B}, values between 0-255.
  */
-Cast.toScaledRgbColor = function (value) {
-    var color;
+Cast.toRgbColor = function (value) {
     if (typeof value == 'string' && value.substring(0, 1) == '#') {
-        color = Color.hexToRgb(value);
+        return Color.hexToRgb(value);
     } else {
-        color = Color.decimalToRgb(Cast.toNumber(value));
+        return Color.decimalToRgb(Cast.toNumber(value));
     }
-    return {
-        r: color.r / 255,
-        g: color.g / 255,
-        b: color.b / 255
-    };
 };
 
 /**

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -1,3 +1,5 @@
+var Color = require('../util/color');
+
 function Cast () {}
 
 /**
@@ -61,6 +63,25 @@ Cast.toBoolean = function (value) {
  */
 Cast.toString = function (value) {
     return String(value);
+};
+
+/**
+ * Cast any Scratch argument to an RGB color object.
+ * @param {*} value Value to convert to RGB color object.
+ * @return {Object} {r: R, g: G, b: B}, values between 0-1.
+ */
+Cast.toScaledRgbColor = function (value) {
+    var color;
+    if (typeof value == 'string' && value.substring(0, 1) == '#') {
+        color = Color.hexToRgb(value);
+    } else {
+        color = Color.decimalToRgb(Cast.toNumber(value));
+    }
+    return {
+        r: color.r / 255,
+        g: color.g / 255,
+        b: color.b / 255
+    };
 };
 
 /**

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -66,16 +66,18 @@ Cast.toString = function (value) {
 };
 
 /**
- * Cast any Scratch argument to an RGB color object.
+ * Cast any Scratch argument to an RGB color object to be used for the renderer.
  * @param {*} value Value to convert to RGB color object.
- * @return {Object} {r: R, g: G, b: B}, values between 0-255.
+ * @return {Array.<number>} [r,g,b], values between 0-255.
  */
-Cast.toRgbColor = function (value) {
+Cast.toRgbColorList = function (value) {
+    var color;
     if (typeof value == 'string' && value.substring(0, 1) == '#') {
-        return Color.hexToRgb(value);
+        color = Color.hexToRgb(value);
     } else {
-        return Color.decimalToRgb(Cast.toNumber(value));
+        color = Color.decimalToRgb(Cast.toNumber(value));
     }
+    return [color.r, color.g, color.b];
 };
 
 /**

--- a/src/util/color.js
+++ b/src/util/color.js
@@ -1,17 +1,81 @@
 function Color () {}
 
 /**
- * Convert a Scratch color number to a hex string, #RRGGBB.
- * @param {number} color RGB color as a decimal.
+ * Convert a Scratch decimal color to a hex string, #RRGGBB.
+ * @param {number} decimal RGB color as a decimal.
  * @return {string} RGB color as #RRGGBB hex string.
  */
-Color.scratchColorToHex = function (color) {
-    if (color < 0) {
-        color += 0xFFFFFF + 1;
+Color.decimalToHex = function (decimal) {
+    if (decimal < 0) {
+        decimal += 0xFFFFFF + 1;
     }
-    var hex = Number(color).toString(16);
+    var hex = Number(decimal).toString(16);
     hex = '#' + '000000'.substr(0, 6 - hex.length) + hex;
     return hex;
 };
+
+/**
+ * Convert a Scratch decimal color to an RGB color object.
+ * CC-BY-SA
+ * https://stackoverflow.com/questions/29241442/
+ * decimal-to-rgb-in-javascript-and-php
+ * @param {number} decimal RGB color as decimal.
+ * @returns {Object} {r: R, g: G, b: B}, values between 0-255
+ */
+Color.decimalToRgb = function (decimal) {
+    var r = Math.floor(decimal / (256 * 256));
+    var g = Math.floor(decimal / 256) % 256;
+    var b = decimal % 256;
+    return {r: r, g: g, b: b};
+};
+
+/**
+ * Convert a hex color (e.g., F00, #03F, #0033FF) to an RGB color object.
+ * CC-BY-SA Tim Down:
+ * https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
+ * @param {!string} hex Hex representation of the color.
+ * @return {Object} {r: R, g: G, b: B}, 0-255, or null.
+ */
+Color.hexToRgb = function (hex) {
+    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, function(m, r, g, b) {
+        return r + r + g + g + b + b;
+    });
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16)
+    } : null;
+};
+
+/**
+ * Convert an RGB color object to a hex color.
+ * @param {Object} rgb {r: R, g: G, b: B}, values between 0-255.
+ * @return {!string} Hex representation of the color.
+ */
+Color.rgbToHex = function (rgb) {
+    return Color.decimalToHex(Color.rgbToDecimal(rgb));
+};
+
+/**
+ * Convert an RGB color object to a Scratch decimal color.
+ * @param {Object} rgb {r: R, g: G, b: B}, values between 0-255.
+ * @return {!number} Number representing the color.
+ */
+Color.rgbToDecimal = function (rgb) {
+    return (rgb.r << 16) + (rgb.g << 8) + rgb.b;
+};
+
+/**
+* Convert a hex color (e.g., F00, #03F, #0033FF) to a decimal color number.
+* @param {!string} hex Hex representation of the color.
+* @return {!number} Number representing the color.
+*/
+Color.hexToDecimal = function (hex) {
+    return Color.rgbToDecimal(Color.hexToRgb(hex));
+};
+
+self.Color = Color;
 
 module.exports = Color;

--- a/src/util/color.js
+++ b/src/util/color.js
@@ -73,6 +73,4 @@ Color.hexToDecimal = function (hex) {
     return Color.rgbToDecimal(Color.hexToRgb(hex));
 };
 
-self.Color = Color;
-
 module.exports = Color;

--- a/src/util/color.js
+++ b/src/util/color.js
@@ -16,16 +16,13 @@ Color.decimalToHex = function (decimal) {
 
 /**
  * Convert a Scratch decimal color to an RGB color object.
- * CC-BY-SA
- * https://stackoverflow.com/questions/29241442/
- * decimal-to-rgb-in-javascript-and-php
  * @param {number} decimal RGB color as decimal.
  * @returns {Object} {r: R, g: G, b: B}, values between 0-255
  */
 Color.decimalToRgb = function (decimal) {
-    var r = Math.floor(decimal / (256 * 256));
-    var g = Math.floor(decimal / 256) % 256;
-    var b = decimal % 256;
+    var r = (decimal >> 16) & 0xFF;
+    var g = (decimal >> 8) & 0xFF;
+    var b = decimal & 0xFF;
     return {r: r, g: g, b: b};
 };
 
@@ -75,5 +72,7 @@ Color.rgbToDecimal = function (rgb) {
 Color.hexToDecimal = function (hex) {
     return Color.rgbToDecimal(Color.hexToRgb(hex));
 };
+
+self.Color = Color;
 
 module.exports = Color;

--- a/src/util/color.js
+++ b/src/util/color.js
@@ -76,6 +76,4 @@ Color.hexToDecimal = function (hex) {
     return Color.rgbToDecimal(Color.hexToRgb(hex));
 };
 
-self.Color = Color;
-
 module.exports = Color;


### PR DESCRIPTION
Demo (https://scratch.mit.edu/projects/120343713/):
![color-touching](https://cloud.githubusercontent.com/assets/120403/18322301/0f167666-7500-11e6-9d2d-b6bfa761be2b.gif)

This is mostly a bunch of utilities to convert colors from one format to another. Since we are keeping things in either hex format (scratch-blocks) or an RGB number (if the user puts in a math block). For completeness/future convenience I added the rest of the color utilities to go between RGB, hex, and decimal colors. Then it's just calls to the renderer.

@cwillisf 
