### PR TITLE
Update playground paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm start
 ```
 
 ## Playground
-To run the Playground, make sure the dev server's running and go to [http://localhost:8073/](http://localhost:8073/) - you will be directed to the playground, which demonstrates various tools and internal state.
+To run the Playground, make sure the dev server's running and go to [http://localhost:8073/playground/](http://localhost:8073/playground/) - you will be directed to the playground, which demonstrates various tools and internal state.
 
 ![VM Playground Screenshot](https://i.imgur.com/nOCNqEc.gif)
 
@@ -50,7 +50,7 @@ npm run build
 ```
 
 ## How to include in a Node.js App
-For an extended setup example, check out the /playground directory, which includes a fully running VM instance.
+For an extended setup example, check out the /src/playground directory, which includes a fully running VM instance.
 ```js
 var VirtualMachine = require('scratch-vm');
 var vm = new VirtualMachine();


### PR DESCRIPTION
### Proposed Changes

Update README.md to reflect the new location for playground source files and the new URL used to access the playground through the dev server.

Note that we may change the URL back, pending further discussion (see https://github.com/LLK/scratch-vm/pull/451#discussion_r100648211). For now, though, this change brings the README back in sync with the actual configuration.

### Reason for Changes

A recent change (#451) moved the playground source files and changed the URL but did not update README.md to reflect these changes.

Thanks, @picklesrus, for bringing this to my attention!

### Test Coverage

No changes to test coverage.
