### PR TITLE
Build the module to be imported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-*
 # Testing
 /.nyc_output
 /coverage
+/dist.js

--- a/package.json
+++ b/package.json
@@ -9,25 +9,26 @@
     "type": "git",
     "url": "git+ssh://git@github.com/LLK/scratch-vm.git"
   },
-  "main": "./src/index.js",
+  "main": "./dist.js",
   "scripts": {
-    "test": "make test",
-    "start": "webpack-dev-server --host 0.0.0.0 --content-base ."
+    "postinstall": "./node_modules/.bin/webpack",
+    "start": "webpack-dev-server --host 0.0.0.0 --content-base .",
+    "test": "make test"
   },
   "dependencies": {
+    "expose-loader": "0.7.1",
     "htmlparser2": "3.9.0",
-    "promise": "7.1.1"
+    "json-loader": "0.5.4",
+    "promise": "7.1.1",
+    "webpack": "1.13.0"
   },
   "devDependencies": {
     "eslint": "2.7.0",
-    "expose-loader": "0.7.1",
     "highlightjs": "8.7.0",
-    "json-loader": "0.5.4",
     "scratch-blocks": "git+https://git@github.com/LLK/scratch-blocks.git#develop",
     "scratch-render": "git+https://git@github.com/LLK/scratch-render.git#develop",
     "stats.js": "0.16.0",
     "tap": "5.7.1",
-    "webpack": "1.13.0",
     "webpack-dev-server": "1.14.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,6 @@
 var webpack = require('webpack');
 
-module.exports = {
-    entry: {
-        'vm': './src/index.js',
-        'vm.min': './src/index.js'
-    },
-    output: {
-        path: __dirname,
-        filename: '[name].js'
-    },
+var base = {
     module: {
         loaders: [
             {
@@ -30,3 +22,24 @@ module.exports = {
         })
     ]
 };
+
+module.exports = [Object.assign({}, base, {
+    entry: {
+        'vm': './src/index.js',
+        'vm.min': './src/index.js'
+    },
+    output: {
+        path: __dirname,
+        filename: '[name].js'
+    }
+}), Object.assign({}, base, {
+    entry: {
+        'dist': './src/index.js'
+    },
+    output: {
+        library: 'VirtualMachine',
+        libraryTarget: 'commonjs2',
+        path: __dirname,
+        filename: '[name].js'
+    }
+})];


### PR DESCRIPTION
This puts the details of the loaders needed to build index.js out of the concern of the packages that require it.
