### PR TITLE
Add issue and PR templates for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Expected behavior
+
+_Please describe what should happen_
+
+### Actual behavior
+
+_Describe what actually happens_
+
+### Steps to reproduce
+
+_Explain what someone needs to do in order to see what's described in *Actual behavior* above_
+
+### Operating system and browser
+
+_e.g. Mac OS 10.11.6 Safari 10.0_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] "Chore" (changes to build script, updates to README, etc.)
+
+### Proposed changes
+
+_Describe what this Pull Request does_
+
+### Reason for changes
+
+_Explain why these changes should be made. Please include an issue # if applicable._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,3 @@
-### Type of change
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Refactor
-- [ ] "Chore" (changes to build script, updates to README, etc.)
-
 ### Proposed changes
 
 _Describe what this Pull Request does_


### PR DESCRIPTION
### Proposed changes

This adds two Github-specific files which will provide starter templates for new Issues and Pull Requests
### Reason for changes

Internally we have good communication about issues in our projects, and changes that should be made. When we receive contributions from the community, they often come without context. These templates should help provide some of that missing context.
