### PR TITLE
Prevent npm from outputting repo URL on gh-pages publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ after_script:
     # Publish to gh-pages as most recent committer
     git config --global user.email $(git log --pretty=format:"%ae" -n1)
     git config --global user.name $(git log --pretty=format:"%an" -n1)
-    npm run deploy -- -x -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+    npm run --silent deploy -- -x -r $GH_PAGES_REPO
   fi

--- a/README.md
+++ b/README.md
@@ -111,5 +111,17 @@ npm test
 npm run coverage
 ```
 
+## Publishing to GitHub Pages
+```bash
+npm run deploy
+```
+
+This will push the currently built playground to the gh-pages branch of the
+currently tracked remote.  If you would like to change where to push to, add
+a repo url argument:
+```bash
+npm run deploy -- -r <your repo url>
+```
+
 ## Donate
 We provide [Scratch](https://scratch.mit.edu) free of charge, and want to keep it that way! Please consider making a [donation](https://secure.donationpay.org/scratchfoundation/) to support our continued engineering, design, community, and resource development efforts. Donations of any size are appreciated. Thank you!


### PR DESCRIPTION
On Travis, this is a secure string, so shouldn't be output.

Also add docs for the deploy script.
