### PR TITLE
Fix check for existing hat threads

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -344,7 +344,7 @@ Runtime.prototype.startHats = function (requestedHatOpcode,
             // any existing threads starting with the top block.
             for (var i = 0; i < instance.threads.length; i++) {
                 if (instance.threads[i].topBlock === topBlockId &&
-                    (!opt_target || instance.threads[i].target == opt_target)) {
+                    instance.threads[i].target == target) {
                     instance._removeThread(instance.threads[i]);
                 }
             }
@@ -353,7 +353,7 @@ Runtime.prototype.startHats = function (requestedHatOpcode,
             // give up if any threads with the top block are running.
             for (var j = 0; j < instance.threads.length; j++) {
                 if (instance.threads[j].topBlock === topBlockId &&
-                    (!opt_target || instance.threads[j].target == opt_target)) {
+                    instance.threads[j].target == target) {
                     // Some thread is already running.
                     return;
                 }


### PR DESCRIPTION
In `startHats`, there are some checks to see if existing threads should be restarted for a hat. One of the conditions is supposed to be that the thread we're checking has the correct target. Previously I was checking against `opt_target`, the optional target restrictor for `startHats`. But the right thing to check against is `target`.

The bug behavior here was that clones couldn't receive broadcasts in http://llk.github.io/scratch-vm/#118946356. Broadcast has no target restriction (the only things that do so far are click hats and "when I start as clone" hats), so `opt_target` is null. The previous code was causing successive clones' threads to be trimmed.
