### PR TITLE
Divide rotation center by bitmap resolution

### DIFF
--- a/src/sprites/clone.js
+++ b/src/sprites/clone.js
@@ -306,7 +306,10 @@ Clone.prototype.setCostume = function (index) {
         this.renderer.updateDrawableProperties(this.drawableID, {
             skin: costume.skin,
             costumeResolution: costume.bitmapResolution,
-            rotationCenter: [costume.rotationCenterX, costume.rotationCenterY]
+            rotationCenter: [
+                costume.rotationCenterX / costume.bitmapResolution,
+                costume.rotationCenterY / costume.bitmapResolution
+            ]
         });
         if (this.visible) {
             this.runtime.requestRedraw();
@@ -367,7 +370,10 @@ Clone.prototype.updateAllDrawableProperties = function () {
             visible: this.visible,
             skin: costume.skin,
             costumeResolution: costume.bitmapResolution,
-            rotationCenter: [costume.rotationCenterX, costume.rotationCenterY]
+            rotationCenter: [
+                costume.rotationCenterX / costume.bitmapResolution,
+                costume.rotationCenterY / costume.bitmapResolution
+            ]
         });
         if (this.visible) {
             this.runtime.requestRedraw();


### PR DESCRIPTION
I noticed the values were doubled when bmp resolution = 2. This seems to fix a lot of projects (+ SVG quirk mode).
