### PR TITLE
Escape field values for XML-unsafe characters

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -371,7 +371,7 @@ Blocks.prototype.blockToXML = function (blockId) {
     for (var field in block.fields) {
         var blockField = block.fields[field];
         var value = blockField.value;
-        if (typeof value == 'string') {
+        if (typeof value === 'string') {
             value = xmlEscape(blockField.value);
         }
         xmlString += '<field name="' + blockField.name + '">' +

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -1,4 +1,5 @@
 var adapter = require('./adapter');
+var xmlEscape = require('../util/xml-escape');
 
 /**
  * @fileoverview
@@ -369,8 +370,12 @@ Blocks.prototype.blockToXML = function (blockId) {
     // Add any fields on this block.
     for (var field in block.fields) {
         var blockField = block.fields[field];
+        var value = blockField.value;
+        if (typeof value == 'string') {
+            value = xmlEscape(blockField.value);
+        }
         xmlString += '<field name="' + blockField.name + '">' +
-            blockField.value + '</field>';
+            value + '</field>';
     }
     // Add blocks connected to the next connection.
     if (block.next) {

--- a/src/util/xml-escape.js
+++ b/src/util/xml-escape.js
@@ -1,0 +1,21 @@
+/**
+ * Escape a string to be safe to use in XML content.
+ * CC-BY-SA: hgoebl
+ * https://stackoverflow.com/questions/7918868/
+ * how-to-escape-xml-entities-in-javascript
+ * @param {!string} unsafe Unsafe string.
+ * @return {string} XML-escaped string, for use within an XML tag.
+ */
+var xmlEscape = function (unsafe) {
+    return unsafe.replace(/[<>&'"]/g, function (c) {
+        switch (c) {
+        case '<': return '&lt;';
+        case '>': return '&gt;';
+        case '&': return '&amp;';
+        case '\'': return '&apos;';
+        case '"': return '&quot;';
+        }
+    });
+};
+
+module.exports = xmlEscape;


### PR DESCRIPTION
A fix for #173.

Now should handle things like this just fine:
<img width="379" alt="screen shot 2016-09-13 at 3 48 53 pm" src="https://cloud.githubusercontent.com/assets/120403/18488946/998d4bb2-79c9-11e6-9afc-fe833dee3aaa.png">
