### PR TITLE
Better handling of float values (fix #172)

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -80,10 +80,8 @@ Scratch3OperatorsBlocks.prototype.random = function (args) {
     var low = nFrom <= nTo ? nFrom : nTo;
     var high = nFrom <= nTo ? nTo : nFrom;
     if (low == high) return low;
-    // If both low and high are ints, truncate the result to an int.
-    var lowInt = low == parseInt(low);
-    var highInt = high == parseInt(high);
-    if (lowInt && highInt) {
+    // If both arguments are ints, truncate the result to an int.
+    if (Cast.isInt(args.FROM) && Cast.isInt(args.TO)) {
         return low + parseInt(Math.random() * ((high + 1) - low));
     }
     return (Math.random() * (high - low)) + low;

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -109,16 +109,16 @@ Cast.compare = function (v1, v2) {
  */
 Cast.isInt = function (val) {
     // Values that are already numbers.
-    if (typeof val == 'number') {
+    if (typeof val === 'number') {
         if (isNaN(val)) { // NaN is considered an integer.
             return true;
         }
         // True if it's "round" (e.g., 2.0 and 2).
         return val == parseInt(val);
-    } else if (typeof val == 'boolean') {
+    } else if (typeof val === 'boolean') {
         // `True` and `false` always represent integer after Scratch cast.
         return true;
-    } else if (typeof val == 'string') {
+    } else if (typeof val === 'string') {
         // If it contains a decimal point, don't consider it an int.
         return val.indexOf('.') < 0;
     }

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -102,4 +102,27 @@ Cast.compare = function (v1, v2) {
     }
 };
 
+/**
+ * Determine if a Scratch argument number represents a round integer.
+ * @param {*} val Value to check.
+ * @return {boolean} True if number looks like an integer.
+ */
+Cast.isInt = function (val) {
+    // Values that are already numbers.
+    if (typeof val == 'number') {
+        if (isNaN(val)) { // NaN is considered an integer.
+            return true;
+        }
+        // True if it's "round" (e.g., 2.0 and 2).
+        return val == parseInt(val);
+    } else if (typeof val == 'boolean') {
+        // `True` and `false` always represent integer after Scratch cast.
+        return true;
+    } else if (typeof val == 'string') {
+        // If it contains a decimal point, don't consider it an int.
+        return val.indexOf('.') < 0;
+    }
+    return false;
+};
+
 module.exports = Cast;


### PR DESCRIPTION
Adds `Cast.isInt` which can be applied to uncasted arguments to determine if it's an int. I think I captured all the current Scratch behavior, but not 100% sure.
