### PR TITLE
Fix dev port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ StartServerWindows.bat
 ```
 
 ## Playground
-To run the Playground, make sure the dev server's running and go to [http://localhost:8080/](http://localhost:8080/) - you will be directed to the playground, which demonstrates various tools and internal state.
+To run the Playground, make sure the dev server's running and go to [http://localhost:8073/](http://localhost:8073/) - you will be directed to the playground, which demonstrates various tools and internal state.
 
 ![VM Playground Screenshot](https://i.imgur.com/nOCNqEc.gif)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ var webpack = require('webpack');
 var base = {
     devServer: {
         contentBase: path.resolve(__dirname, 'playground'),
-        host: '0.0.0.0'
+        host: '0.0.0.0',
+        port: process.env.PORT || 8073
     },
     module: {
         loaders: [


### PR DESCRIPTION
### Proposed changes

Update the dev port number from 8080 to 8073

### Reason for changes

scratch-www: 8333
scratch-api: 8491
scratch-gui: 8601

Clearly the port should be 8073 for scratch-vm.

Also because 8080 is one of the ports already used by scratchr2, so this will avoid conflicts if that is already running (which it frequently is for some of us).