### PR TITLE
Fix/improve playground threads display

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -85,8 +85,7 @@ window.onload = function() {
     // Thread representation tab.
     var threadexplorer = document.getElementById('threadexplorer');
     var cachedThreadJSON = '';
-    var updateThreadExplorer = function (threads) {
-        var newJSON = JSON.stringify(threads, null, 2);
+    var updateThreadExplorer = function (newJSON) {
         if (newJSON != cachedThreadJSON) {
             cachedThreadJSON = newJSON;
             threadexplorer.innerHTML = cachedThreadJSON;

--- a/src/index.js
+++ b/src/index.js
@@ -76,9 +76,19 @@ VirtualMachine.prototype.stopAll = function () {
  * Get data for playground. Data comes back in an emitted event.
  */
 VirtualMachine.prototype.getPlaygroundData = function () {
+    var instance = this;
+    // Only send back thread data for the current editingTarget.
+    var threadData = this.runtime.threads.filter(function(thread) {
+        return thread.target == instance.editingTarget;
+    });
+    // Remove the target key, since it's a circular reference.
+    var filteredThreadData = JSON.stringify(threadData, function(key, value) {
+        if (key == 'target') return undefined;
+        return value;
+    }, 2);
     this.emit('playgroundData', {
         blocks: this.editingTarget.blocks,
-        threads: this.runtime.threads
+        threads: filteredThreadData
     });
 };
 


### PR DESCRIPTION
Implement #174, and filter out a circular data reference that was preventing JSON serialization.
