### PR TITLE
Show Categories that use custom code to load (variables, procedures)

### DIFF
--- a/src/util/filter-toolbox.js
+++ b/src/util/filter-toolbox.js
@@ -39,6 +39,7 @@ var filterToolbox = function (toolbox, opcodes) {
             if (category.nodeName.toLowerCase() !== 'category') continue;
             var filteredCategory = filterToolboxNode(category, opcodes);
             if (filteredCategory.hasChildNodes()) filteredToolbox.appendChild(filteredCategory);
+            if (!filteredCategory.hasChildNodes() && filteredCategory.hasAttribute("custom")) filteredToolbox.appendChild(filteredCategory);
         }
     } else {
         filteredToolbox = filterToolboxNode(toolbox, opcodes);

--- a/src/util/filter-toolbox.js
+++ b/src/util/filter-toolbox.js
@@ -39,7 +39,10 @@ var filterToolbox = function (toolbox, opcodes) {
             if (category.nodeName.toLowerCase() !== 'category') continue;
             var filteredCategory = filterToolboxNode(category, opcodes);
             if (filteredCategory.hasChildNodes()) filteredToolbox.appendChild(filteredCategory);
-            if (!filteredCategory.hasChildNodes() && filteredCategory.hasAttribute("custom")) filteredToolbox.appendChild(filteredCategory);
+            if (
+                !filteredCategory.hasChildNodes() && 
+                filteredCategory.hasAttribute('custom')
+            ) filteredToolbox.appendChild(filteredCategory);
         }
     } else {
         filteredToolbox = filterToolboxNode(toolbox, opcodes);

--- a/src/util/filter-toolbox.js
+++ b/src/util/filter-toolbox.js
@@ -38,11 +38,11 @@ var filterToolbox = function (toolbox, opcodes) {
         ) {
             if (category.nodeName.toLowerCase() !== 'category') continue;
             var filteredCategory = filterToolboxNode(category, opcodes);
-            if (filteredCategory.hasChildNodes()) filteredToolbox.appendChild(filteredCategory);
-            if (
-                !filteredCategory.hasChildNodes() && 
+            if (filteredCategory.hasChildNodes() ||
                 filteredCategory.hasAttribute('custom')
-            ) filteredToolbox.appendChild(filteredCategory);
+            ) {
+                filteredToolbox.appendChild(filteredCategory);
+            }
         }
     } else {
         filteredToolbox = filterToolboxNode(toolbox, opcodes);


### PR DESCRIPTION
### Resolves

_More of LLK/scratch-gui#16_

### Proposed Changes

_If a category uses the "custom" tag to generate blocks don't delete in the filtered toolbox_

### Reason for Changes

_So you can use thins like variables and custom blocks._