### PR TITLE
Report costume data in sprite info reports and targetsUpdate

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -121,13 +121,13 @@ window.onload = function() {
         // Generate new select box.
         for (var i = 0; i < data.targetList.length; i++) {
             var targetOption = document.createElement('option');
-            targetOption.setAttribute('value', data.targetList[i][0]);
+            targetOption.setAttribute('value', data.targetList[i].id);
             // If target id matches editingTarget id, select it.
-            if (data.targetList[i][0] == data.editingTarget) {
+            if (data.targetList[i].id == data.editingTarget) {
                 targetOption.setAttribute('selected', 'selected');
             }
             targetOption.appendChild(
-                document.createTextNode(data.targetList[i][1])
+                document.createTextNode(data.targetList[i].name)
             );
             selectedTarget.appendChild(targetOption);
         }

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -154,6 +154,7 @@ window.onload = function() {
     });
 
     vm.on('SPRITE_INFO_REPORT', function(data) {
+        if (data.id !== selectedTarget.value) return; // Not the editingTarget
         document.getElementById('sinfo-x').value = data.x;
         document.getElementById('sinfo-y').value = data.y;
         document.getElementById('sinfo-direction').value = data.direction;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -734,6 +734,7 @@ Runtime.prototype.spriteInfoReport = function (target) {
         x: target.x,
         y: target.y,
         direction: target.direction,
+        costume: target.getCurrentCostume(),
         visible: target.visible,
         rotationStyle: target.rotationStyle
     });

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -729,15 +729,7 @@ Runtime.prototype.visualReport = function (blockId, value) {
 Runtime.prototype.spriteInfoReport = function (target) {
     if (!target.isOriginal) return;
 
-    this.emit(Runtime.SPRITE_INFO_REPORT, {
-        id: target.id,
-        x: target.x,
-        y: target.y,
-        direction: target.direction,
-        costume: target.getCurrentCostume(),
-        visible: target.visible,
-        rotationStyle: target.rotationStyle
-    });
+    this.emit(Runtime.SPRITE_INFO_REPORT, target.toJSON());
 };
 
 /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -723,14 +723,14 @@ Runtime.prototype.visualReport = function (blockId, value) {
 };
 
 /**
- * Emit a sprite info report if the provided target is the editing target.
+ * Emit a sprite info report if the provided target is the original sprite
  * @param {!Target} target Target to report sprite info for.
  */
 Runtime.prototype.spriteInfoReport = function (target) {
-    if (target !== this._editingTarget) {
-        return;
-    }
+    if (!target.isOriginal) return;
+
     this.emit(Runtime.SPRITE_INFO_REPORT, {
+        id: target.id,
         x: target.x,
         y: target.y,
         direction: target.direction,

--- a/src/index.js
+++ b/src/index.js
@@ -304,7 +304,7 @@ VirtualMachine.prototype.emitTargetsUpdate = function () {
             // Don't report clones.
             return !target.hasOwnProperty('isOriginal') || target.isOriginal;
         }).map(function (target) {
-            return [target.id, target.getName()];
+            return target.toJSON();
         }),
         // Currently editing target id.
         editingTarget: this.editingTarget ? this.editingTarget.id : null

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -380,6 +380,14 @@ RenderedTarget.prototype.getCurrentCostume = function () {
 };
 
 /**
+ * Get full costume list
+ * @return {object[]} list of costumes
+ */
+RenderedTarget.prototype.getCostumes = function () {
+    return this.sprite.costumes;
+};
+
+/**
  * Update all drawable properties for this rendered target.
  * Use when a batch has changed, e.g., when the drawable is first created.
  */
@@ -652,6 +660,25 @@ RenderedTarget.prototype.postSpriteInfo = function (data) {
     if (data.hasOwnProperty('visible')) {
         this.setVisible(data.visible);
     }
+};
+
+/**
+ * Serialize sprite info, used when emitting events about the sprite
+ * @returns {object} sprite data as a simple object
+ */
+RenderedTarget.prototype.toJSON = function () {
+    return {
+        id: this.id,
+        name: this.getName(),
+        isStage: this.isStage,
+        x: this.x,
+        y: this.y,
+        direction: this.direction,
+        costume: this.getCurrentCostume(),
+        costumeCount: this.getCostumes().length,
+        visible: this.visible,
+        rotationStyle: this.rotationStyle
+    };
 };
 
 /**

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -329,6 +329,7 @@ RenderedTarget.prototype.setCostume = function (index) {
             this.runtime.requestRedraw();
         }
     }
+    this.runtime.spriteInfoReport(this);
 };
 
 /**
@@ -368,6 +369,14 @@ RenderedTarget.prototype.getCostumeIndexByName = function (costumeName) {
         }
     }
     return -1;
+};
+
+/**
+ * Get a costume of this rendered target by id.
+ * @return {object} current costume
+ */
+RenderedTarget.prototype.getCurrentCostume = function () {
+    return this.sprite.costumes[this.currentCostume];
 };
 
 /**


### PR DESCRIPTION
* Unify the data reported for each target in `targetsUpdate` and `SPRITE_INFO_REPORT`. Previously the client needed to merge `SPRITE_INFO_REPORT` data with `targetsUpdate` data on the initial project load to have the full state of each target. This way the client can simply use what is in the initial `targetsUpdate`.
* Emit sprite info report whenever any sprite changes, so that the sprite list can display current sprite data for all sprites, not just the currently edited sprite.
* Include current costume data in sprite info, so the GUI can display the current costume/backdrop in the sprite list.

For https://github.com/LLK/scratch-gui/issues/14
Required by LLK/scratch-gui#25