### PR TITLE
Implement "go to" block

### DIFF
--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -55,6 +55,9 @@ Scratch3MotionBlocks.prototype.goTo = function (args, util) {
     if (args.TO === '_mouse_') {
         targetX = util.ioQuery('mouse', 'getX');
         targetY = util.ioQuery('mouse', 'getY');
+    } else if (args.TO === '_random_') {
+        targetX = this.runtime.constructor.STAGE_WIDTH * (Math.random() - 0.5)
+        targetY = this.runtime.constructor.STAGE_HEIGHT * (Math.random() - 0.5)
     } else {
         var goToTarget = this.runtime.getSpriteTargetByName(args.TO);
         if (!goToTarget) return;

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -18,6 +18,7 @@ Scratch3MotionBlocks.prototype.getPrimitives = function() {
     return {
         'motion_movesteps': this.moveSteps,
         'motion_gotoxy': this.goToXY,
+        'motion_goto': this.goTo,
         'motion_turnright': this.turnRight,
         'motion_turnleft': this.turnLeft,
         'motion_pointindirection': this.pointInDirection,
@@ -47,6 +48,21 @@ Scratch3MotionBlocks.prototype.goToXY = function (args, util) {
     var y = Cast.toNumber(args.Y);
     util.target.setXY(x, y);
 };
+
+Scratch3MotionBlocks.prototype.goTo = function (args, util) {
+    var targetX = 0;
+    var targetY = 0;
+    if (args.TO === '_mouse_') {
+        targetX = util.ioQuery('mouse', 'getX');
+        targetY = util.ioQuery('mouse', 'getY');
+    } else {
+        var goToTarget = this.runtime.getSpriteTargetByName(args.TO);
+        if (!goToTarget) return;
+        targetX = goToTarget.x;
+        targetY = goToTarget.y;
+    }
+    util.target.setXY(targetX, targetY);
+}
 
 Scratch3MotionBlocks.prototype.turnRight = function (args, util) {
     var degrees = Cast.toNumber(args.DEGREES);

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -56,8 +56,10 @@ Scratch3MotionBlocks.prototype.goTo = function (args, util) {
         targetX = util.ioQuery('mouse', 'getX');
         targetY = util.ioQuery('mouse', 'getY');
     } else if (args.TO === '_random_') {
-        targetX = this.runtime.constructor.STAGE_WIDTH * (Math.random() - 0.5)
-        targetY = this.runtime.constructor.STAGE_HEIGHT * (Math.random() - 0.5)
+        var stageWidth = this.runtime.constructor.STAGE_WIDTH;
+        var stageHeight = this.runtime.constructor.STAGE_HEIGHT;
+        targetX = stageWidth * (Math.random() - 0.5);
+        targetY = stageHeight * (Math.random() - 0.5);
     } else {
         var goToTarget = this.runtime.getSpriteTargetByName(args.TO);
         if (!goToTarget) return;

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -58,8 +58,8 @@ Scratch3MotionBlocks.prototype.goTo = function (args, util) {
     } else if (args.TO === '_random_') {
         var stageWidth = this.runtime.constructor.STAGE_WIDTH;
         var stageHeight = this.runtime.constructor.STAGE_HEIGHT;
-        targetX = stageWidth * (Math.random() - 0.5);
-        targetY = stageHeight * (Math.random() - 0.5);
+        targetX = Math.round(stageWidth * (Math.random() - 0.5));
+        targetY = Math.round(stageHeight * (Math.random() - 0.5));
     } else {
         var goToTarget = this.runtime.getSpriteTargetByName(args.TO);
         if (!goToTarget) return;

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -62,7 +62,7 @@ Scratch3MotionBlocks.prototype.goTo = function (args, util) {
         targetY = goToTarget.y;
     }
     util.target.setXY(targetX, targetY);
-}
+};
 
 Scratch3MotionBlocks.prototype.turnRight = function (args, util) {
     var degrees = Cast.toNumber(args.DEGREES);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -70,6 +70,18 @@ function Runtime () {
 }
 
 /**
+ * Width of the stage, in pixels.
+ * @const {number}
+ */
+Runtime.STAGE_WIDTH = 480;
+
+/**
+ * Height of the stage, in pixels.
+ * @const {number}
+ */
+Runtime.STAGE_HEIGHT = 360;
+
+/**
  * Event name for glowing a script.
  * @const {string}
  */


### PR DESCRIPTION
Test project ID: [124084337](https://scratch.mit.edu/projects/124084337/)

As you'd expect, it works with both the mouse and sprites. Also, it won't do anything if the target sprite doesn't exist.

It (probably) does _not_ work with the pen as the pen hasn't been implemented at all yet, as far as I know - it'll probably need to be changed then. (Maybe a more generic `Clone.prototype.goTo`, sort of like [scratch-flash does](https://github.com/LLK/scratch-flash/blob/5cff62b909856b7d7b3d116a5dcc2b4f03de8482/src/primitives/MotionAndPenPrims.as#L312-L320)?)
