### PR TITLE
Remove extra calls to `updateAllDrawableProperties`

### DIFF
--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -38,7 +38,6 @@ util.inherits(Clone, Target);
 Clone.prototype.initDrawable = function () {
     if (this.renderer) {
         this.drawableID = this.renderer.createDrawable();
-        this.updateAllDrawableProperties();
     }
     // If we're a clone, start the hats.
     if (!this.isOriginal) {

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -50,7 +50,6 @@ Sprite.prototype.createClone = function () {
     this.clones.push(newClone);
     if (newClone.isOriginal) {
         newClone.initDrawable();
-        newClone.updateAllDrawableProperties();
     }
     return newClone;
 };


### PR DESCRIPTION
These only need to happen when a new sprite is created (i.e., from an SB2) or a new clone is created (from a block).
