### PR TITLE
Interpreter fixes, enhancements, features

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -15,6 +15,12 @@
             <button id="greenflag">Green flag</button>
             <button id="stopall">Stop</button>
         </div>
+        <div>
+            Turbo: <input id='turbomode' type='checkbox' />
+        </div>
+        <div>
+            Pause: <input id='pausemode' type='checkbox' />
+        </div>
         <br />
         <ul id="playgroundLinks">
             <li><a id="renderexplorer-link" href="#">Renderer</a></li>

--- a/playground/index.html
+++ b/playground/index.html
@@ -26,6 +26,7 @@
         </div>
         <div>
             Single stepping:  <input id='singlestepmode' type='checkbox' />
+            <input id='singlestepspeed' type='range' min='1' max='20' value='10' />
         </div>
         <br />
         <ul id="playgroundLinks">

--- a/playground/index.html
+++ b/playground/index.html
@@ -21,6 +21,9 @@
         <div>
             Pause: <input id='pausemode' type='checkbox' />
         </div>
+        <div>
+            Compatibility (30 TPS):  <input id='compatmode' type='checkbox' />
+        </div>
         <br />
         <ul id="playgroundLinks">
             <li><a id="renderexplorer-link" href="#">Renderer</a></li>

--- a/playground/index.html
+++ b/playground/index.html
@@ -24,6 +24,9 @@
         <div>
             Compatibility (30 TPS):  <input id='compatmode' type='checkbox' />
         </div>
+        <div>
+            Single stepping:  <input id='singlestepmode' type='checkbox' />
+        </div>
         <br />
         <ul id="playgroundLinks">
             <li><a id="renderexplorer-link" href="#">Renderer</a></li>

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -253,6 +253,11 @@ window.onload = function() {
         var pauseOn = document.getElementById('pausemode').checked;
         vm.setPauseMode(pauseOn);
     });
+    document.getElementById('compatmode').addEventListener('change',
+    function() {
+        var compatibilityMode = document.getElementById('compatmode').checked;
+        vm.setCompatibilityMode(compatibilityMode);
+    });
 
     var tabBlockExplorer = document.getElementById('tab-blockexplorer');
     var tabThreadExplorer = document.getElementById('tab-threadexplorer');

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -258,6 +258,11 @@ window.onload = function() {
         var compatibilityMode = document.getElementById('compatmode').checked;
         vm.setCompatibilityMode(compatibilityMode);
     });
+    document.getElementById('singlestepmode').addEventListener('change',
+    function() {
+        var singleStep = document.getElementById('singlestepmode').checked;
+        vm.setSingleSteppingMode(singleStep);
+    });
 
     var tabBlockExplorer = document.getElementById('tab-blockexplorer');
     var tabThreadExplorer = document.getElementById('tab-threadexplorer');

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -263,6 +263,11 @@ window.onload = function() {
         var singleStep = document.getElementById('singlestepmode').checked;
         vm.setSingleSteppingMode(singleStep);
     });
+    document.getElementById('singlestepspeed').addEventListener('input',
+    function() {
+        var speed = document.getElementById('singlestepspeed').value;
+        vm.setSingleSteppingSpeed(speed);
+    });
 
     var tabBlockExplorer = document.getElementById('tab-blockexplorer');
     var tabThreadExplorer = document.getElementById('tab-threadexplorer');

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -245,6 +245,14 @@ window.onload = function() {
     document.getElementById('stopall').addEventListener('click', function() {
         vm.stopAll();
     });
+    document.getElementById('turbomode').addEventListener('change', function() {
+        var turboOn = document.getElementById('turbomode').checked;
+        vm.setTurboMode(turboOn);
+    });
+    document.getElementById('pausemode').addEventListener('change', function() {
+        var pauseOn = document.getElementById('pausemode').checked;
+        vm.setPauseMode(pauseOn);
+    });
 
     var tabBlockExplorer = document.getElementById('tab-blockexplorer');
     var tabThreadExplorer = document.getElementById('tab-threadexplorer');

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -65,7 +65,7 @@ Scratch3ControlBlocks.prototype.repeatUntil = function(args, util) {
 Scratch3ControlBlocks.prototype.waitUntil = function(args, util) {
     var condition = Cast.toBoolean(args.CONDITION);
     if (!condition) {
-        util.yieldFrame();
+        util.yield();
     }
 };
 

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -46,56 +46,31 @@ Scratch3ControlBlocks.prototype.repeat = function(args, util) {
     // Only execute once per frame.
     // When the branch finishes, `repeat` will be executed again and
     // the second branch will be taken, yielding for the rest of the frame.
-    if (!util.stackFrame.executedInFrame) {
-        util.stackFrame.executedInFrame = true;
-        // Decrease counter
-        util.stackFrame.loopCounter--;
-        // If we still have some left, start the branch.
-        if (util.stackFrame.loopCounter >= 0) {
-            util.startBranch();
-        }
-    } else {
-        util.stackFrame.executedInFrame = false;
-        util.yieldFrame();
+    // Decrease counter
+    util.stackFrame.loopCounter--;
+    // If we still have some left, start the branch.
+    if (util.stackFrame.loopCounter >= 0) {
+        util.startBranch(1, true);
     }
 };
 
 Scratch3ControlBlocks.prototype.repeatUntil = function(args, util) {
     var condition = Cast.toBoolean(args.CONDITION);
-    // Only execute once per frame.
-    // When the branch finishes, `repeat` will be executed again and
-    // the second branch will be taken, yielding for the rest of the frame.
-    if (!util.stackFrame.executedInFrame) {
-        util.stackFrame.executedInFrame = true;
-        // If the condition is true, start the branch.
-        if (!condition) {
-            util.startBranch();
-        }
-    } else {
-        util.stackFrame.executedInFrame = false;
-        util.yieldFrame();
+    // If the condition is true, start the branch.
+    if (!condition) {
+        util.startBranch(1, true);
     }
 };
 
 Scratch3ControlBlocks.prototype.waitUntil = function(args, util) {
     var condition = Cast.toBoolean(args.CONDITION);
-    // Only execute once per frame.
     if (!condition) {
         util.yieldFrame();
     }
 };
 
 Scratch3ControlBlocks.prototype.forever = function(args, util) {
-    // Only execute once per frame.
-    // When the branch finishes, `forever` will be executed again and
-    // the second branch will be taken, yielding for the rest of the frame.
-    if (!util.stackFrame.executedInFrame) {
-        util.stackFrame.executedInFrame = true;
-        util.startBranch();
-    } else {
-        util.stackFrame.executedInFrame = false;
-        util.yieldFrame();
-    }
+    util.startBranch(1, true);
 };
 
 Scratch3ControlBlocks.prototype.wait = function(args) {
@@ -109,27 +84,17 @@ Scratch3ControlBlocks.prototype.wait = function(args) {
 
 Scratch3ControlBlocks.prototype.if = function(args, util) {
     var condition = Cast.toBoolean(args.CONDITION);
-    // Only execute one time. `if` will be returned to
-    // when the branch finishes, but it shouldn't execute again.
-    if (util.stackFrame.executedInFrame === undefined) {
-        util.stackFrame.executedInFrame = true;
-        if (condition) {
-            util.startBranch();
-        }
+    if (condition) {
+        util.startBranch(1, false);
     }
 };
 
 Scratch3ControlBlocks.prototype.ifElse = function(args, util) {
     var condition = Cast.toBoolean(args.CONDITION);
-    // Only execute one time. `ifElse` will be returned to
-    // when the branch finishes, but it shouldn't execute again.
-    if (util.stackFrame.executedInFrame === undefined) {
-        util.stackFrame.executedInFrame = true;
-        if (condition) {
-            util.startBranch(1);
-        } else {
-            util.startBranch(2);
-        }
+    if (condition) {
+        util.startBranch(1, false);
+    } else {
+        util.startBranch(2, false);
     }
 };
 

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -23,7 +23,6 @@ Scratch3ControlBlocks.prototype.getPrimitives = function() {
         'control_if': this.if,
         'control_if_else': this.ifElse,
         'control_stop': this.stop,
-        'control_create_clone_of_menu': this.createCloneMenu,
         'control_create_clone_of': this.createClone,
         'control_delete_this_clone': this.deleteClone
     };
@@ -113,11 +112,6 @@ Scratch3ControlBlocks.prototype.stop = function(args, util) {
     } else if (option == 'this script') {
         util.stopThread();
     }
-};
-
-// @todo (GH-146): remove.
-Scratch3ControlBlocks.prototype.createCloneMenu = function (args) {
-    return args.CLONE_OPTION;
 };
 
 Scratch3ControlBlocks.prototype.createClone = function (args, util) {

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -1,5 +1,5 @@
 var Cast = require('../util/cast');
-var Promise = require('promise');
+var Timer = require('../util/timer');
 
 function Scratch3ControlBlocks(runtime) {
     /**
@@ -73,13 +73,18 @@ Scratch3ControlBlocks.prototype.forever = function(args, util) {
     util.startBranch(1, true);
 };
 
-Scratch3ControlBlocks.prototype.wait = function(args) {
-    var duration = Cast.toNumber(args.DURATION);
-    return new Promise(function(resolve) {
-        setTimeout(function() {
-            resolve();
-        }, 1000 * duration);
-    });
+Scratch3ControlBlocks.prototype.wait = function(args, util) {
+    if (!util.stackFrame.timer) {
+        util.stackFrame.timer = new Timer();
+        util.stackFrame.timer.start();
+        util.yield();
+        this.runtime.requestRedraw();
+    } else {
+        var duration = Math.max(0, 1000 * Cast.toNumber(args.DURATION));
+        if (util.stackFrame.timer.timeElapsed() < duration) {
+            util.yield();
+        }
+    }
 };
 
 Scratch3ControlBlocks.prototype.if = function(args, util) {

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -82,7 +82,7 @@ Scratch3EventBlocks.prototype.broadcastAndWait = function (args, util) {
         return instance.runtime.isActiveThread(thread);
     });
     if (waiting) {
-        util.yieldFrame();
+        util.yield();
     }
 };
 

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -151,7 +151,7 @@ Scratch3LooksBlocks.prototype.switchBackdropAndWait = function (args, util) {
         return instance.runtime.isActiveThread(thread);
     });
     if (waiting) {
-        util.yieldFrame();
+        util.yield();
     }
 };
 

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -118,6 +118,7 @@ Scratch3MotionBlocks.prototype.glide = function (args, util) {
             util.target.setXY(util.stackFrame.endX, util.stackFrame.endY);
             return;
         }
+        util.yield();
     } else {
         var timeElapsed = util.stackFrame.timer.timeElapsed();
         if (timeElapsed < util.stackFrame.duration * 1000) {
@@ -129,6 +130,7 @@ Scratch3MotionBlocks.prototype.glide = function (args, util) {
                 util.stackFrame.startX + dx,
                 util.stackFrame.startY + dy
             );
+            util.yield();
         } else {
             // Finished: move to final position.
             util.target.setXY(util.stackFrame.endX, util.stackFrame.endY);

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -118,7 +118,6 @@ Scratch3MotionBlocks.prototype.glide = function (args, util) {
             util.target.setXY(util.stackFrame.endX, util.stackFrame.endY);
             return;
         }
-        util.yieldFrame();
     } else {
         var timeElapsed = util.stackFrame.timer.timeElapsed();
         if (timeElapsed < util.stackFrame.duration * 1000) {
@@ -130,7 +129,6 @@ Scratch3MotionBlocks.prototype.glide = function (args, util) {
                 util.stackFrame.startX + dx,
                 util.stackFrame.startY + dy
             );
-            util.yieldFrame();
         } else {
             // Finished: move to final position.
             util.target.setXY(util.stackFrame.endX, util.stackFrame.endY);

--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -38,9 +38,6 @@ Scratch3ProcedureBlocks.prototype.callNoReturn = function (args, util) {
 
 Scratch3ProcedureBlocks.prototype.param = function (args, util) {
     var value = util.getParam(args.mutation.paramname);
-    if (!value) {
-        return 0;
-    }
     return value;
 };
 

--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -24,15 +24,15 @@ Scratch3ProcedureBlocks.prototype.defNoReturn = function () {
 
 Scratch3ProcedureBlocks.prototype.callNoReturn = function (args, util) {
     if (!util.stackFrame.executed) {
-        var procedureName = args.mutation.proccode;
-        var paramNames = util.getProcedureParamNames(procedureName);
+        var procedureCode = args.mutation.proccode;
+        var paramNames = util.getProcedureParamNames(procedureCode);
         for (var i = 0; i < paramNames.length; i++) {
             if (args.hasOwnProperty('input' + i)) {
                 util.pushParam(paramNames[i], args['input' + i]);
             }
         }
         util.stackFrame.executed = true;
-        util.startProcedure(procedureName);
+        util.startProcedure(procedureCode);
     }
 };
 

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -135,7 +135,7 @@ Blocks.prototype.getMutation = function (id) {
 Blocks.prototype.getTopLevelScript = function (id) {
     if (typeof this._blocks[id] === 'undefined') return null;
     var block = this._blocks[id];
-    while (block.parent !== null) {
+    while (block.parent !== null && this._blocks[block.parent]) {
         block = this._blocks[block.parent];
     }
     return block.id;

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -135,7 +135,7 @@ Blocks.prototype.getMutation = function (id) {
 Blocks.prototype.getTopLevelScript = function (id) {
     if (typeof this._blocks[id] === 'undefined') return null;
     var block = this._blocks[id];
-    while (block.parent !== null && this._blocks[block.parent]) {
+    while (block.parent !== null) {
         block = this._blocks[block.parent];
     }
     return block.id;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -133,15 +133,20 @@ var execute = function (sequencer, thread) {
         var input = inputs[inputName];
         var inputBlockId = input.block;
         // Is there no value for this input waiting in the stack frame?
-        if (typeof currentStackFrame.reported[inputName] === 'undefined') {
+        if (typeof currentStackFrame.reported[inputName] === 'undefined'
+            && inputBlockId) {
             // If there's not, we need to evaluate the block.
-            var reporterYielded = (
-                sequencer.stepToReporter(thread, inputBlockId, inputName)
-            );
-            // If the reporter yielded, return immediately;
-            // it needs time to finish and report its value.
-            if (reporterYielded) {
+            // Push to the stack to evaluate the reporter block.
+            thread.pushStack(inputBlockId);
+            // Save name of input for `Thread.pushReportedValue`.
+            currentStackFrame.waitingReporter = inputName;
+            // Actually execute the block.
+            execute(sequencer, thread);
+            if (thread.status === Thread.STATUS_PROMISE_WAIT) {
                 return;
+            } else {
+                currentStackFrame.waitingReporter = null;
+                thread.popStack();
             }
         }
         argValues[inputName] = currentStackFrame.reported[inputName];
@@ -163,18 +168,11 @@ var execute = function (sequencer, thread) {
     primitiveReportedValue = blockFunction(argValues, {
         stackFrame: currentStackFrame.executionContext,
         target: target,
-        yield: function() {
-            thread.setStatus(Thread.STATUS_YIELD);
-        },
         yieldFrame: function() {
             thread.setStatus(Thread.STATUS_YIELD_FRAME);
         },
-        done: function() {
-            thread.setStatus(Thread.STATUS_RUNNING);
-            sequencer.proceedThread(thread);
-        },
-        startBranch: function (branchNum) {
-            sequencer.stepToBranch(thread, branchNum);
+        startBranch: function (branchNum, isLoop) {
+            sequencer.stepToBranch(thread, branchNum, isLoop);
         },
         stopAll: function () {
             runtime.stopAll();
@@ -221,18 +219,24 @@ var execute = function (sequencer, thread) {
     if (isPromise(primitiveReportedValue)) {
         if (thread.status === Thread.STATUS_RUNNING) {
             // Primitive returned a promise; automatically yield thread.
-            thread.setStatus(Thread.STATUS_YIELD);
+            thread.setStatus(Thread.STATUS_PROMISE_WAIT);
         }
         // Promise handlers
         primitiveReportedValue.then(function(resolvedValue) {
             handleReport(resolvedValue);
-            sequencer.proceedThread(thread);
+            if (typeof resolvedValue !== 'undefined') {
+                thread.popStack();
+            } else {
+                var popped = thread.popStack();
+                var nextBlockId = thread.target.blocks.getNextBlock(popped);
+                thread.pushStack(nextBlockId);
+            }
         }, function(rejectionReason) {
             // Promise rejected: the primitive had some error.
             // Log it and proceed.
             console.warn('Primitive rejected promise: ', rejectionReason);
             thread.setStatus(Thread.STATUS_RUNNING);
-            sequencer.proceedThread(thread);
+            thread.popStack();
         });
     } else if (thread.status === Thread.STATUS_RUNNING) {
         handleReport(primitiveReportedValue);

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -145,6 +145,8 @@ var execute = function (sequencer, thread) {
             if (thread.status === Thread.STATUS_PROMISE_WAIT) {
                 return;
             } else {
+                // Execution returned immediately,
+                // and presumably a value was reported, so pop the stack.
                 currentStackFrame.waitingReporter = null;
                 thread.popStack();
             }
@@ -183,11 +185,11 @@ var execute = function (sequencer, thread) {
         stopThread: function() {
             sequencer.retireThread(thread);
         },
-        startProcedure: function (procedureName) {
-            sequencer.stepToProcedure(thread, procedureName);
+        startProcedure: function (procedureCode) {
+            sequencer.stepToProcedure(thread, procedureCode);
         },
-        getProcedureParamNames: function (procedureName) {
-            return blockContainer.getProcedureParamNames(procedureName);
+        getProcedureParamNames: function (procedureCode) {
+            return blockContainer.getProcedureParamNames(procedureCode);
         },
         pushParam: function (paramName, paramValue) {
             thread.pushParam(paramName, paramValue);

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -90,7 +90,7 @@ var execute = function (sequencer, thread) {
                 runtime.visualReport(currentBlockId, resolvedValue);
             }
             // Finished any yields.
-            thread.setStatus(Thread.STATUS_RUNNING);
+            thread.status = Thread.STATUS_RUNNING;
         }
     };
 
@@ -168,8 +168,8 @@ var execute = function (sequencer, thread) {
     primitiveReportedValue = blockFunction(argValues, {
         stackFrame: currentStackFrame.executionContext,
         target: target,
-        yieldFrame: function() {
-            thread.setStatus(Thread.STATUS_YIELD_FRAME);
+        yield: function() {
+            thread.status = Thread.STATUS_YIELD;
         },
         startBranch: function (branchNum, isLoop) {
             sequencer.stepToBranch(thread, branchNum, isLoop);
@@ -219,7 +219,7 @@ var execute = function (sequencer, thread) {
     if (isPromise(primitiveReportedValue)) {
         if (thread.status === Thread.STATUS_RUNNING) {
             // Primitive returned a promise; automatically yield thread.
-            thread.setStatus(Thread.STATUS_PROMISE_WAIT);
+            thread.status = Thread.STATUS_PROMISE_WAIT;
         }
         // Promise handlers
         primitiveReportedValue.then(function(resolvedValue) {
@@ -235,7 +235,7 @@ var execute = function (sequencer, thread) {
             // Promise rejected: the primitive had some error.
             // Log it and proceed.
             console.warn('Primitive rejected promise: ', rejectionReason);
-            thread.setStatus(Thread.STATUS_RUNNING);
+            thread.status = Thread.STATUS_RUNNING;
             thread.popStack();
         });
     } else if (thread.status === Thread.STATUS_RUNNING) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -488,11 +488,8 @@ Runtime.prototype._step = function () {
         }
     }
     this.redrawRequested = false;
-    var inactiveThreads = this.sequencer.stepThreads(this.threads);
+    this.sequencer.stepThreads();
     this._updateScriptGlows();
-    for (var i = 0; i < inactiveThreads.length; i++) {
-        this._removeThread(inactiveThreads[i]);
-    }
 };
 
 Runtime.prototype.setEditingTarget = function (editingTarget) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -70,6 +70,18 @@ function Runtime () {
      * @type {number}
      */
     this._cloneCounter = 0;
+
+    /**
+     * Whether the project is in "turbo mode."
+     * @type {Boolean}
+     */
+    this.turboMode = false;
+
+    /**
+     * Whether the project is in "pause mode."
+     * @type {Boolean}
+     */
+    this.pauseMode = false;
 }
 
 /**
@@ -451,6 +463,10 @@ Runtime.prototype.stopAll = function () {
  * inactive threads after each iteration.
  */
 Runtime.prototype._step = function () {
+    if (this.pauseMode) {
+        // Don't do any execution while in pause mode.
+        return;
+    }
     // Find all edge-activated hats, and add them to threads to be evaluated.
     for (var hatType in this._hats) {
         var hat = this._hats[hatType];

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -644,7 +644,7 @@ Runtime.prototype._updateScriptGlows = function (opt_extraThreads) {
         var thread = searchThreads[i];
         var target = thread.target;
         if (target == this._editingTarget) {
-            var blockForThread = thread.peekStack() || thread.topBlock;
+            var blockForThread = thread.peekStack();
             if (thread.requestScriptGlowInFrame) {
                 var script = target.blocks.getTopLevelScript(blockForThread);
                 if (!script) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -500,8 +500,8 @@ Runtime.prototype._step = function () {
         }
     }
     this.redrawRequested = false;
-    this.sequencer.stepThreads();
-    this._updateScriptGlows();
+    var inactiveThreads = this.sequencer.stepThreads();
+    this._updateScriptGlows(inactiveThreads);
 };
 
 Runtime.prototype.setEditingTarget = function (editingTarget) {
@@ -534,7 +534,12 @@ Runtime.prototype.setSingleSteppingSpeed = function (speed) {
     }
 };
 
-Runtime.prototype._updateScriptGlows = function () {
+Runtime.prototype._updateScriptGlows = function (opt_extraThreads) {
+    var searchThreads = [];
+    searchThreads.push.apply(searchThreads, this.threads);
+    if (opt_extraThreads) {
+        searchThreads.push.apply(searchThreads, opt_extraThreads);
+    }
     // Set of scripts that request a glow this frame.
     var requestedGlowsThisFrame = [];
     var requestedBlockGlowsThisFrame = [];
@@ -542,8 +547,8 @@ Runtime.prototype._updateScriptGlows = function () {
     var finalScriptGlows = [];
     var finalBlockGlows = [];
     // Find all scripts that should be glowing.
-    for (var i = 0; i < this.threads.length; i++) {
-        var thread = this.threads[i];
+    for (var i = 0; i < searchThreads.length; i++) {
+        var thread = searchThreads[i];
         var target = thread.target;
         if (target == this._editingTarget) {
             var blockForThread = thread.peekStack() || thread.topBlock;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -97,6 +97,11 @@ function Runtime () {
      * @type {Boolean}
      */
     this.singleStepping = false;
+
+    /**
+     * How fast in ms "single stepping mode" should run.
+     */
+    this.singleStepInterval = 1000 / 10;
 }
 
 /**
@@ -155,11 +160,6 @@ Runtime.THREAD_STEP_INTERVAL = 1000 / 60;
  * In compatibility mode, how rapidly we try to step threads, in ms.
  */
 Runtime.THREAD_STEP_INTERVAL_COMPATIBILITY = 1000 / 30;
-
-/**
- * In single-stepping mode, how rapidly we try to step threads, in ms.
- */
-Runtime.THREAD_STEP_INTERVAL_SINGLE_STEP = 1000 / 4;
 
 /**
  * How many clones can be created at a time.
@@ -526,6 +526,14 @@ Runtime.prototype.setSingleSteppingMode = function (singleSteppingOn) {
     }
 };
 
+Runtime.prototype.setSingleSteppingSpeed = function (speed) {
+    this.singleStepInterval = 1000 / speed;
+    if (this._steppingInterval) {
+        self.clearInterval(this._steppingInterval);
+        this.start();
+    }
+};
+
 Runtime.prototype._updateScriptGlows = function () {
     // Set of scripts that request a glow this frame.
     var requestedGlowsThisFrame = [];
@@ -727,7 +735,7 @@ Runtime.prototype.animationFrame = function () {
 Runtime.prototype.start = function () {
     var interval = Runtime.THREAD_STEP_INTERVAL;
     if (this.singleStepping) {
-        interval = Runtime.THREAD_STEP_INTERVAL_SINGLE_STEP;
+        interval = this.singleStepInterval;
     } else if (this.compatibilityMode) {
         interval = Runtime.THREAD_STEP_INTERVAL_COMPATIBILITY;
     }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -130,6 +130,8 @@ Runtime.THREAD_STEP_INTERVAL = 1000 / 60;
  */
 Runtime.MAX_CLONES = 300;
 
+Runtime.redrawRequested = false;
+
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 
@@ -456,6 +458,7 @@ Runtime.prototype._step = function () {
             this.startHats(hatType);
         }
     }
+    this.redrawRequested = false;
     var inactiveThreads = this.sequencer.stepThreads(this.threads);
     this._updateScriptGlows();
     for (var i = 0; i < inactiveThreads.length; i++) {
@@ -617,12 +620,19 @@ Runtime.prototype.getTargetForStage = function () {
     }
 };
 
+Runtime.prototype.requestRedraw = function () {
+    this.redrawRequested = true;
+};
+
 /**
  * Handle an animation frame from the main thread.
  */
 Runtime.prototype.animationFrame = function () {
     if (this.renderer) {
-        this.renderer.draw();
+        this._step();
+        if (this.redrawRequested) {
+            this.renderer.draw();
+        }
     }
 };
 
@@ -630,9 +640,8 @@ Runtime.prototype.animationFrame = function () {
  * Set up timers to repeatedly step in a browser
  */
 Runtime.prototype.start = function () {
-    self.setInterval(function() {
-        this._step();
-    }.bind(this), Runtime.THREAD_STEP_INTERVAL);
+    /*self.setInterval(function() {
+    }.bind(this), Runtime.THREAD_STEP_INTERVAL);*/
 };
 
 module.exports = Runtime;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -644,7 +644,7 @@ Runtime.prototype._updateGlows = function (opt_extraThreads) {
         var thread = searchThreads[i];
         var target = thread.target;
         if (target == this._editingTarget) {
-            var blockForThread = thread.peekStack();
+            var blockForThread = thread.blockGlowInFrame;
             if (thread.requestScriptGlowInFrame) {
                 var script = target.blocks.getTopLevelScript(blockForThread);
                 if (!script) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -645,10 +645,8 @@ Runtime.prototype.requestRedraw = function () {
  */
 Runtime.prototype.animationFrame = function () {
     if (this.renderer) {
-        this._step();
-        if (this.redrawRequested) {
-            this.renderer.draw();
-        }
+        // @todo: Only render when this.redrawRequested or clones rendered.
+        this.renderer.draw();
     }
 };
 
@@ -656,8 +654,9 @@ Runtime.prototype.animationFrame = function () {
  * Set up timers to repeatedly step in a browser
  */
 Runtime.prototype.start = function () {
-    /*self.setInterval(function() {
-    }.bind(this), Runtime.THREAD_STEP_INTERVAL);*/
+    self.setInterval(function() {
+        this._step();
+    }.bind(this), Runtime.THREAD_STEP_INTERVAL);
 };
 
 module.exports = Runtime;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -555,7 +555,7 @@ Runtime.prototype._step = function () {
     }
     this.redrawRequested = false;
     var inactiveThreads = this.sequencer.stepThreads();
-    this._updateScriptGlows(inactiveThreads);
+    this._updateGlows(inactiveThreads);
 };
 
 /**
@@ -566,7 +566,7 @@ Runtime.prototype.setEditingTarget = function (editingTarget) {
     this._editingTarget = editingTarget;
     // Script glows must be cleared.
     this._scriptGlowsPreviousFrame = [];
-    this._updateScriptGlows();
+    this._updateGlows();
 };
 
 /**
@@ -627,7 +627,7 @@ Runtime.prototype.setSingleSteppingSpeed = function (speed) {
  * Looks at `this.threads` and notices which have turned on/off new glows.
  * @param {Array.<Thread>=} opt_extraThreads Optional list of inactive threads.
  */
-Runtime.prototype._updateScriptGlows = function (opt_extraThreads) {
+Runtime.prototype._updateGlows = function (opt_extraThreads) {
     var searchThreads = [];
     searchThreads.push.apply(searchThreads, this.threads);
     if (opt_extraThreads) {
@@ -658,7 +658,7 @@ Runtime.prototype._updateScriptGlows = function (opt_extraThreads) {
                 }
             }
             // Only show block glows in single-stepping mode.
-            if (this.singleStepping) {
+            if (this.singleStepping && blockForThread) {
                 requestedBlockGlowsThisFrame.push(blockForThread);
             }
         }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -85,6 +85,7 @@ function Runtime () {
      * @type {Boolean}
      */
     this.pauseMode = false;
+    this.pauseTime = null;
 
     /**
      * Whether the project is in "compatibility mode" (30 TPS).
@@ -508,6 +509,18 @@ Runtime.prototype.setEditingTarget = function (editingTarget) {
     this._scriptGlowsPreviousFrame = [];
     this._editingTarget = editingTarget;
     this._updateScriptGlows();
+};
+
+Runtime.prototype.setPauseMode = function (pauseModeOn) {
+    if (this.ioDevices.clock) {
+        if (pauseModeOn && !this.pauseMode) {
+            this.ioDevices.clock.pause();
+        }
+        if (!pauseModeOn && this.pauseMode) {
+            this.ioDevices.clock.resume();
+        }    
+    }
+    this.pauseMode = pauseModeOn;
 };
 
 Runtime.prototype.setCompatibilityMode = function (compatibilityModeOn) {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -111,6 +111,7 @@ Sequencer.prototype.stepThread = function (thread) {
         // Save the current block ID to notice if we did control flow.
         currentBlockId = thread.peekStack();
         execute(this, thread);
+        thread.blockGlowInFrame = currentBlockId;
         // If the thread has yielded or is waiting, yield to other threads.
         if (thread.status === Thread.STATUS_YIELD) {
             // Mark as running for next iteration.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -60,6 +60,10 @@ Sequencer.prototype.stepThreads = function () {
         }
         // Filter out threads that have stopped.
         this.runtime.threads = newThreads;
+        // In single-stepping mode, only step each thread once per interval.
+        if (this.runtime.singleStepping) {
+            return;
+        }
     }
 };
 
@@ -116,6 +120,11 @@ Sequencer.prototype.stepThread = function (thread) {
             }
             // Get next block of existing block on the stack.
             thread.goToNextBlock();
+        }
+        // In single-stepping mode, force `stepThread` to only run one block
+        // at a time.
+        if (this.runtime.singleStepping) {
+            return;
         }
     }
 };

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -204,7 +204,7 @@ Sequencer.prototype.stepToBranch = function (thread, branchNum, isLoop) {
 /**
  * Step a procedure.
  * @param {!Thread} thread Thread object to step to procedure.
- * @param {!string} procedureCode Proceduer code of procedure to step to.
+ * @param {!string} procedureCode Procedure code of procedure to step to.
  */
 Sequencer.prototype.stepToProcedure = function (thread, procedureCode) {
     var definition = thread.target.blocks.getProcedureDefinition(procedureCode);

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -16,14 +16,6 @@ function Sequencer (runtime) {
     this.runtime = runtime;
 }
 
-/**
- * The sequencer does as much work as it can within WORK_TIME milliseconds,
- * then yields. This is essentially a rate-limiter for blocks.
- * In Scratch 2.0, this is set to 75% of the target stage frame-rate (30fps).
- * @const {!number}
- */
-Sequencer.WORK_TIME = 10;
-
 Sequencer.WARP_TIME = 500;
 
 /**
@@ -32,6 +24,7 @@ Sequencer.WARP_TIME = 500;
  * @return {Array.<Thread>} All threads which have finished in this iteration.
  */
 Sequencer.prototype.stepThreads = function (threads) {
+    var WORK_TIME = 0.75 * this.runtime.currentStepTime;
     // Start counting toward WORK_TIME
     this.timer.start();
     // List of threads which have been killed by this step.
@@ -42,7 +35,7 @@ Sequencer.prototype.stepThreads = function (threads) {
     // continue executing threads.
     while (threads.length > 0 &&
            numActiveThreads > 0 &&
-           this.timer.timeElapsed() < Sequencer.WORK_TIME &&
+           this.timer.timeElapsed() < WORK_TIME &&
            (this.runtime.turboMode || !this.runtime.redrawRequested)) {
         // New threads at the end of the iteration.
         var newThreads = [];

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -53,7 +53,7 @@ Sequencer.prototype.stepThreads = function () {
             if (activeThread.stack.length === 0 ||
                 activeThread.status === Thread.STATUS_DONE) {
                 // Finished with this thread.
-                if (inactiveThreads.indexOf(activeThread) < -1) {
+                if (inactiveThreads.indexOf(activeThread) < 0) {
                     inactiveThreads.push(activeThread);
                 }
                 continue;
@@ -84,6 +84,13 @@ Sequencer.prototype.stepThreads = function () {
         // threads on the next tick.
         ranFirstTick = true;
     }
+    // Filter inactive threads from `this.runtime.threads`.
+    this.runtime.threads = this.runtime.threads.filter(function(thread) {
+        if (inactiveThreads.indexOf(thread) > -1) {
+            return false;
+        }
+        return true;
+    });
     return inactiveThreads;
 };
 

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -20,6 +20,7 @@ Sequencer.WARP_TIME = 500;
 
 /**
  * Step through all threads in `this.runtime.threads`, running them in order.
+ * @return {Array.<!Thread>} List of inactive threads after stepping.
  */
 Sequencer.prototype.stepThreads = function () {
     var WORK_TIME = 0.75 * this.runtime.currentStepTime;
@@ -28,6 +29,7 @@ Sequencer.prototype.stepThreads = function () {
     // Count of active threads.
     var numActiveThreads = Infinity;
     var ranFirstFrame = false;
+    var filteredThreads = [];
     // While there are still threads to run and we are within WORK_TIME,
     // continue executing threads.
     while (this.runtime.threads.length > 0 &&
@@ -60,6 +62,7 @@ Sequencer.prototype.stepThreads = function () {
             if (activeThread.stack.length === 0 ||
                 activeThread.status === Thread.STATUS_DONE) {
                 // Finished with this thread.
+                filteredThreads.push(activeThread);
             } else {
                 // Keep this thead in the loop.
                 newThreads.push(activeThread);
@@ -69,6 +72,7 @@ Sequencer.prototype.stepThreads = function () {
         this.runtime.threads = newThreads;
         ranFirstFrame = true;
     }
+    return filteredThreads;
 };
 
 /**

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -48,7 +48,7 @@ Sequencer.prototype.stepThreads = function (threads) {
     while (threads.length > 0 &&
            threads.length > numYieldingThreads &&
            this.timer.timeElapsed() < Sequencer.WORK_TIME &&
-           !this.runtime.redrawRequested) {
+           (this.runtime.turboMode || !this.runtime.redrawRequested)) {
         // New threads at the end of the iteration.
         var newThreads = [];
         // Reset yielding thread count.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -47,7 +47,8 @@ Sequencer.prototype.stepThreads = function (threads) {
     // continue executing threads.
     while (threads.length > 0 &&
            threads.length > numYieldingThreads &&
-           this.timer.timeElapsed() < Sequencer.WORK_TIME) {
+           this.timer.timeElapsed() < Sequencer.WORK_TIME &&
+           !this.runtime.redrawRequested) {
         // New threads at the end of the iteration.
         var newThreads = [];
         // Reset yielding thread count.
@@ -57,13 +58,13 @@ Sequencer.prototype.stepThreads = function (threads) {
             var activeThread = threads[i];
             if (activeThread.status === Thread.STATUS_RUNNING) {
                 // Normal-mode thread: step.
-                this.startThread(activeThread);
-            } else if (activeThread.status === Thread.STATUS_YIELD ||
+                this.stepThread(activeThread);
+            } else if (activeThread.status === Thread.STATUS_PROMISE_WAIT ||
                        activeThread.status === Thread.STATUS_YIELD_FRAME) {
                 // Yielding thread: do nothing for this step.
                 numYieldingThreads++;
             }
-            if (activeThread.stack.length === 0 &&
+            if (activeThread.stack.length === 0 ||
                 activeThread.status === Thread.STATUS_DONE) {
                 // Finished with this thread - tell runtime to clean it up.
                 inactiveThreads.push(activeThread);
@@ -82,7 +83,7 @@ Sequencer.prototype.stepThreads = function (threads) {
  * Step the requested thread
  * @param {!Thread} thread Thread object to step
  */
-Sequencer.prototype.startThread = function (thread) {
+Sequencer.prototype.stepThread = function (thread) {
     var currentBlockId = thread.peekStack();
     if (!currentBlockId) {
         // A "null block" - empty branch.
@@ -91,13 +92,34 @@ Sequencer.prototype.startThread = function (thread) {
         thread.setStatus(Thread.STATUS_YIELD_FRAME);
         return;
     }
-    // Execute the current block
-    execute(this, thread);
-    // If the block executed without yielding and without doing control flow,
-    // move to done.
-    if (thread.status === Thread.STATUS_RUNNING &&
-        thread.peekStack() === currentBlockId) {
-        this.proceedThread(thread);
+    while (thread.peekStack()) {
+        // Execute the current block.
+        currentBlockId = thread.peekStack();
+        execute(this, thread);
+        // If the thread has yielded or is waiting, yield to other threads.
+        if (thread.status === Thread.STATUS_YIELD_FRAME ||
+            thread.status === Thread.STATUS_PROMISE_WAIT) {
+            return;
+        }
+        // If no control flow has happened, switch to next block.
+        if (thread.peekStack() === currentBlockId) {
+            thread.goToNextBlock();
+        }
+        // If no next block has been found at this point, look on the stack.
+        while (!thread.peekStack()) {
+            thread.popStack();
+            if (thread.stack.length === 0) {
+                thread.status = Thread.STATUS_DONE;
+                return;
+            }
+            if (thread.peekStackFrame().isLoop) {
+                return;
+            } else if (thread.peekStackFrame().waitingReporter) {
+                return;
+            }
+            // Get next block of existing block on the stack.
+            thread.goToNextBlock();
+        }
     }
 };
 
@@ -105,8 +127,9 @@ Sequencer.prototype.startThread = function (thread) {
  * Step a thread into a block's branch.
  * @param {!Thread} thread Thread object to step to branch.
  * @param {Number} branchNum Which branch to step to (i.e., 1, 2).
+ * @param {Boolean} isLoop Whether this block is a loop.
  */
-Sequencer.prototype.stepToBranch = function (thread, branchNum) {
+Sequencer.prototype.stepToBranch = function (thread, branchNum, isLoop) {
     if (!branchNum) {
         branchNum = 1;
     }
@@ -115,12 +138,10 @@ Sequencer.prototype.stepToBranch = function (thread, branchNum) {
         currentBlockId,
         branchNum
     );
+    thread.peekStackFrame().isLoop = isLoop;
     if (branchId) {
         // Push branch ID to the thread's stack.
         thread.pushStack(branchId);
-    } else {
-        // Push null, so we come back to the current block.
-        thread.pushStack(null);
     }
 };
 
@@ -134,36 +155,11 @@ Sequencer.prototype.stepToProcedure = function (thread, procedureName) {
     thread.pushStack(definition);
     // Check if the call is recursive. If so, yield.
     // @todo: Have behavior match Scratch 2.0.
-    if (thread.stack.indexOf(definition) > -1) {
+    /*if (thread.stack.indexOf(definition) > -1) {
         thread.setStatus(Thread.STATUS_YIELD_FRAME);
-    }
+    }*/
 };
 
-/**
- * Step a thread into an input reporter, and manage its status appropriately.
- * @param {!Thread} thread Thread object to step to reporter.
- * @param {!string} blockId ID of reporter block.
- * @param {!string} inputName Name of input on parent block.
- * @return {boolean} True if yielded, false if it finished immediately.
- */
-Sequencer.prototype.stepToReporter = function (thread, blockId, inputName) {
-    var currentStackFrame = thread.peekStackFrame();
-    // Push to the stack to evaluate the reporter block.
-    thread.pushStack(blockId);
-    // Save name of input for `Thread.pushReportedValue`.
-    currentStackFrame.waitingReporter = inputName;
-    // Actually execute the block.
-    this.startThread(thread);
-    // If a reporter yielded, caller must wait for it to unyield.
-    // The value will be populated once the reporter unyields,
-    // and passed up to the currentStackFrame on next execution.
-    return thread.status === Thread.STATUS_YIELD;
-};
-
-/**
- * Finish stepping a thread and proceed it to the next block.
- * @param {!Thread} thread Thread object to proceed.
- */
 Sequencer.prototype.proceedThread = function (thread) {
     var currentBlockId = thread.peekStack();
     // Mark the status as done and proceed to the next block.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -176,7 +176,9 @@ Sequencer.prototype.stepToProcedure = function (thread, procedureName) {
             thread.warpMode = true;
         }
         // Check if the call is recursive. If so, yield.
-        thread.status = Thread.STATUS_YIELD;
+        if (thread.isRecursiveCall(procedureName)) {
+            thread.status = Thread.STATUS_YIELD;
+        }
     }
 };
 

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -42,6 +42,12 @@ function Thread (firstBlock) {
     this.requestScriptGlowInFrame = false;
 
     /**
+     * Which block ID should glow during this frame, if any.
+     * @type {?string}
+     */
+    this.blockGlowInFrame = null;
+
+    /**
      * A timer for when the thread enters warp mode.
      * Substitutes the sequencer's count toward WORK_TIME on a per-thread basis.
      * @type {?Timer}

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -58,10 +58,10 @@ Thread.STATUS_RUNNING = 0;
 Thread.STATUS_PROMISE_WAIT = 1;
 
 /**
- * Thread status for a single-frame yield.
+ * Thread status for yield.
  * @const
  */
-Thread.STATUS_YIELD_FRAME = 2;
+Thread.STATUS_YIELD = 2;
 
 /**
  * Thread status for a finished/done thread.
@@ -156,14 +156,6 @@ Thread.prototype.getParam = function (paramName) {
  */
 Thread.prototype.atStackTop = function () {
     return this.peekStack() === this.topBlock;
-};
-
-/**
- * Set thread status.
- * @param {number} status Enum representing thread status.
- */
-Thread.prototype.setStatus = function (status) {
-    this.status = status;
 };
 
 /**

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -66,11 +66,18 @@ Thread.STATUS_PROMISE_WAIT = 1;
 Thread.STATUS_YIELD = 2;
 
 /**
+ * Thread status for a single-frame yield. This will be cleared when the
+ * thread is returned to.
+ * @const
+ */
+Thread.STATUS_YIELD_FRAME = 3;
+
+/**
  * Thread status for a finished/done thread.
  * Thread is in this state when there are no more blocks to execute.
  * @const
  */
-Thread.STATUS_DONE = 3;
+Thread.STATUS_DONE = 4;
 
 /**
  * Push stack and update stack frames appropriately.

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -184,8 +184,7 @@ Thread.prototype.goToNextBlock = function () {
 };
 
 Thread.prototype.isRecursiveCall = function (procedureName) {
-    // @todo: Scratch 2.0 only checks 5 levels, probably as an optimization.
-    // Should we do the same?
+    var callCount = 5; // Max number of enclosing procedure calls to examine.
     var sp = this.stack.length;
     for (var i = sp - 1; i >= 0; i--) {
         var block = this.target.blocks.getBlock(this.stack[i]);
@@ -193,6 +192,7 @@ Thread.prototype.isRecursiveCall = function (procedureName) {
             block.mutation.proccode == procedureName)  {
             return true;
         }
+        if (--callCount < 0) return false;
     }
     return false;
 };

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -40,6 +40,9 @@ function Thread (firstBlock) {
      * @type {boolean}
      */
     this.requestScriptGlowInFrame = false;
+
+    this.warpMode = false;
+    this.warpTimer = null;
 }
 
 /**

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -183,4 +183,18 @@ Thread.prototype.goToNextBlock = function () {
     this.pushStack(nextBlockId);
 };
 
+Thread.prototype.isRecursiveCall = function (procedureName) {
+    // @todo: Scratch 2.0 only checks 5 levels, probably as an optimization.
+    // Should we do the same?
+    var sp = this.stack.length;
+    for (var i = sp - 1; i >= 0; i--) {
+        var block = this.target.blocks.getBlock(this.stack[i]);
+        if (block.opcode == 'procedures_callnoreturn' &&
+            block.mutation.proccode == procedureName)  {
+            return true;
+        }
+    }
+    return false;
+};
+
 module.exports = Thread;

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ VirtualMachine.prototype.greenFlag = function () {
 };
 
 /**
- * Set whether the project is in "turbo mode."
+ * Set whether the VM is in "turbo mode."
  * When true, loops don't yield to redraw.
  * @param {Boolean} turboModeOn Whether turbo mode should be set.
  */
@@ -76,12 +76,21 @@ VirtualMachine.prototype.setTurboMode = function (turboModeOn) {
 };
 
 /**
- * Set whether the project is in "pause mode."
+ * Set whether the VM is in "pause mode."
  * When true, nothing is stepped.
  * @param {Boolean} pauseModeOn Whether pause mode should be set.
  */
 VirtualMachine.prototype.setPauseMode = function (pauseModeOn) {
     this.runtime.pauseMode = (pauseModeOn == true);
+};
+
+/**
+ * Set whether the VM is in 2.0 "compatibility mode."
+ * When true, ticks go at 2.0 speed (30 TPS).
+ * @param {Boolean} compatibilityModeOn Whether compatibility mode is set.
+ */
+VirtualMachine.prototype.setCompatibilityMode = function (compatibilityModeOn) {
+    this.runtime.setCompatibilityMode(compatibilityModeOn == true);
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ VirtualMachine.prototype.greenFlag = function () {
  * @param {Boolean} turboModeOn Whether turbo mode should be set.
  */
 VirtualMachine.prototype.setTurboMode = function (turboModeOn) {
-    this.runtime.turboMode = (turboModeOn == true);
+    this.runtime.turboMode = !!turboModeOn;
 };
 
 /**
@@ -81,7 +81,7 @@ VirtualMachine.prototype.setTurboMode = function (turboModeOn) {
  * @param {Boolean} pauseModeOn Whether pause mode should be set.
  */
 VirtualMachine.prototype.setPauseMode = function (pauseModeOn) {
-    this.runtime.setPauseMode(pauseModeOn == true);
+    this.runtime.setPauseMode(!!pauseModeOn);
 };
 
 /**
@@ -90,7 +90,7 @@ VirtualMachine.prototype.setPauseMode = function (pauseModeOn) {
  * @param {Boolean} compatibilityModeOn Whether compatibility mode is set.
  */
 VirtualMachine.prototype.setCompatibilityMode = function (compatibilityModeOn) {
-    this.runtime.setCompatibilityMode(compatibilityModeOn == true);
+    this.runtime.setCompatibilityMode(!!compatibilityModeOn);
 };
 
 /**
@@ -99,7 +99,7 @@ VirtualMachine.prototype.setCompatibilityMode = function (compatibilityModeOn) {
  * @param {Boolean} singleSteppingOn Whether single-stepping mode is set.
  */
 VirtualMachine.prototype.setSingleSteppingMode = function (singleSteppingOn) {
-    this.runtime.setSingleSteppingMode(singleSteppingOn == true);
+    this.runtime.setSingleSteppingMode(!!singleSteppingOn);
 };
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ VirtualMachine.prototype.setTurboMode = function (turboModeOn) {
  * @param {Boolean} pauseModeOn Whether pause mode should be set.
  */
 VirtualMachine.prototype.setPauseMode = function (pauseModeOn) {
-    this.runtime.pauseMode = (pauseModeOn == true);
+    this.runtime.setPauseMode(pauseModeOn == true);
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,17 @@ VirtualMachine.prototype.setSingleSteppingMode = function (singleSteppingOn) {
     this.runtime.setSingleSteppingMode(singleSteppingOn == true);
 };
 
+
+/**
+ * Set single-stepping mode speed.
+ * When in single-stepping mode, adjusts the speed of execution.
+ * @param {Number} speed Interval length in ms.
+ */
+VirtualMachine.prototype.setSingleSteppingSpeed = function (speed) {
+    this.runtime.setSingleSteppingSpeed(speed);
+};
+
+
 /**
  * Stop all threads and running activities.
  */

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,15 @@ VirtualMachine.prototype.setCompatibilityMode = function (compatibilityModeOn) {
 };
 
 /**
+ * Set whether the VM is in "single stepping mode."
+ * When true, blocks execute slowly and are highlighted visually.
+ * @param {Boolean} singleSteppingOn Whether single-stepping mode is set.
+ */
+VirtualMachine.prototype.setSingleSteppingMode = function (singleSteppingOn) {
+    this.runtime.setSingleSteppingMode(singleSteppingOn == true);
+};
+
+/**
  * Stop all threads and running activities.
  */
 VirtualMachine.prototype.stopAll = function () {

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,24 @@ VirtualMachine.prototype.greenFlag = function () {
 };
 
 /**
+ * Set whether the project is in "turbo mode."
+ * When true, loops don't yield to redraw.
+ * @param {Boolean} turboModeOn Whether turbo mode should be set.
+ */
+VirtualMachine.prototype.setTurboMode = function (turboModeOn) {
+    this.runtime.turboMode = (turboModeOn == true);
+};
+
+/**
+ * Set whether the project is in "pause mode."
+ * When true, nothing is stepped.
+ * @param {Boolean} pauseModeOn Whether pause mode should be set.
+ */
+VirtualMachine.prototype.setPauseMode = function (pauseModeOn) {
+    this.runtime.pauseMode = (pauseModeOn == true);
+};
+
+/**
  * Stop all threads and running activities.
  */
 VirtualMachine.prototype.stopAll = function () {

--- a/src/io/clock.js
+++ b/src/io/clock.js
@@ -1,12 +1,33 @@
 var Timer = require('../util/timer');
 
-function Clock () {
+function Clock (runtime) {
     this._projectTimer = new Timer();
     this._projectTimer.start();
+    this._pausedTime = null;
+    this._paused = false;
+    /**
+     * Reference to the owning Runtime.
+     * @type{!Runtime}
+     */
+    this.runtime = runtime;
 }
 
 Clock.prototype.projectTimer = function () {
+    if (this._paused) {
+        return this._pausedTime / 1000;
+    }
     return this._projectTimer.timeElapsed() / 1000;
+};
+
+Clock.prototype.pause = function () {
+    this._paused = true;
+    this._pausedTime = this._projectTimer.timeElapsed();
+};
+
+Clock.prototype.resume = function () {
+    this._paused = false;
+    var dt = this._projectTimer.timeElapsed() - this._pausedTime;
+    this._projectTimer.startTime += dt;
 };
 
 Clock.prototype.resetProjectTimer = function () {

--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -152,6 +152,9 @@ Clone.prototype.setXY = function (x, y) {
         this.renderer.updateDrawableProperties(this.drawableID, {
             position: [this.x, this.y]
         });
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -191,6 +194,9 @@ Clone.prototype.setDirection = function (direction) {
             direction: renderedDirectionScale.direction,
             scale: renderedDirectionScale.scale
         });
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -224,6 +230,9 @@ Clone.prototype.setVisible = function (visible) {
         this.renderer.updateDrawableProperties(this.drawableID, {
             visible: this.visible
         });
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -243,6 +252,9 @@ Clone.prototype.setSize = function (size) {
             direction: renderedDirectionScale.direction,
             scale: renderedDirectionScale.scale
         });
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -258,6 +270,9 @@ Clone.prototype.setEffect = function (effectName, value) {
         var props = {};
         props[effectName] = this.effects[effectName];
         this.renderer.updateDrawableProperties(this.drawableID, props);
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -270,6 +285,9 @@ Clone.prototype.clearEffects = function () {
     }
     if (this.renderer) {
         this.renderer.updateDrawableProperties(this.drawableID, this.effects);
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -287,6 +305,9 @@ Clone.prototype.setCostume = function (index) {
         this.renderer.updateDrawableProperties(this.drawableID, {
             skin: this.sprite.costumes[this.currentCostume].skin
         });
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -308,6 +329,9 @@ Clone.prototype.setRotationStyle = function (rotationStyle) {
             direction: renderedDirectionScale.direction,
             scale: renderedDirectionScale.scale
         });
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -339,6 +363,9 @@ Clone.prototype.updateAllDrawableProperties = function () {
             visible: this.visible,
             skin: this.sprite.costumes[this.currentCostume].skin
         });
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 
@@ -421,6 +448,9 @@ Clone.prototype.dispose = function () {
     this.runtime.changeCloneCounter(-1);
     if (this.renderer && this.drawableID !== null) {
         this.renderer.destroyDrawable(this.drawableID);
+        if (this.visible) {
+            this.runtime.requestRedraw();
+        }
     }
 };
 


### PR DESCRIPTION
I spent a bunch of time reworking and refactoring parts of the sequencer, control blocks, and stepping mechanisms to ensure 2.0 compatibility and add a bunch of things we wanted.

---
## Fixed our stepping mechanism to work like 2.0.

In playing with custom blocks, I noticed that scratch-vm executed simple recursive procedures like "calculate factorial(n)" about 100-1000x slower than Scratch 2.0, even with any kind of yielding turned off. That was pretty shocking, so I started digging into the reason. Basically, we were switching threads way too often.

Consider this set:
<img width="434" alt="screen shot 2016-10-17 at 12 51 51 pm" src="https://cloud.githubusercontent.com/assets/120403/19446814/937dbf72-9468-11e6-9942-7d76ec8b3cdb.png">

In Scratch 2.0 and 1.4, and after this PR, both of those scripts are guaranteed to execute atomically. So, as long as the left script executes before the right script, the sprite will _always_ turn.

In the previous scratch-vm implementation, the thread would switch as soon as executing one block. I.e., it would do each green flag, then a single set, then check the if, etc. Not only is this slow, it's just not how Scratch currently executes things.

I believe I've fixed this by switching our previous `startThread` to a `stepThreads` that looks like Scratch 2.0's.

---
## Add warp-mode thread

Since I was already digging into thread stepping, I added the warp-mode thread for "run procedure without screen refresh." This is again modeled on 2.0's implementation.

---
## Add `interp.redraw` equivalent and correct behavior for yielding at the end of loops.

This is pretty closely modeled on 2.0, including when `stepThread` and `stepThreads` returns.

---
## Add turbo mode support

With the previous implemented, it was very easy to add turbo mode.

---
## Add 2.0 compatibility 30TPS mode

I thought it would be helpful to have this to do a closer project comparison. Basically, it switches the stepping interval to 30TPS.

---
## Add pause mode

This suspends the stepping timer and also tells the project timer to pause itself as appropriate, so the "timer" block is also paused.

---
## Add single-stepping mode and a sliding speed adjustment

Getting into the weeds of stepping, this also made sense to address and was fun to do. Basically, it throws "running" status threads into a single-tick yield after executing. Otherwise, it adjusts the stepping interval according to the given speed. This also involved updating the "glow update" method, to handle highlighting the blocks in single-stepping mode.

<img width="321" alt="screen shot 2016-10-17 at 1 00 43 pm" src="https://cloud.githubusercontent.com/assets/120403/19447042/bf6d03da-9469-11e6-854c-e1fde410b282.png">

<img width="205" alt="screen shot 2016-10-17 at 1 04 59 pm" src="https://cloud.githubusercontent.com/assets/120403/19447191/62480528-946a-11e6-9ecc-97b2816852be.png">

---

I also improved JSDoc and documentation in several places. If merged, I think this resolves #207, #89, and #65.

cc: @rschamp FYI - not sure if/when we want to use any of these options in the GUI!
