### PR TITLE
Updated blocks for new renderer features

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -30,6 +30,8 @@ Scratch3LooksBlocks.prototype.getPrimitives = function() {
         'looks_cleargraphiceffects': this.clearEffects,
         'looks_changesizeby': this.changeSize,
         'looks_setsizeto': this.setSize,
+        'looks_gotofront': this.goToFront,
+        'looks_gobacklayers': this.goBackLayers,
         'looks_size': this.getSize,
         'looks_costumeorder': this.getCostumeIndex,
         'looks_backdroporder': this.getBackdropIndex,
@@ -188,6 +190,14 @@ Scratch3LooksBlocks.prototype.changeSize = function (args, util) {
 Scratch3LooksBlocks.prototype.setSize = function (args, util) {
     var size = Cast.toNumber(args.SIZE);
     util.target.setSize(size);
+};
+
+Scratch3LooksBlocks.prototype.goToFront = function (args, util) {
+    util.target.goToFront();
+};
+
+Scratch3LooksBlocks.prototype.goBackLayers = function (args, util) {
+    util.target.goBackLayers(args.NUM);
 };
 
 Scratch3LooksBlocks.prototype.getSize = function (args, util) {

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -173,8 +173,7 @@ Scratch3MotionBlocks.prototype.ifOnEdgeBounce = function (args, util) {
         return; // Not touching any edge.
     }
     // Point away from the nearest edge.
-    // @todo: Fix after GH-229 is resolved.
-    var radians = MathUtil.degToRad(util.target.direction);
+    var radians = MathUtil.degToRad(90 - util.target.direction);
     var dx = Math.cos(radians);
     var dy = -Math.sin(radians);
     if (nearestEdge == 'left') {

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -141,6 +141,9 @@ Scratch3MotionBlocks.prototype.glide = function (args, util) {
 
 Scratch3MotionBlocks.prototype.ifOnEdgeBounce = function (args, util) {
     var bounds = util.target.getBounds();
+    if (!bounds) {
+        return;
+    }
     // Measure distance to edges.
     // Values are positive when the sprite is far away,
     // and clamped to zero when the sprite is beyond.

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -24,6 +24,7 @@ Scratch3MotionBlocks.prototype.getPrimitives = function() {
         'motion_pointindirection': this.pointInDirection,
         'motion_pointtowards': this.pointTowards,
         'motion_glidesecstoxy': this.glide,
+        'motion_ifonedgebounce': this.ifOnEdgeBounce,
         'motion_setrotationstyle': this.setRotationStyle,
         'motion_changexby': this.changeX,
         'motion_setx': this.setX,
@@ -136,6 +137,60 @@ Scratch3MotionBlocks.prototype.glide = function (args, util) {
             util.target.setXY(util.stackFrame.endX, util.stackFrame.endY);
         }
     }
+};
+
+Scratch3MotionBlocks.prototype.ifOnEdgeBounce = function (args, util) {
+    var bounds = util.target.getBounds();
+    // Measure distance to edges.
+    // Values are positive when the sprite is far away,
+    // and clamped to zero when the sprite is beyond.
+    var stageWidth = this.runtime.constructor.STAGE_WIDTH;
+    var stageHeight = this.runtime.constructor.STAGE_HEIGHT;
+    var distLeft = Math.max(0, stageWidth / 2 + bounds.left);
+    var distTop = Math.max(0, stageHeight / 2 - bounds.top);
+    var distRight = Math.max(0, stageWidth / 2 - bounds.right);
+    var distBottom = Math.max(0, stageHeight / 2 + bounds.bottom);
+    // Find the nearest edge.
+    var nearestEdge = '';
+    var minDist = Infinity;
+    if (distLeft < minDist) {
+        minDist = distLeft;
+        nearestEdge = 'left';
+    }
+    if (distTop < minDist) {
+        minDist = distTop;
+        nearestEdge = 'top';
+    }
+    if (distRight < minDist) {
+        minDist = distRight;
+        nearestEdge = 'right';
+    }
+    if (distBottom < minDist) {
+        minDist = distBottom;
+        nearestEdge = 'bottom';
+    }
+    if (minDist > 0) {
+        return; // Not touching any edge.
+    }
+    // Point away from the nearest edge.
+    // @todo: Fix after GH-229 is resolved.
+    var radians = MathUtil.degToRad(util.target.direction);
+    var dx = Math.cos(radians);
+    var dy = -Math.sin(radians);
+    if (nearestEdge == 'left') {
+        dx = Math.max(0.2, Math.abs(dx));
+    } else if (nearestEdge == 'top') {
+        dy = Math.max(0.2, Math.abs(dy));
+    } else if (nearestEdge == 'right') {
+        dx = 0 - Math.max(0.2, Math.abs(dx));
+    } else if (nearestEdge == 'bottom') {
+        dy = 0 - Math.max(0.2, Math.abs(dy));
+    }
+    var newDirection = MathUtil.radToDeg(Math.atan2(dy, dx)) + 90;
+    util.target.setDirection(newDirection);
+    // Keep within the stage.
+    var fencedPosition = util.target.keepInFence(util.target.x, util.target.y);
+    util.target.setXY(fencedPosition[0], fencedPosition[1]);
 };
 
 Scratch3MotionBlocks.prototype.setRotationStyle = function (args, util) {

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -14,6 +14,7 @@ function Scratch3SensingBlocks(runtime) {
  */
 Scratch3SensingBlocks.prototype.getPrimitives = function() {
     return {
+        'sensing_touchingobject': this.touchingObject,
         'sensing_touchingcolor': this.touchingColor,
         'sensing_coloristouchingcolor': this.colorTouchingColor,
         'sensing_distanceto': this.distanceTo,
@@ -25,6 +26,19 @@ Scratch3SensingBlocks.prototype.getPrimitives = function() {
         'sensing_keypressed': this.getKeyPressed,
         'sensing_current': this.current
     };
+};
+
+Scratch3SensingBlocks.prototype.touchingObject = function (args, util) {
+    var requestedObject = args.TOUCHINGOBJECTMENU;
+    if (requestedObject == '_mouse_') {
+        var mouseX = util.ioQuery('mouse', 'getX');
+        var mouseY = util.ioQuery('mouse', 'getY');
+        return util.target.isTouchingPoint(mouseX, mouseY);
+    } else if (requestedObject == '_edge_') {
+        return util.target.isTouchingEdge();
+    } else {
+        return util.target.isTouchingSprite(requestedObject);
+    }
 };
 
 Scratch3SensingBlocks.prototype.touchingColor = function (args, util) {

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -395,10 +395,10 @@ Clone.prototype.isTouchingEdge = function () {
         var stageWidth = this.runtime.constructor.STAGE_WIDTH;
         var stageHeight = this.runtime.constructor.STAGE_HEIGHT;
         var bounds = this.getBounds();
-        if (bounds.left <= -stageWidth / 2 ||
-            bounds.right >= stageWidth / 2 ||
-            bounds.top >= stageHeight / 2 ||
-            bounds.bottom <= -stageHeight / 2) {
+        if (bounds.left < -stageWidth / 2 ||
+            bounds.right > stageWidth / 2 ||
+            bounds.top > stageHeight / 2 ||
+            bounds.bottom < -stageHeight / 2) {
             return true;
         }
     }
@@ -468,6 +468,48 @@ Clone.prototype.goBackLayers = function (nLayers) {
     if (this.renderer) {
         this.renderer.setDrawableOrder(this.drawableID, -nLayers, true, 1);
     }
+};
+
+/**
+ * Keep a desired position within a fence.
+ * @param {number} newX New desired X position.
+ * @param {number} newY New desired Y position.
+ * @param {Object=} opt_fence Optional fence with left, right, top bottom.
+ * @return {Array.<number>} Fenced X and Y coordinates.
+ */
+Clone.prototype.keepInFence = function (newX, newY, opt_fence) {
+    var fence = opt_fence;
+    if (!fence) {
+        fence = {
+            left: -this.runtime.constructor.STAGE_WIDTH / 2,
+            right: this.runtime.constructor.STAGE_WIDTH / 2,
+            top: this.runtime.constructor.STAGE_HEIGHT / 2,
+            bottom: -this.runtime.constructor.STAGE_HEIGHT / 2
+        };
+    }
+    var bounds = this.getBounds();
+    if (!bounds) return;
+    // Adjust the known bounds to the target position.
+    bounds.left += (newX - this.x);
+    bounds.right += (newX - this.x);
+    bounds.top += (newY - this.y);
+    bounds.bottom += (newY - this.y);
+    // Find how far we need to move the target position.
+    var dx = 0;
+    var dy = 0;
+    if (bounds.left < fence.left) {
+        dx += fence.left - bounds.left;
+    }
+    if (bounds.right > fence.right) {
+        dx += fence.right - bounds.right;
+    }
+    if (bounds.top > fence.top) {
+        dy += fence.top - bounds.top;
+    }
+    if (bounds.bottom < fence.bottom) {
+        dy += fence.bottom - bounds.bottom;
+    }
+    return [newX + dx, newY + dy];
 };
 
 /**

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -353,9 +353,8 @@ Clone.prototype.getName = function () {
 
 /**
  * Return the clone's tight bounding box.
- * @param {number} x X coordinate of test point.
- * @param {number} y Y coordinate of test point.
- * @return {Boolean} True iff the clone is touching the point.
+ * Includes top, left, bottom, right attributes in Scratch coordinates.
+ * @return {?Object} Tight bounding box of clone, or null.
  */
 Clone.prototype.getBounds = function () {
     if (this.renderer) {


### PR DESCRIPTION
- Add layer blocks implementation (go to front, go back N layers)
- Add "touching" block implementation, including "touching mouse pointer" (using pick), "touching edge" (using bounds), and "touching sprite" (using touching-drawables).
- Add "if on edge, bounce" implementation. I didn't try to pull apart how this works exactly, was just reproducing it as a test. Had to adjust the coordinates to be in Scratch coordinates instead of top-left (0,0) that the original implementation uses. I also refactored the "keep on stage" logic into its own method, `keepInFence`, which can take an arbitrary bounding box to keep the clone inside. I figure this will be useful when we try to reproduce fence mode. Original for reference: https://github.com/LLK/scratch-flash/blob/master/src/primitives/MotionAndPenPrims.as#L202
