### PR TITLE
Drop single-stepping and pause modes

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -19,14 +19,7 @@
             Turbo: <input id='turbomode' type='checkbox' />
         </div>
         <div>
-            Pause: <input id='pausemode' type='checkbox' />
-        </div>
-        <div>
             Compatibility (30 TPS):  <input id='compatmode' type='checkbox' />
-        </div>
-        <div>
-            Single stepping:  <input id='singlestepmode' type='checkbox' />
-            <input id='singlestepspeed' type='range' min='1' max='20' value='10' />
         </div>
         <br />
         <ul id="playgroundLinks">

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -249,26 +249,11 @@ window.onload = function() {
         var turboOn = document.getElementById('turbomode').checked;
         vm.setTurboMode(turboOn);
     });
-    document.getElementById('pausemode').addEventListener('change', function() {
-        var pauseOn = document.getElementById('pausemode').checked;
-        vm.setPauseMode(pauseOn);
-    });
     document.getElementById('compatmode').addEventListener('change',
     function() {
         var compatibilityMode = document.getElementById('compatmode').checked;
         vm.setCompatibilityMode(compatibilityMode);
     });
-    document.getElementById('singlestepmode').addEventListener('change',
-    function() {
-        var singleStep = document.getElementById('singlestepmode').checked;
-        vm.setSingleSteppingMode(singleStep);
-    });
-    document.getElementById('singlestepspeed').addEventListener('input',
-    function() {
-        var speed = document.getElementById('singlestepspeed').value;
-        vm.setSingleSteppingSpeed(speed);
-    });
-
     var tabBlockExplorer = document.getElementById('tab-blockexplorer');
     var tabThreadExplorer = document.getElementById('tab-threadexplorer');
     var tabRenderExplorer = document.getElementById('tab-renderexplorer');

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -70,13 +70,6 @@ Sequencer.prototype.stepThreads = function () {
                 activeThread.warpTimer = null;
             }
             if (activeThread.status === Thread.STATUS_RUNNING) {
-                // After stepping, status is still running.
-                // If we're in single-stepping mode, mark the thread as
-                // a single-tick yield so it doesn't re-execute
-                // until the next frame.
-                if (this.runtime.singleStepping) {
-                    activeThread.status = Thread.STATUS_YIELD_TICK;
-                }
                 numActiveThreads++;
             }
         }
@@ -168,11 +161,6 @@ Sequencer.prototype.stepThread = function (thread) {
             }
             // Get next block of existing block on the stack.
             thread.goToNextBlock();
-        }
-        // In single-stepping mode, force `stepThread` to only run one block
-        // at a time.
-        if (this.runtime.singleStepping) {
-            return;
         }
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -76,15 +76,6 @@ VirtualMachine.prototype.setTurboMode = function (turboModeOn) {
 };
 
 /**
- * Set whether the VM is in "pause mode."
- * When true, nothing is stepped.
- * @param {Boolean} pauseModeOn Whether pause mode should be set.
- */
-VirtualMachine.prototype.setPauseMode = function (pauseModeOn) {
-    this.runtime.setPauseMode(!!pauseModeOn);
-};
-
-/**
  * Set whether the VM is in 2.0 "compatibility mode."
  * When true, ticks go at 2.0 speed (30 TPS).
  * @param {Boolean} compatibilityModeOn Whether compatibility mode is set.
@@ -92,26 +83,6 @@ VirtualMachine.prototype.setPauseMode = function (pauseModeOn) {
 VirtualMachine.prototype.setCompatibilityMode = function (compatibilityModeOn) {
     this.runtime.setCompatibilityMode(!!compatibilityModeOn);
 };
-
-/**
- * Set whether the VM is in "single stepping mode."
- * When true, blocks execute slowly and are highlighted visually.
- * @param {Boolean} singleSteppingOn Whether single-stepping mode is set.
- */
-VirtualMachine.prototype.setSingleSteppingMode = function (singleSteppingOn) {
-    this.runtime.setSingleSteppingMode(!!singleSteppingOn);
-};
-
-
-/**
- * Set single-stepping mode speed.
- * When in single-stepping mode, adjusts the speed of execution.
- * @param {Number} speed Interval length in ms.
- */
-VirtualMachine.prototype.setSingleSteppingSpeed = function (speed) {
-    this.runtime.setSingleSteppingSpeed(speed);
-};
-
 
 /**
  * Stop all threads and running activities.


### PR DESCRIPTION
After a design discussion yesterday, it seems that both of these would need to be reimplemented in a different way. Also, I realized that this implementation doesn't match Scratch 1.0 single-stepping. In that implementation, execution proceeds to step through threads in the same order it would in normal mode. But, in this implementation, it allows all threads to be stepped in a single stepThreads, which actually changes the execution behavior. If we want a correct implementation, it would need to be redone.
