### PR TITLE
Implement the point-towards block

### DIFF
--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -71,6 +71,7 @@ Scratch3MotionBlocks.prototype.pointTowards = function (args, util) {
         targetY = util.ioQuery('mouse', 'getY');
     } else {
         var pointTarget = this.runtime.getSpriteTargetByName(args.TOWARDS);
+        if (!pointTarget) return;
         targetX = pointTarget.x;
         targetY = pointTarget.y;
     }

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -21,6 +21,7 @@ Scratch3MotionBlocks.prototype.getPrimitives = function() {
         'motion_turnright': this.turnRight,
         'motion_turnleft': this.turnLeft,
         'motion_pointindirection': this.pointInDirection,
+        'motion_pointtowards': this.pointTowards,
         'motion_glidesecstoxy': this.glide,
         'motion_setrotationstyle': this.setRotationStyle,
         'motion_changexby': this.changeX,
@@ -59,6 +60,24 @@ Scratch3MotionBlocks.prototype.turnLeft = function (args, util) {
 
 Scratch3MotionBlocks.prototype.pointInDirection = function (args, util) {
     var direction = Cast.toNumber(args.DIRECTION);
+    util.target.setDirection(direction);
+};
+
+Scratch3MotionBlocks.prototype.pointTowards = function (args, util) {
+    var targetX = 0;
+    var targetY = 0;
+    if (args.TOWARDS === '_mouse_') {
+        targetX = util.ioQuery('mouse', 'getX');
+        targetY = util.ioQuery('mouse', 'getY');
+    } else {
+        var pointTarget = this.runtime.getSpriteTargetByName(args.TOWARDS);
+        targetX = pointTarget.x;
+        targetY = pointTarget.y;
+    }
+
+    var dx = targetX - util.target.x;
+    var dy = targetY - util.target.y;
+    var direction = 90 - MathUtil.radToDeg(Math.atan2(dy, dx));
     util.target.setDirection(direction);
 };
 


### PR DESCRIPTION
Test project ID: [124055382](https://scratch.mit.edu/projects/124055382/)

Both pointing towards a sprite and the mouse-pointer work (assuming that the `TOWARDS` argument being `_mouse_` means to point towards the mouse pointer!).

Based on [scratch-flash's implementation](https://github.com/LLK/scratch-flash/blob/5cff62b909856b7d7b3d116a5dcc2b4f03de8482/src/primitives/MotionAndPenPrims.as#L112-L121).
