### PR TITLE
Cleanly handle deleting running scripts

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -185,6 +185,10 @@ Blocks.prototype.blocklyListen = function (e, isFlyout, opt_runtime) {
         if (this._blocks[e.blockId].shadow) {
             return;
         }
+        // Inform any runtime to forget about glows on this script.
+        if (opt_runtime && this._blocks[e.blockId].topLevel) {
+            opt_runtime.quietGlow(e.blockId);
+        }
         this.deleteBlock({
             id: e.blockId
         });

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -22,6 +22,13 @@ var execute = function (sequencer, thread) {
     var currentBlockId = thread.peekStack();
     var currentStackFrame = thread.peekStackFrame();
 
+    // Verify that the block still exists.
+    if (!target ||
+        typeof target.blocks.getBlock(currentBlockId) === 'undefined') {
+        // No block found: stop the thread; script no longer exists.
+        sequencer.retireThread(thread);
+        return;
+    }
     // Query info about the block.
     var opcode = target.blocks.getOpcode(currentBlockId);
     var blockFunction = runtime.getOpcodeFunction(opcode);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -383,7 +383,9 @@ Runtime.prototype._updateScriptGlows = function () {
         if (thread.requestScriptGlowInFrame && target == this._editingTarget) {
             var blockForThread = thread.peekStack() || thread.topBlock;
             var script = target.blocks.getTopLevelScript(blockForThread);
-            requestedGlowsThisFrame.push(script);
+            if (script) {
+                requestedGlowsThisFrame.push(script);
+            }
         }
     }
     // Compare to previous frame.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -409,6 +409,19 @@ Runtime.prototype._updateScriptGlows = function () {
 };
 
 /**
+ * "Quiet" a script's glow: stop the VM from generating glow/unglow events
+ * about that script. Use when a script has just been deleted, but we may
+ * still be tracking glow data about it.
+ * @param {!string} scriptBlockId Id of top-level block in script to quiet.
+ */
+Runtime.prototype.quietGlow = function (scriptBlockId) {
+    var index = this._scriptGlowsPreviousFrame.indexOf(scriptBlockId);
+    if (index > -1) {
+        this._scriptGlowsPreviousFrame.splice(index, 1);
+    }
+};
+
+/**
  * Emit feedback for block glowing (used in the sequencer).
  * @param {?string} blockId ID for the block to update glow
  * @param {boolean} isGlowing True to turn on glow; false to turn off.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -173,6 +173,7 @@ Sequencer.prototype.proceedThread = function (thread) {
 Sequencer.prototype.retireThread = function (thread) {
     thread.stack = [];
     thread.stackFrame = [];
+    thread.requestScriptGlowInFrame = false;
     thread.setStatus(Thread.STATUS_DONE);
 };
 


### PR DESCRIPTION
Fix for #91.

Two parts:
1. When a block disappears (i.e., it no longer exists in the VM representation) but a thread is still trying to work on it (i.e., because it's in the thread's stack), retire the thread.
2. When a top-level block (script) gets deleted, remove it from the runtime's glow tracking, so we don't emit an extraneous unglow event.
