### PR TITLE
Pass volume to audioengine playnote

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -135,8 +135,9 @@ Scratch3SoundBlocks.prototype.playNoteForBeats = function (args, util) {
     var beats = Cast.toNumber(args.BEATS);
     var soundState = this._getSoundState(util.target);
     var inst = soundState.currentInstrument;
+    var vol = soundState.volume;
     if (typeof this.runtime.audioEngine === 'undefined') return;
-    return this.runtime.audioEngine.playNoteForBeatsWithInst(note, beats, inst);
+    return this.runtime.audioEngine.playNoteForBeatsWithInstAndVol(note, beats, inst, vol);
 };
 
 Scratch3SoundBlocks.prototype.playDrumForBeats = function (args, util) {


### PR DESCRIPTION
### Resolves

Addresses https://github.com/LLK/scratch-vm/issues/404

Depends on PR to scratch-audio https://github.com/LLK/scratch-audio/pull/26

### Proposed Changes

Pass the volume from the vm in the call to the audio engine to play the note.

### Reason for Changes

This is a way to set the volume of the notes played by the play note block. The current InstrumentPlayer approach will be replaced, but this is a workaround for one of its limitations, which is that it cannot be easily connected to the effects chain for an AudioPlayer, which would control its volume.