### PR TITLE
Fix up property imports from SB2

### DIFF
--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -68,23 +68,23 @@ function parseScratchObject (object, runtime, topLevel) {
     var target = sprite.createClone();
     // Add it to the runtime's list of targets.
     runtime.targets.push(target);
-    if (object.scratchX) {
+    if (object.hasOwnProperty('scratchX')) {
         target.x = object.scratchX;
     }
-    if (object.scratchY) {
+    if (object.hasOwnProperty('scratchY')) {
         target.y = object.scratchY;
     }
-    if (object.direction) {
+    if (object.hasOwnProperty('direction')) {
         target.direction = object.direction;
     }
-    if (object.scale) {
+    if (object.hasOwnProperty('scale')) {
         // SB2 stores as 1.0 = 100%; we use % in the VM.
         target.size = object.scale * 100;
     }
-    if (object.visible) {
+    if (object.hasOwnProperty('visible')) {
         target.visible = object.visible;
     }
-    if (object.currentCostumeIndex) {
+    if (object.hasOwnProperty('currentCostumeIndex')) {
         target.currentCostume = object.currentCostumeIndex;
     }
     target.isStage = topLevel;

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -51,7 +51,7 @@ function parseScratchObject (object, runtime, topLevel) {
             var costume = object.costumes[i];
             // @todo: Make sure all the relevant metadata is being pulled out.
             sprite.costumes.push({
-                skin: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' 
+                skin: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/'
                     + costume.baseLayerMD5 + '/get/',
                 name: costume.costumeName,
                 bitmapResolution: costume.bitmapResolution,
@@ -88,6 +88,7 @@ function parseScratchObject (object, runtime, topLevel) {
         target.currentCostume = object.currentCostumeIndex;
     }
     target.isStage = topLevel;
+    target.updateAllDrawableProperties();
     // The stage will have child objects; recursively process them.
     if (object.children) {
         for (var j = 0; j < object.children.length; j++) {


### PR DESCRIPTION
Should fix #185.

There were two problems:
1. Drawable properties weren't being refreshed on a target's creation.
2. If any property was "false"-like (e.g., visible: false), it wasn't copied to the target.
