### PR TITLE
Fix "stable" specifier for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '4'
-- stable
+- "4"
+- "node"
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
This shorthand has become unrecognized, so match the docs suggestion of "node" for the most recent stable release.