### PR TITLE
Fix adding SVG costumes

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -329,13 +329,17 @@ RenderedTarget.prototype.setCostume = function (index) {
     );
     if (this.renderer) {
         var costume = this.sprite.costumes[this.currentCostume];
+        var rotationCenter = costume.bitmapResolution ? [
+            costume.rotationCenterX / costume.bitmapResolution,
+            costume.rotationCenterY / costume.bitmapResolution
+        ] : [
+            costume.rotationCenterX,
+            costume.rotationCenterY
+        ];
         this.renderer.updateDrawableProperties(this.drawableID, {
             skin: costume.skin,
             costumeResolution: costume.bitmapResolution,
-            rotationCenter: [
-                costume.rotationCenterX / costume.bitmapResolution,
-                costume.rotationCenterY / costume.bitmapResolution
-            ]
+            rotationCenter: rotationCenter
         });
         if (this.visible) {
             this.runtime.requestRedraw();


### PR DESCRIPTION
Previously `setCostume` assumed every costume to have a `bitmapResolution` property which doesn't apply to SVG costumes. This caused the renderer to not render added SVG costumes on `setCostume`.

Thanks to @cwillisf for stepping through the issue with me.