### PR TITLE
Keep min and max scale in relative bounds as in Scratch 2.0

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -249,9 +249,18 @@ RenderedTarget.prototype.setSize = function (size) {
     if (this.isStage) {
         return;
     }
-    // Keep size between 5% and 535%.
-    this.size = MathUtil.clamp(size, 5, 535);
     if (this.renderer) {
+        // Clamp to scales relative to costume and stage size.
+        // See original ScratchSprite.as:setSize.
+        var costumeSize = this.renderer.getSkinSize(this.drawableID);
+        var origW = Math.round(costumeSize[0]);
+        var origH = Math.round(costumeSize[1]);
+        var minScale = Math.min(1, Math.max(5 / origW, 5 / origH));
+        var maxScale = Math.min(
+            (1.5 * this.runtime.constructor.STAGE_WIDTH) / origW,
+            (1.5 * this.runtime.constructor.STAGE_HEIGHT) / origH
+        );
+        this.size = Math.round(MathUtil.clamp(size / 100, minScale, maxScale) * 100);
         var renderedDirectionScale = this._getRenderedDirectionAndScale();
         this.renderer.updateDrawableProperties(this.drawableID, {
             direction: renderedDirectionScale.direction,


### PR DESCRIPTION
Use the formula from scratch-flash for calculating the min and max scale for a sprite. Resolves #255. Note that the min and max still don't always match 2.0, because `renderer.getSkinSize` doesn't always report the same width and height that 2.0 is calculating. That is possibly a rendering bug....