### PR TITLE
Ensure scratch-* dependencies are up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ sudo: false
 cache:
   directories:
   - node_modules
+before_install:
+# Install the most up to date scratch-* dependencies
+- rm -rf node_modules/scratch-*
 after_script:
 - |
   # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel


### PR DESCRIPTION
With node_modules cached, npm install sees the scratch-\* dependencies satisfied (since if any version 0.1.0-prepublish.x satisfies ^0.1.0-prepublish).  So remove these before the install step to ensure the latest version is installed.
