### PR TITLE
Bugfix - Continue import if opcode is not found during SB2 import

### DIFF
--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -193,6 +193,7 @@ var parseBlockList = function (blockList) {
     for (var i = 0; i < blockList.length; i++) {
         var block = blockList[i];
         var parsedBlock = parseBlock(block);
+        if (typeof parsedBlock === 'undefined') continue;
         if (previousBlock) {
             parsedBlock.parent = previousBlock.id;
             previousBlock.next = parsedBlock.id;


### PR DESCRIPTION
### Resolves

GH-413

### Proposed Changes

Checks `parsedBlock` to ensure it is defined before pushing it into the block list. This prevents undefined or unimplemented opcodes (such as `remark: %s`) from throwing a fatal exceptions during import.