### PR TITLE
Default bitmapResolution to 1 if not provided in costume metadata

### DIFF
--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -45,7 +45,7 @@ var parseScratchObject = function (object, runtime, topLevel) {
                 skin: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
                     costume.baseLayerMD5 + '/get/',
                 name: costume.costumeName,
-                bitmapResolution: costume.bitmapResolution || 1,
+                bitmapResolution: costume.bitmapResolution,
                 rotationCenterX: costume.rotationCenterX,
                 rotationCenterY: costume.rotationCenterY
             });

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -45,7 +45,7 @@ var parseScratchObject = function (object, runtime, topLevel) {
                 skin: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
                     costume.baseLayerMD5 + '/get/',
                 name: costume.costumeName,
-                bitmapResolution: costume.bitmapResolution,
+                bitmapResolution: costume.bitmapResolution || 1,
                 rotationCenterX: costume.rotationCenterX,
                 rotationCenterY: costume.rotationCenterY
             });

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -428,16 +428,17 @@ RenderedTarget.prototype.updateAllDrawableProperties = function () {
     if (this.renderer) {
         var renderedDirectionScale = this._getRenderedDirectionAndScale();
         var costume = this.sprite.costumes[this.currentCostume];
+        var bitmapResolution = costume.bitmapResolution || 1;
         var props = {
             position: [this.x, this.y],
             direction: renderedDirectionScale.direction,
             scale: renderedDirectionScale.scale,
             visible: this.visible,
             skin: costume.skin,
-            costumeResolution: costume.bitmapResolution,
+            costumeResolution: bitmapResolution,
             rotationCenter: [
-                costume.rotationCenterX / costume.bitmapResolution,
-                costume.rotationCenterY / costume.bitmapResolution
+                costume.rotationCenterX / bitmapResolution,
+                costume.rotationCenterY / bitmapResolution
             ]
         };
         for (var effectName in this.effects) {


### PR DESCRIPTION
### Resolves

Resolves GH-484

### Proposed Changes

Default `bitmapResolution` to `1` during `updateAllDrawableProperties` if no value is provided in the costume metadata.

### Reason for Changes

Many sprites in the sprite library (e.g. "Apple") do not specify a `bitmapResolution` in their costume metadata. This leads to a bug in the GUI when one of these sprites is added to the project and the sprite is not rendered to the screen.

Example: 
https://github.com/LLK/scratch-gui/blob/develop/src/lib/libraries/sprites.json#L569
