### PR TITLE
Switch From Return Null to Return Empty String in keyCodeToScratchKey

### DIFF
--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -56,7 +56,7 @@ Keyboard.prototype._keyCodeToScratchKey = function (keyCode) {
     case 39: return 'right arrow';
     case 40: return 'down arrow';
     }
-    return null;
+    return '';
 };
 
 /**


### PR DESCRIPTION
### Resolves

Resolves #443 

### Proposed Changes

Return empty string instead of null.

### Reason for Changes

You can preform checks and actions on empty strings you can't on null, which was previously throwing errors -- but will still lead to exit.