### PR TITLE
Bug pen opacity reset

### DIFF
--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -147,6 +147,7 @@ Scratch3PenBlocks.prototype._updatePenColor = function (penState) {
     penState.penAttributes.color4f[0] = rgb.r / 255.0;
     penState.penAttributes.color4f[1] = rgb.g / 255.0;
     penState.penAttributes.color4f[2] = rgb.b / 255.0;
+    penState.penAttributes.color4f[3] = 1;
 };
 
 /**
@@ -260,6 +261,8 @@ Scratch3PenBlocks.prototype.setPenColorToColor = function (args, util) {
     penState.penAttributes.color4f[2] = rgb.b / 255.0;
     if (rgb.hasOwnProperty('a')) {  // Will there always be an 'a'?
         penState.penAttributes.color4f[3] = rgb.a / 255.0;
+    } else {
+        penState.penAttributes.color4f[3] = 1;
     }
 };
 


### PR DESCRIPTION
Pen opacity must be returned to fully opaque when no color alpha is supplied.