### PR TITLE
Executing blocks in the toolbox

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -73,8 +73,9 @@ window.onload = function() {
     window.workspace = workspace;
 
     // Attach scratch-blocks events to VM.
-    // @todo: Re-enable flyout listening after fixing GH-69.
     workspace.addChangeListener(vm.blockListener);
+    var flyoutWorkspace = workspace.getFlyout().getWorkspace();
+    flyoutWorkspace.addChangeListener(vm.flyoutBlockListener);
 
     // Create FPS counter.
     var stats = new window.Stats();
@@ -119,11 +120,9 @@ window.onload = function() {
 
     // Receipt of new block XML for the selected target.
     vm.on('workspaceUpdate', function (data) {
-        window.Blockly.Events.disable();
         workspace.clear();
         var dom = window.Blockly.Xml.textToDom(data.xml);
         window.Blockly.Xml.domToWorkspace(dom, workspace);
-        window.Blockly.Events.enable();
     });
 
     // Receipt of new list of targets, selected target update.

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -22,19 +22,34 @@ var execute = function (sequencer, thread) {
     var currentBlockId = thread.peekStack();
     var currentStackFrame = thread.peekStackFrame();
 
-    // Verify that the block still exists.
-    if (!target ||
-        typeof target.blocks.getBlock(currentBlockId) === 'undefined') {
+    // Check where the block lives: target blocks or flyout blocks.
+    var targetHasBlock = (
+        typeof target.blocks.getBlock(currentBlockId) !== 'undefined'
+    );
+    var flyoutHasBlock = (
+        typeof runtime.flyoutBlocks.getBlock(currentBlockId) !== 'undefined'
+    );
+
+    // Stop if block or target no longer exists.
+    if (!target || (!targetHasBlock && !flyoutHasBlock)) {
         // No block found: stop the thread; script no longer exists.
         sequencer.retireThread(thread);
         return;
     }
+
     // Query info about the block.
-    var opcode = target.blocks.getOpcode(currentBlockId);
+    var blockContainer = null;
+    if (targetHasBlock) {
+        blockContainer = target.blocks;
+    } else {
+        blockContainer = runtime.flyoutBlocks;
+    }
+    var opcode = blockContainer.getOpcode(currentBlockId);
+    var fields = blockContainer.getFields(currentBlockId);
+    var inputs = blockContainer.getInputs(currentBlockId);
     var blockFunction = runtime.getOpcodeFunction(opcode);
     var isHat = runtime.getIsHat(opcode);
-    var fields = target.blocks.getFields(currentBlockId);
-    var inputs = target.blocks.getInputs(currentBlockId);
+
 
     if (!opcode) {
         console.warn('Could not get opcode for block: ' + currentBlockId);
@@ -133,7 +148,7 @@ var execute = function (sequencer, thread) {
     }
 
     // Add any mutation to args (e.g., for procedures).
-    var mutation = target.blocks.getMutation(currentBlockId);
+    var mutation = blockContainer.getMutation(currentBlockId);
     if (mutation) {
         argValues.mutation = mutation;
     }
@@ -165,7 +180,7 @@ var execute = function (sequencer, thread) {
             sequencer.stepToProcedure(thread, procedureName);
         },
         getProcedureParamNames: function (procedureName) {
-            return thread.target.blocks.getProcedureParamNames(procedureName);
+            return blockContainer.getProcedureParamNames(procedureName);
         },
         pushParam: function (paramName, paramValue) {
             thread.pushParam(paramName, paramValue);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events');
 var Sequencer = require('./sequencer');
+var Blocks = require('./blocks');
 var Thread = require('./thread');
 var util = require('util');
 
@@ -43,6 +44,8 @@ function Runtime () {
 
     /** @type {!Sequencer} */
     this.sequencer = new Sequencer(this);
+
+    this.flyoutBlocks = new Blocks();
 
     /**
      * Map to look up a block primitive's implementation function by its opcode.
@@ -463,6 +466,10 @@ Runtime.prototype._updateScriptGlows = function () {
         if (thread.requestScriptGlowInFrame && target == this._editingTarget) {
             var blockForThread = thread.peekStack() || thread.topBlock;
             var script = target.blocks.getTopLevelScript(blockForThread);
+            if (!script) {
+                // Attempt to find in flyout blocks.
+                script = this.flyoutBlocks.getTopLevelScript(blockForThread);
+            }
             if (script) {
                 requestedGlowsThisFrame.push(script);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ function VirtualMachine () {
     });
 
     this.blockListener = this.blockListener.bind(this);
+    this.flyoutBlockListener = this.flyoutBlockListener.bind(this);
 }
 
 /**
@@ -186,12 +187,16 @@ VirtualMachine.prototype.attachRenderer = function (renderer) {
  */
 VirtualMachine.prototype.blockListener = function (e) {
     if (this.editingTarget) {
-        this.editingTarget.blocks.blocklyListen(
-            e,
-            false,
-            this.runtime
-        );
+        this.editingTarget.blocks.blocklyListen(e, this.runtime);
     }
+};
+
+/**
+ * Handle a Blockly event for the flyout.
+ * @param {!Blockly.Event} e Any Blockly event.
+ */
+VirtualMachine.prototype.flyoutBlockListener = function (e) {
+    this.runtime.flyoutBlocks.blocklyListen(e, this.runtime);
 };
 
 /**


### PR DESCRIPTION
Blocks in the toolbox don't really belong to any given target. So, instead of storing their blocks in `editingTarget`, this stores them in a separate blocks object, `runtime.flyoutBlocks`. These also won't be part of block searches for things like the green flag (as desired) since those search target-attached blocks.

However, during execution, we need to make sure these blocks can be found (even though they're not associated with the execution target). If a block isn't found on a target, now execution will search for the block in the flyout before assuming it's deleted.

Also adds a new method, `flyoutBlockListener`, which VM consumers can attach to the scratch-blocks flyout.
