### PR TITLE
Remove rAF usage and inline into _step

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -231,9 +231,7 @@ window.onload = function() {
 
     // Inform VM of animation frames.
     var animate = function() {
-        stats.end();
-        stats.begin();
-        window.vm.animationFrame();
+        stats.update();
         requestAnimationFrame(animate);
     };
     requestAnimationFrame(animate);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -102,13 +102,6 @@ var Runtime = function () {
     this.compatibilityMode = false;
 
     /**
-     * How fast in ms "single stepping mode" should run, in ms.
-     * Can be updated dynamically.
-     * @type {!number}
-     */
-    this.singleStepInterval = 1000 / 10;
-
-    /**
      * A reference to the current runtime stepping interval, set
      * by a `setInterval`.
      * @type {!number}
@@ -534,6 +527,10 @@ Runtime.prototype._step = function () {
     this.redrawRequested = false;
     var inactiveThreads = this.sequencer.stepThreads();
     this._updateGlows(inactiveThreads);
+    if (this.renderer) {
+        // @todo: Only render when this.redrawRequested or clones rendered.
+        this.renderer.draw();
+    }
 };
 
 /**
@@ -730,23 +727,11 @@ Runtime.prototype.requestRedraw = function () {
 };
 
 /**
- * Handle an animation frame from the main thread.
- */
-Runtime.prototype.animationFrame = function () {
-    if (this.renderer) {
-        // @todo: Only render when this.redrawRequested or clones rendered.
-        this.renderer.draw();
-    }
-};
-
-/**
  * Set up timers to repeatedly step in a browser.
  */
 Runtime.prototype.start = function () {
     var interval = Runtime.THREAD_STEP_INTERVAL;
-    if (this.singleStepping) {
-        interval = this.singleStepInterval;
-    } else if (this.compatibilityMode) {
+    if (this.compatibilityMode) {
         interval = Runtime.THREAD_STEP_INTERVAL_COMPATIBILITY;
     }
     this.currentStepTime = interval;

--- a/src/index.js
+++ b/src/index.js
@@ -121,13 +121,6 @@ VirtualMachine.prototype.getPlaygroundData = function () {
 };
 
 /**
- * Handle an animation frame.
- */
-VirtualMachine.prototype.animationFrame = function () {
-    this.runtime.animationFrame();
-};
-
-/**
  * Post I/O data to the virtual devices.
  * @param {?string} device Name of virtual I/O device.
  * @param {Object} data Any data object to post to the I/O device.


### PR DESCRIPTION
Here I remove our usage of `requestAnimationFrame` for drawing and replacing it with a call to the renderer inlined into the `_step` function, which is called by `setInterval`.

This seems to me to address the choppiness issue raised in #208.
