### PR TITLE
Provide method for filtering toolbox XML

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gh-pages": "^0.12.0",
     "highlightjs": "^9.8.0",
     "htmlparser2": "3.9.2",
+    "jsdom": "^9.11.0",
     "json": "^9.0.4",
     "lodash.defaultsdeep": "4.6.0",
     "minilog": "3.1.0",

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -59,6 +59,11 @@ window.onload = function () {
     });
     window.workspace = workspace;
 
+    // Filter available blocks
+    var toolbox = vm.filterToolbox(workspace.options.languageTree);
+    // var toolbox = workspace.options.languageTree;
+    workspace.updateToolbox(toolbox);
+
     // Attach scratch-blocks events to VM.
     workspace.addChangeListener(vm.blockListener);
     var flyoutWorkspace = workspace.getFlyout().getWorkspace();

--- a/src/util/filter-toolbox.js
+++ b/src/util/filter-toolbox.js
@@ -1,0 +1,49 @@
+/**
+ * Filter Blockly toolbox XML node containing blocks to only those with
+ * valid opcodes. Return a copy of the node with valid blocks.
+ * @param {HTMLElement} node Blockly toolbox XML node
+ * @param {Array.<string>} opcodes Valid opcodes. Blocks producing other opcodes
+ * will be filtered.
+ * @returns {HTMLElement} filtered toolbox XML node
+ */
+var filterToolboxNode = function (node, opcodes) {
+    var filteredCategory = node.cloneNode();
+    for (var block = node.firstElementChild; block; block = block.nextElementSibling) {
+        if (block.nodeName.toLowerCase() !== 'block') continue;
+        var opcode = block.getAttribute('type').toLowerCase();
+        if (opcodes.indexOf(opcode) !== -1) {
+            filteredCategory.appendChild(block.cloneNode(true));
+        }
+    }
+    return filteredCategory;
+};
+
+/**
+ * Filter Blockly toolbox XML and return a copy which only contains blocks with
+ * existent opcodes. Categories with no valid children will be removed.
+ * @param {HTMLElement} toolbox Blockly toolbox XML node
+ * @param {Array.<string>} opcodes Valid opcodes. Blocks producing other opcodes
+ * will be filtered.
+ * @returns {HTMLElement} filtered toolbox XML node
+ */
+var filterToolbox = function (toolbox, opcodes) {
+    if (!toolbox.hasChildNodes()) return toolbox;
+    var filteredToolbox;
+    if (toolbox.firstElementChild.nodeName.toLowerCase() === 'category') {
+        filteredToolbox = toolbox.cloneNode();
+        for (
+            var category = toolbox.firstElementChild;
+            category;
+            category = category.nextElementSibling
+        ) {
+            if (category.nodeName.toLowerCase() !== 'category') continue;
+            var filteredCategory = filterToolboxNode(category, opcodes);
+            if (filteredCategory.hasChildNodes()) filteredToolbox.appendChild(filteredCategory);
+        }
+    } else {
+        filteredToolbox = filterToolboxNode(toolbox, opcodes);
+    }
+    return filteredToolbox;
+};
+
+module.exports = filterToolbox;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -336,4 +336,23 @@ VirtualMachine.prototype.postSpriteInfo = function (data) {
     this.editingTarget.postSpriteInfo(data);
 };
 
+VirtualMachine.prototype.filterToolbox = function (toolboxDOM) {
+    var filteredToolbox = toolboxDOM.cloneNode();
+    var category = toolboxDOM.firstElementChild;
+    while (category) {
+        var filteredCategory = category.cloneNode();
+        var block = category.firstElementChild;
+        while (block) {
+            var opcode = block.getAttribute('type');
+            if (opcode in this.runtime._primitives || opcode in this.runtime._hats) {
+                filteredCategory.appendChild(block.cloneNode(true));
+            }
+            block = block.nextElementSibling;
+        }
+        if (filteredCategory.hasChildNodes()) filteredToolbox.appendChild(filteredCategory);
+        category = category.nextElementSibling;
+    }
+    return filteredToolbox;
+};
+
 module.exports = VirtualMachine;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1,6 +1,7 @@
 var EventEmitter = require('events');
 var util = require('util');
 
+var filterToolbox = require('./util/filter-toolbox');
 var Runtime = require('./engine/runtime');
 var sb2import = require('./import/sb2import');
 
@@ -336,23 +337,17 @@ VirtualMachine.prototype.postSpriteInfo = function (data) {
     this.editingTarget.postSpriteInfo(data);
 };
 
-VirtualMachine.prototype.filterToolbox = function (toolboxDOM) {
-    var filteredToolbox = toolboxDOM.cloneNode();
-    var category = toolboxDOM.firstElementChild;
-    while (category) {
-        var filteredCategory = category.cloneNode();
-        var block = category.firstElementChild;
-        while (block) {
-            var opcode = block.getAttribute('type');
-            if (opcode in this.runtime._primitives || opcode in this.runtime._hats) {
-                filteredCategory.appendChild(block.cloneNode(true));
-            }
-            block = block.nextElementSibling;
-        }
-        if (filteredCategory.hasChildNodes()) filteredToolbox.appendChild(filteredCategory);
-        category = category.nextElementSibling;
-    }
-    return filteredToolbox;
+
+/**
+ * Filter Blockly toolbox XML and return a copy which only contains blocks with
+ * existent opcodes. Categories with no valid children will be removed.
+ * @param {HTMLElement} toolbox Blockly toolbox XML node
+ * @returns {HTMLElement} filtered toolbox XML node
+ */
+VirtualMachine.prototype.filterToolbox = function (toolbox) {
+    var opcodes = Object.keys(this.runtime._primitives)
+        .concat(Object.keys(this.runtime._hats));
+    return filterToolbox(toolbox, opcodes);
 };
 
 module.exports = VirtualMachine;

--- a/test/fixtures/.eslintrc.js
+++ b/test/fixtures/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        'max-len': [0]
+    }
+};

--- a/test/fixtures/toolboxes.js
+++ b/test/fixtures/toolboxes.js
@@ -1,0 +1,845 @@
+var jsdom = require('jsdom').jsdom;
+var categories = '<xml id="toolbox-categories" style="display: none">' +
+  '<category name="Motion" colour="#4C97FF" secondaryColour="#3373CC">' +
+    '<block type="motion_movesteps">' +
+      '<value name="STEPS">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_turnright">' +
+      '<value name="DEGREES">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">15</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_turnleft">' +
+      '<value name="DEGREES">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">15</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_pointindirection">' +
+      '<value name="DIRECTION">' +
+        '<shadow type="math_angle">' +
+          '<field name="NUM">90</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_pointtowards">' +
+      '<value name="TOWARDS">' +
+        '<shadow type="motion_pointtowards_menu">' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_gotoxy">' +
+      '<value name="X">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="Y">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_goto">' +
+      '<value name="TO">' +
+        '<shadow type="motion_goto_menu">' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_glidesecstoxy">' +
+      '<value name="SECS">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="X">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="Y">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_changexby">' +
+      '<value name="DX">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_setx">' +
+      '<value name="X">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_changeyby">' +
+      '<value name="DY">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_sety">' +
+      '<value name="Y">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_ifonedgebounce"></block>' +
+    '<block type="motion_setrotationstyle">' +
+      '<value name="STYLE">' +
+        '<shadow type="motion_setrotationstyle_menu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="motion_xposition"></block>' +
+    '<block type="motion_yposition"></block>' +
+    '<block type="motion_direction"></block>' +
+  '</category>' +
+  '<category name="Looks" colour="#9966FF" secondaryColour="#774DCB">' +
+    '<block type="looks_sayforsecs">' +
+      '<value name="MESSAGE">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">Hello!</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="SECS">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">2</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_say">' +
+      '<value name="MESSAGE">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">Hello!</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_thinkforsecs">' +
+      '<value name="MESSAGE">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">Hmm...</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="SECS">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">2</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_think">' +
+      '<value name="MESSAGE">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">Hmm...</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_show"></block>' +
+    '<block type="looks_hide"></block>' +
+    '<block type="looks_switchcostumeto">' +
+      '<value name="COSTUME">' +
+        '<shadow type="looks_costume"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_nextcostume"></block>' +
+    '<block type="looks_nextbackdrop"></block>' +
+    '<block type="looks_switchbackdropto">' +
+      '<value name="BACKDROP">' +
+        '<shadow type="looks_backdrops"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_switchbackdroptoandwait">' +
+      '<value name="BACKDROP">' +
+        '<shadow type="looks_backdrops"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_changeeffectby">' +
+      '<value name="EFFECT">' +
+        '<shadow type="looks_effectmenu"></shadow>' +
+      '</value>' +
+      '<value name="CHANGE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_seteffectto">' +
+      '<value name="EFFECT">' +
+        '<shadow type="looks_effectmenu"></shadow>' +
+      '</value>' +
+      '<value name="VALUE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_cleargraphiceffects"></block>' +
+    '<block type="looks_changesizeby">' +
+      '<value name="CHANGE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_setsizeto">' +
+      '<value name="SIZE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">100</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_gotofront"></block>' +
+    '<block type="looks_gobacklayers">' +
+      '<value name="NUM">' +
+        '<shadow type="math_integer">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="looks_costumeorder"></block>' +
+    '<block type="looks_backdroporder"></block>' +
+    '<block type="looks_backdropname"></block>' +
+    '<block type="looks_size"></block>' +
+  '</category>' +
+  '<category name="Sound" colour="#D65CD6" secondaryColour="#BD42BD">' +
+    '<block type="sound_play">' +
+      '<value name="SOUND_MENU">' +
+        '<shadow type="sound_sounds_menu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_playuntildone">' +
+      '<value name="SOUND_MENU">' +
+        '<shadow type="sound_sounds_menu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_stopallsounds"></block>' +
+    '<block type="sound_playdrumforbeats">' +
+      '<value name="DRUM">' +
+        '<shadow type="sound_drums_menu"></shadow>' +
+      '</value>' +
+      '<value name="BEATS">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0.25</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_restforbeats">' +
+      '<value name="BEATS">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0.25</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_playnoteforbeats">' +
+      '<value name="NOTE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">60</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="BEATS">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0.5</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_setinstrumentto">' +
+      '<value name="INSTRUMENT">' +
+        '<shadow type="sound_instruments_menu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_seteffectto">' +
+      '<value name="EFFECT">' +
+        '<shadow type="sound_effects_menu"></shadow>' +
+      '</value>' +
+      '<value name="VALUE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">100</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_changeeffectby">' +
+      '<value name="EFFECT">' +
+        '<shadow type="sound_effects_menu"></shadow>' +
+      '</value>' +
+      '<value name="VALUE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_cleareffects"></block>' +
+    '<block type="sound_changevolumeby">' +
+      '<value name="VOLUME">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">-10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_setvolumeto">' +
+      '<value name="VOLUME">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">100</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_volume"></block>' +
+    '<block type="sound_changetempoby">' +
+      '<value name="TEMPO">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">20</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_settempotobpm">' +
+      '<value name="TEMPO">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">60</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sound_tempo"></block>' +
+  '</category>' +
+  '<category name="Pen" colour="#00B295" secondaryColour="#0B8E69">' +
+    '<block type="pen_clear"></block>' +
+    '<block type="pen_stamp"></block>' +
+    '<block type="pen_pendown"></block>' +
+    '<block type="pen_penup"></block>' +
+    '<block type="pen_setpencolortocolor">' +
+      '<value name="COLOR">' +
+        '<shadow type="colour_picker">' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="pen_changepencolorby">' +
+      '<value name="COLOR">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="pen_setpencolortonum">' +
+      '<value name="COLOR">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="pen_changepenshadeby">' +
+      '<value name="SHADE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="pen_setpenshadeto">' +
+      '<value name="SHADE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">50</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="pen_changepensizeby">' +
+      '<value name="SIZE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="pen_setpensizeto">' +
+      '<value name="SIZE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+  '</category>' +
+  '<category name="Data" colour="#FF8C1A" secondaryColour="#DB6E00" custom="VARIABLE">' +
+  '</category>' +
+  '<category name="Lists" colour="#FF8C1A" secondaryColour="#DB6E00">' +
+    '<block type="data_listcontents"></block>' +
+    '<block type="data_addtolist">' +
+      '<value name="ITEM">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">thing</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="data_deleteoflist">' +
+      '<value name="INDEX">' +
+        '<shadow type="data_listindexall">' +
+          '<field name="INDEX">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="data_insertatlist">' +
+      '<value name="INDEX">' +
+        '<shadow type="data_listindexrandom">' +
+          '<field name="INDEX">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="ITEM">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">thing</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="data_replaceitemoflist">' +
+      '<value name="INDEX">' +
+        '<shadow type="data_listindexrandom">' +
+          '<field name="INDEX">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="ITEM">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">thing</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="data_itemoflist">' +
+      '<value name="INDEX">' +
+        '<shadow type="data_listindexrandom">' +
+          '<field name="INDEX">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="data_lengthoflist"></block>' +
+    '<block type="data_listcontainsitem">' +
+      '<value name="ITEM">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">thing</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="data_showlist"></block>' +
+    '<block type="data_hidelist"></block>' +
+  '</category>' +
+  '<category name="Events" colour="#FFD500" secondaryColour="#CC9900">' +
+    '<block type="event_whenflagclicked"></block>' +
+    '<block type="event_whenkeypressed">' +
+    '</block>' +
+    '<block type="event_whenthisspriteclicked"></block>' +
+    '<block type="event_whenbackdropswitchesto">' +
+    '</block>' +
+    '<block type="event_whengreaterthan">' +
+      '<value name="VALUE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="event_whenbroadcastreceived">' +
+    '</block>' +
+    '<block type="event_broadcast">' +
+      '<value name="BROADCAST_OPTION">' +
+        '<shadow type="event_broadcast_menu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="event_broadcastandwait">' +
+      '<value name="BROADCAST_OPTION">' +
+        '<shadow type="event_broadcast_menu"></shadow>' +
+      '</value>' +
+    '</block>' +
+  '</category>' +
+  '<category name="Control" colour="#FFAB19" secondaryColour="#CF8B17">' +
+    '<block type="control_wait">' +
+      '<value name="DURATION">' +
+        '<shadow type="math_positive_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="control_repeat">' +
+      '<value name="TIMES">' +
+        '<shadow type="math_whole_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="control_forever"></block>' +
+    '<block type="control_if"></block>' +
+    '<block type="control_if_else"></block>' +
+    '<block type="control_wait_until"></block>' +
+    '<block type="control_repeat_until"></block>' +
+    '<block type="control_stop"></block>' +
+    '<block type="control_start_as_clone"></block>' +
+    '<block type="control_create_clone_of">' +
+      '<value name="CLONE_OPTION">' +
+        '<shadow type="control_create_clone_of_menu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="control_delete_this_clone"></block>' +
+  '</category>' +
+  '<category name="Sensing" colour="#4CBFE6" secondaryColour="#2E8EB8">' +
+    '<block type="sensing_touchingobject">' +
+      '<value name="TOUCHINGOBJECTMENU">' +
+        '<shadow type="sensing_touchingobjectmenu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sensing_touchingcolor">' +
+      '<value name="COLOR">' +
+        '<shadow type="colour_picker"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sensing_coloristouchingcolor">' +
+      '<value name="COLOR">' +
+        '<shadow type="colour_picker"></shadow>' +
+      '</value>' +
+      '<value name="COLOR2">' +
+        '<shadow type="colour_picker"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sensing_distanceto">' +
+      '<value name="DISTANCETOMENU">' +
+        '<shadow type="sensing_distancetomenu"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="sensing_askandwait">' +
+      '<value name="QUESTION">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">What\'s your name?</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+  '<block type="sensing_answer"></block>' +
+  '<block type="sensing_keypressed">' +
+      '<value name="KEY_OPTION">' +
+        '<shadow type="sensing_keyoptions"></shadow>' +
+      '</value>' +
+  '</block>' +
+  '<block type="sensing_mousedown"></block>' +
+  '<block type="sensing_mousex"></block>' +
+  '<block type="sensing_mousey"></block>' +
+  '<block type="sensing_loudness"></block>' +
+  '<block type="sensing_videoon">' +
+      '<value name="VIDEOONMENU1">' +
+        '<shadow type="sensing_videoonmenuone"></shadow>' +
+      '</value>' +
+      '<value name="VIDEOONMENU2">' +
+        '<shadow type="sensing_videoonmenutwo"></shadow>' +
+      '</value>' +
+  '</block>' +
+  '<block type="sensing_videotoggle">' +
+      '<value name="VIDEOTOGGLEMENU">' +
+        '<shadow type="sensing_videotogglemenu"></shadow>' +
+      '</value>' +
+  '</block>' +
+  '<block type="sensing_setvideotransparency">' +
+    '<value name="TRANSPARENCY">' +
+      '<shadow type="math_number">' +
+        '<field name="NUM">50</field>' +
+      '</shadow>' +
+    '</value>' +
+  '</block>' +
+  '<block type="sensing_timer"></block>' +
+  '<block type="sensing_resettimer"></block>' +
+  '<block type="sensing_of">' +
+    '<value name="PROPERTY">' +
+      '<shadow type="sensing_of_property_menu"></shadow>' +
+    '</value>' +
+    '<value name="OBJECT">' +
+      '<shadow type="sensing_of_object_menu"></shadow>' +
+    '</value>' +
+  '</block>' +
+  '<block type="sensing_current">' +
+    '<value name="CURRENTMENU">' +
+      '<shadow type="sensing_currentmenu"></shadow>' +
+    '</value>' +
+  '</block>' +
+  '<block type="sensing_dayssince2000"></block>' +
+  '<block type="sensing_username"></block>' +
+  '</category>' +
+  '<category name="Operators" colour="#40BF4A" secondaryColour="#389438">' +
+    '<block type="operator_add">' +
+      '<value name="NUM1">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="NUM2">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_subtract">' +
+      '<value name="NUM1">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="NUM2">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_multiply">' +
+      '<value name="NUM1">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="NUM2">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_divide">' +
+      '<value name="NUM1">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="NUM2">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_random">' +
+      '<value name="FROM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="TO">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_lt">' +
+      '<value name="OPERAND1">' +
+        '<shadow type="text">' +
+          '<field name="TEXT"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="OPERAND2">' +
+        '<shadow type="text">' +
+          '<field name="TEXT"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_equals">' +
+      '<value name="OPERAND1">' +
+        '<shadow type="text">' +
+          '<field name="TEXT"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="OPERAND2">' +
+        '<shadow type="text">' +
+          '<field name="TEXT"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_gt">' +
+      '<value name="OPERAND1">' +
+        '<shadow type="text">' +
+          '<field name="TEXT"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="OPERAND2">' +
+        '<shadow type="text">' +
+          '<field name="TEXT"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_and"></block>' +
+    '<block type="operator_or"></block>' +
+    '<block type="operator_not"></block>' +
+    '<block type="operator_join">' +
+      '<value name="STRING1">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">hello</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="STRING2">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">world</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_letter_of">' +
+      '<value name="LETTER">' +
+        '<shadow type="math_whole_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="STRING">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">world</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_length">' +
+      '<value name="STRING">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">world</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_mod">' +
+      '<value name="NUM1">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="NUM2">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_round">' +
+      '<value name="NUM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="operator_mathop">' +
+      '<value name="OPERATOR">' +
+        '<shadow type="operator_mathop_menu"></shadow>' +
+      '</value>' +
+      '<value name="NUM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+  '</category>' +
+  '<category name="More Blocks" colour="#FF6680" secondaryColour="#FF3355" custom="PROCEDURE"></category>' +
+  '</xml>';
+var simple = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?><xml id="toolbox-simple" style="display: none">' +
+    '  <block type="operator_random">' +
+    '    <value name="FROM">' +
+    '      <shadow type="math_number">' +
+    '        <field name="NUM">1</field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '    <value name="TO">' +
+    '      <shadow type="math_number">' +
+    '        <field name="NUM">10</field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_lt">' +
+    '    <value name="OPERAND1">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '    <value name="OPERAND2">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_equals">' +
+    '    <value name="OPERAND1">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '    <value name="OPERAND2">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_gt">' +
+    '    <value name="OPERAND1">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '    <value name="OPERAND2">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_and"></block>' +
+    '  <block type="operator_or"></block>' +
+    '  <block type="operator_not"></block>' +
+    '  <block type="operator_join">' +
+    '    <value name="STRING1">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT">hello</field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '    <value name="STRING2">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT">world</field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_letter_of">' +
+    '    <value name="LETTER">' +
+    '      <shadow type="math_whole_number">' +
+    '        <field name="NUM">1</field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '    <value name="STRING">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT">world</field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_length">' +
+    '    <value name="STRING">' +
+    '      <shadow type="text">' +
+    '        <field name="TEXT">world</field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_mod">' +
+    '    <value name="NUM1">' +
+    '      <shadow type="math_number">' +
+    '        <field name="NUM"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '    <value name="NUM2">' +
+    '      <shadow type="math_number">' +
+    '        <field name="NUM"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_round">' +
+    '    <value name="NUM">' +
+    '      <shadow type="math_number">' +
+    '        <field name="NUM"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '  <block type="operator_mathop">' +
+    '    <value name="OPERATOR">' +
+    '      <shadow type="operator_mathop_menu"></shadow>' +
+    '    </value>' +
+    '    <value name="NUM">' +
+    '      <shadow type="math_number">' +
+    '        <field name="NUM"></field>' +
+    '      </shadow>' +
+    '    </value>' +
+    '  </block>' +
+    '</xml>';
+var empty = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?><xml id="toolbox-simple" style="display: none"></xml>';
+module.exports = {
+    categories: jsdom(categories).body.firstElementChild,
+    simple: jsdom(simple).body.firstElementChild,
+    empty: jsdom(empty).body.firstElementChild
+};

--- a/test/unit/util_filter-toolbox.js
+++ b/test/unit/util_filter-toolbox.js
@@ -1,0 +1,22 @@
+var toolboxes = require('../fixtures/toolboxes');
+var test = require('tap').test;
+var filterToolbox = require('../../src/util/filter-toolbox');
+
+test('categories', function (t) {
+    var filteredToolbox = filterToolbox(toolboxes.categories, ['operator_random']);
+    t.strictEqual(filteredToolbox.children.length, 1);
+    t.strictEqual(filteredToolbox.firstElementChild.children.length, 1);
+    t.end();
+});
+
+test('simple', function (t) {
+    var filteredToolbox = filterToolbox(toolboxes.simple, ['operator_random']);
+    t.strictEqual(filteredToolbox.children.length, 1);
+    t.end();
+});
+
+test('empty', function (t) {
+    var filteredToolbox = filterToolbox(toolboxes.empty, ['operator_random']);
+    t.strictEqual(filteredToolbox.children.length, 0);
+    t.end();
+});


### PR DESCRIPTION
### Resolves

For LLK/scratch-gui#16

### Proposed Changes

Provides a method to transform Blockly toolbox XML to only contain blocks which the VM can handle. It does this by removing any blocks in the toolbox for which it does not have a registered opcode.

### Reason for Changes

We need this method so that we can strip a given toolbox to only the blocks that the VM is capable of running. This is a temporary solution until we have a way to generate the toolbox based on the editing target.

### Test Coverage

I would like to include tests, but I didn't want to require `jsdom` or a similar DOM-simulating library just for this one hacky method...  Any suggestions for a lighter DOM-mocking method would be appreciated!

I considered the possibility that the fact that I would need to include a library to test this may indicate that I'm putting this method in the wrong place. However, given the other parts of the VM that interact with Blockly, this seems like the right place for now.