### PR TITLE
Fix scratch-* dependency versions for npm update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ after_script:
     # Publish to gh-pages as most recent committer
     git config --global user.email $(git log --pretty=format:"%ae" -n1)
     git config --global user.name $(git log --pretty=format:"%an" -n1)
-    ./node_modules/.bin/gh-pages -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git -d playground -m "Build for $(git log --pretty=format:%H -n1)"
+    npm run deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
   fi

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "./node_modules/.bin/webpack --progress --colors --bail",
     "coverage": "./node_modules/.bin/tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",
+    "deploy": "./node_modules/.bin/gh-pages -d playground -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "lint": "./node_modules/.bin/eslint .",
     "prepublish": "npm run build",
     "prepublish-watch": "npm run watch",
@@ -34,8 +35,8 @@
     "json-loader": "0.5.4",
     "lodash.defaultsdeep": "4.6.0",
     "promise": "7.1.1",
-    "scratch-blocks": "^0.1.0-prepublish",
-    "scratch-render": "^0.1.0-prepublish",
+    "scratch-blocks": "latest",
+    "scratch-render": "latest",
     "script-loader": "0.7.0",
     "stats.js": "0.16.0",
     "tap": "5.7.1",


### PR DESCRIPTION
Fixes #284 

The issues:
- The scratch-blocks@0.1.0 version exists because I accidentally published 0.1.0 (no -prerelease modifier) while setting up NPM
- I added a step that causes Travis to run `npm update` after installing
- The "0.1.0-prepublish" dependency version makes no sense

This made Travis install the old version of scratch-blocks that I published accidentally, which breaks the playground.
