### PR TITLE
give external blocks a chance to load into vm without modify the defaultBlockPackages

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -231,10 +231,11 @@ Runtime.MAX_CLONES = 300;
 /**
  * Register default block packages with this runtime.
  * @todo Prefix opcodes with package name.
+ * @param {!string} packageToLoad The package to be loaded, if null load the defaultBlockPackages
  * @private
  */
 Runtime.prototype._registerBlockPackages = function (packageToLoad) {
-    if(packageToLoad==null){
+    if (packageToLoad === null){
         packageToLoad = defaultBlockPackages;
     }
     for (var packageName in packageToLoad) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -233,11 +233,14 @@ Runtime.MAX_CLONES = 300;
  * @todo Prefix opcodes with package name.
  * @private
  */
-Runtime.prototype._registerBlockPackages = function () {
-    for (var packageName in defaultBlockPackages) {
-        if (defaultBlockPackages.hasOwnProperty(packageName)) {
+Runtime.prototype._registerBlockPackages = function (packageToLoad) {
+    if(packageToLoad==null){
+        packageToLoad = defaultBlockPackages;
+    }
+    for (var packageName in packageToLoad) {
+        if (packageToLoad.hasOwnProperty(packageName)) {
             // @todo pass a different runtime depending on package privilege?
-            var packageObject = new (defaultBlockPackages[packageName])(this);
+            var packageObject = new (packageToLoad[packageName])(this);
             // Collect primitives from package.
             if (packageObject.getPrimitives) {
                 var packagePrimitives = packageObject.getPrimitives();


### PR DESCRIPTION

### Proposed changes

give external blocks a chance to load into vm without modify the defaultBlockPackages setup.

### Reason for changes

User don't have to add primitive source code to scratch-vm\src\blocks when apply a custom block.
For example: 
```javascript
var runtime = this.props.vm.runtime;

var pluginPackage = {
       "pluginName":pluginmodule
};
runtime._registerBlockPackages(pluginPackage);
```
