### PR TITLE
Drop `useRound` option from `Cast.toListIndex`

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -73,7 +73,7 @@ Scratch3DataBlocks.prototype.addToList = function (args, util) {
 
 Scratch3DataBlocks.prototype.deleteOfList = function (args, util) {
     var list = util.target.lookupOrCreateList(args.LIST);
-    var index = Cast.toListIndex(args.INDEX, list.contents.length, true);
+    var index = Cast.toListIndex(args.INDEX, list.contents.length);
     if (index === Cast.LIST_INVALID) {
         return;
     } else if (index === Cast.LIST_ALL) {

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -134,7 +134,6 @@ Cast.LIST_ALL = 'ALL';
  * LIST_INVALID: if the index was invalid in any way.
  * @param {*} index Scratch arg, including 1-based numbers or special cases.
  * @param {number} length Length of the list.
- * @param {boolean} useRound If set, Math.round (not Math.floor for 2.0 compat).
  * @return {(number|string)} 1-based index for list, LIST_ALL, or LIST_INVALID.
  */
 Cast.toListIndex = function (
@@ -155,11 +154,7 @@ Cast.toListIndex = function (
             return Cast.LIST_INVALID;
         }
     }
-    if (useRound) {
-        index = Math.round(Cast.toNumber(index));
-    } else {
-        index = Math.floor(Cast.toNumber(index));
-    }
+    index = Math.floor(Cast.toNumber(index));
     if (index < 1 || index > length) {
         return Cast.LIST_INVALID;
     }

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -136,8 +136,7 @@ Cast.LIST_ALL = 'ALL';
  * @param {number} length Length of the list.
  * @return {(number|string)} 1-based index for list, LIST_ALL, or LIST_INVALID.
  */
-Cast.toListIndex = function (
-    index, length, useRound) {
+Cast.toListIndex = function (index, length) {
     if (typeof index !== 'number') {
         if (index == 'all') {
             return Cast.LIST_ALL;


### PR DESCRIPTION
Fix #202
