### PR TITLE
Fix parent setting in sb2 importer

### DIFF
--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -292,8 +292,14 @@ function parseBlock (sb2block) {
                     // Single block occupies the input.
                     innerBlocks = [parseBlock(providedArg)];
                 }
+                var previousBlock = null;
                 for (var j = 0; j < innerBlocks.length; j++) {
-                    innerBlocks[j].parent = activeBlock.id;
+                    if (j == 0) {
+                        innerBlocks[j].parent = activeBlock.id;
+                    } else {
+                        innerBlocks[j].parent = previousBlock;
+                    }
+                    previousBlock = innerBlocks[j].id;
                 }
                 // Obscures any shadow.
                 shadowObscured = true;


### PR DESCRIPTION
Previously, the SB2 importer would set the parent of all blocks in an inner block list to the outer block. But, the expected behavior is that blocks after the 0th have their parent set to the previous block. This was leading to weird behavior where splitting the blocks out of the input could lead to old non-connected blocks to be highlighted when the block was running. I believe this fixes #205.
