### PR TITLE
Round costume values

### DIFF
--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -108,7 +108,7 @@ function parseScratchObject (object, runtime, topLevel) {
         target.visible = object.visible;
     }
     if (object.hasOwnProperty('currentCostumeIndex')) {
-        target.currentCostume = object.currentCostumeIndex;
+        target.currentCostume = Math.round(object.currentCostumeIndex);
     }
     target.isStage = topLevel;
     target.updateAllDrawableProperties();

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -231,6 +231,7 @@ Clone.prototype.clearEffects = function () {
  */
 Clone.prototype.setCostume = function (index) {
     // Keep the costume index within possible values.
+    index = Math.round(index);
     this.currentCostume = MathUtil.wrapClamp(
         index, 0, this.sprite.costumes.length - 1
     );


### PR DESCRIPTION
On `Clone.setCostume` and on initialization from SB2. Values are set directly in the SB2 loader so `updateDrawableProperties` is done as a batch.

Sort of fixes project 96920096.
