### PR TITLE
Removed reference to `StartServerWindows.bat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ Open a Command Prompt or Terminal in the repository and run:
 ```bash
 npm start
 ```
-Or on Windows:
-```bash
-StartServerWindows.bat
-```
 
 ## Playground
 To run the Playground, make sure the dev server's running and go to [http://localhost:8073/](http://localhost:8073/) - you will be directed to the playground, which demonstrates various tools and internal state.


### PR DESCRIPTION
### Proposed changes

Removes `README.md` reference to since-deleted `StartServerWindows.bat`.

### Reason for changes

This file was removed in PR #276, which also made the `npm start` instructions work on Windows.
