### PR TITLE
Runtime does not exit warp mode if at end of loop #398

### DIFF
--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -131,12 +131,17 @@ Sequencer.prototype.stepThread = function (thread) {
         // If no next block has been found at this point, look on the stack.
         while (!thread.peekStack()) {
             thread.popStack();
+
             if (thread.stack.length === 0) {
                 // No more stack to run!
                 thread.status = Thread.STATUS_DONE;
                 return;
             }
-            if (thread.peekStackFrame().isLoop) {
+			
+			var stackFrame = thread.peekStackFrame();
+	        isWarpMode = stackFrame.warpMode;
+
+            if (stackFrame.isLoop) {
                 // The current level of the stack is marked as a loop.
                 // Return to yield for the frame/tick in general.
                 // Unless we're in warp mode - then only return if the
@@ -151,7 +156,7 @@ Sequencer.prototype.stepThread = function (thread) {
                     // since loops need to be re-executed.
                     continue;
                 }
-            } else if (thread.peekStackFrame().waitingReporter) {
+            } else if (stackFrame.waitingReporter) {
                 // This level of the stack was waiting for a value.
                 // This means a reporter has just returned - so don't go
                 // to the next block for this level of the stack.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -137,9 +137,9 @@ Sequencer.prototype.stepThread = function (thread) {
                 thread.status = Thread.STATUS_DONE;
                 return;
             }
-			
-			var stackFrame = thread.peekStackFrame();
-	        isWarpMode = stackFrame.warpMode;
+
+            var stackFrame = thread.peekStackFrame();
+            isWarpMode = stackFrame.warpMode;
 
             if (stackFrame.isLoop) {
                 // The current level of the stack is marked as a loop.


### PR DESCRIPTION
When popping down the stack frame it is assumed that you keep using the previous warp state rather than looking at the warp state of the level you just popped out to. This causes the loss of screen updates if the warping block was the last statement in a loop as the loop does not obey it's 'non warp' status.