### PR TITLE
Add methods for dragging and dropping sprites

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -794,6 +794,18 @@ Runtime.prototype.getSpriteTargetByName = function (spriteName) {
 };
 
 /**
+ * Get a target by its drawable id.
+ * @param {number} drawableID drawable id of target to find
+ * @return {?Target} The target, if found
+ */
+Runtime.prototype.getTargetByDrawableId = function (drawableID) {
+    for (var i = 0; i < this.targets.length; i++) {
+        var target = this.targets[i];
+        if (target.drawableID === drawableID) return target;
+    }
+};
+
+/**
  * Update the clone counter to track how many clones are created.
  * @param {number} changeAmount How many clones have been created/destroyed.
  */

--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -46,7 +46,7 @@ Mouse.prototype.postData = function (data) {
     }
     if (typeof data.isDown !== 'undefined') {
         this._isDown = data.isDown;
-        if (this._isDown) {
+        if (!this._isDown) {
             this._activateClickHats(data.x, data.y);
         }
     }

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -34,6 +34,13 @@ var RenderedTarget = function (sprite, runtime) {
     this.drawableID = null;
 
     /**
+     * Drag state of this rendered target. If true, x/y position can't be
+     * changed by blocks.
+     * @type {boolean}
+     */
+    this.dragging = false;
+
+    /**
      * Map of current graphic effect values.
      * @type {!Object.<string, number>}
      */
@@ -160,11 +167,11 @@ RenderedTarget.prototype.rotationStyle = (
  * Set the X and Y coordinates.
  * @param {!number} x New X coordinate, in Scratch coordinates.
  * @param {!number} y New Y coordinate, in Scratch coordinates.
+ * @param {?boolean} force Force setting X/Y, in case of dragging
  */
-RenderedTarget.prototype.setXY = function (x, y) {
-    if (this.isStage) {
-        return;
-    }
+RenderedTarget.prototype.setXY = function (x, y, force) {
+    if (this.isStage) return;
+    if (this.dragging && !force) return;
     var oldX = this.x;
     var oldY = this.y;
     if (this.renderer) {
@@ -695,11 +702,12 @@ RenderedTarget.prototype.onStopAll = function () {
  * @param {object} data An object with sprite info data to set.
  */
 RenderedTarget.prototype.postSpriteInfo = function (data) {
+    var force = data.hasOwnProperty('force') ? data.force : null;
     if (data.hasOwnProperty('x')) {
-        this.setXY(data.x, this.y);
+        this.setXY(data.x, this.y, force);
     }
     if (data.hasOwnProperty('y')) {
-        this.setXY(this.x, data.y);
+        this.setXY(this.x, data.y, force);
     }
     if (data.hasOwnProperty('direction')) {
         this.setDirection(data.direction);
@@ -710,6 +718,20 @@ RenderedTarget.prototype.postSpriteInfo = function (data) {
     if (data.hasOwnProperty('visible')) {
         this.setVisible(data.visible);
     }
+};
+
+/**
+ * Put the sprite into the drag state. While in effect, setXY must be forced
+ */
+RenderedTarget.prototype.startDrag = function () {
+    this.dragging = true;
+};
+
+/**
+ * Remove the sprite from the drag state.
+ */
+RenderedTarget.prototype.stopDrag = function () {
+    this.dragging = false;
 };
 
 /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -330,6 +330,41 @@ VirtualMachine.prototype.emitWorkspaceUpdate = function () {
 };
 
 /**
+ * Get a target id for a drawable id. Useful for interacting with the renderer
+ * @param {int} drawableId The drawable id to request the target id for
+ * @returns {?string} The target id, if found. Will also be null if the target found is the stage.
+ */
+VirtualMachine.prototype.getTargetIdForDrawableId = function (drawableId) {
+    var target = this.runtime.getTargetByDrawableId(drawableId);
+    if (target.hasOwnProperty('id') && target.hasOwnProperty('isStage') && !target.isStage) {
+        return target.id;
+    }
+    return null;
+};
+
+/**
+ * Put a target into a "drag" state, during which its X/Y positions will be unaffected
+ * by blocks.
+ * @param {string} targetId The id for the target to put into a drag state
+ */
+VirtualMachine.prototype.startDrag = function (targetId) {
+    var target = this.runtime.getTargetById(targetId);
+    if (target) {
+        target.startDrag();
+        this.setEditingTarget(target.id);
+    }
+};
+
+/**
+ * Remove a target from a drag state, so blocks may begin affecting X/Y position again
+ * @param {string} targetId The id for the target to remove from the drag state
+ */
+VirtualMachine.prototype.stopDrag = function (targetId) {
+    var target = this.runtime.getTargetById(targetId);
+    if (target) target.stopDrag();
+};
+
+/**
  * Post/edit sprite info for the current editing target.
  * @param {object} data An object with sprite info data to set.
  */


### PR DESCRIPTION
* Add `getTargetIdForDrawableId` to translate between renderer picks and VM targets
* Add `startDrag` to stop sprite motion while dragging
* Add `stopDrag` to return sprite motion after dragging

Also update click hats to run on mouse up to match 2.0

For https://github.com/LLK/scratch-gui/issues/66

/fyi @thisandagain @cwillisf 