### PR TITLE
Update packages after installing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ sudo: false
 cache:
   directories:
   - node_modules
-before_install:
-# Install the most up to date scratch-* dependencies
-- rm -rf node_modules/scratch-*
+install:
+- npm install
+- npm update
 after_script:
 - |
   # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel


### PR DESCRIPTION
This is the less hacky way to keep scratch-\* packages up to date (and any others in the future).  This is only necessary because we cache the node_modules directory.
