### PR TITLE
Exclude more unfinished blocks from toolbox

### DIFF
--- a/src/util/filter-toolbox.js
+++ b/src/util/filter-toolbox.js
@@ -24,9 +24,11 @@ var filterToolboxNode = function (node, opcodes) {
  * @param {HTMLElement} toolbox Blockly toolbox XML node
  * @param {Array.<string>} opcodes Valid opcodes. Blocks producing other opcodes
  * will be filtered.
+ * @param {boolean} includeCustom Include empty categories with a non-empty `custom` attribute
  * @returns {HTMLElement} filtered toolbox XML node
  */
-var filterToolbox = function (toolbox, opcodes) {
+var filterToolbox = function (toolbox, opcodes, includeCustom) {
+    if (typeof includeCustom === 'undefined') includeCustom = true;
     if (!toolbox.hasChildNodes()) return toolbox;
     var filteredToolbox;
     if (toolbox.firstElementChild.nodeName.toLowerCase() === 'category') {
@@ -39,7 +41,7 @@ var filterToolbox = function (toolbox, opcodes) {
             if (category.nodeName.toLowerCase() !== 'category') continue;
             var filteredCategory = filterToolboxNode(category, opcodes);
             if (filteredCategory.hasChildNodes() ||
-                filteredCategory.hasAttribute('custom')
+                (filteredCategory.hasAttribute('custom') && includeCustom)
             ) {
                 filteredToolbox.appendChild(filteredCategory);
             }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -4,6 +4,8 @@ var util = require('util');
 var filterToolbox = require('./util/filter-toolbox');
 var Runtime = require('./engine/runtime');
 var sb2import = require('./import/sb2import');
+var Scratch3DataBlocks = require('./blocks/scratch3_data');
+var Scratch3ProcedureBlocks = require('./blocks/scratch3_procedures');
 
 /**
  * Handles connections between blocks, stage, and extensions.
@@ -380,9 +382,22 @@ VirtualMachine.prototype.postSpriteInfo = function (data) {
  * @returns {HTMLElement} filtered toolbox XML node
  */
 VirtualMachine.prototype.filterToolbox = function (toolbox) {
+    var exclusions = [
+        'looks_say',
+        'looks_sayforsecs',
+        'looks_think',
+        'looks_thinkforsecs'
+    ].concat(
+        Object.keys(Scratch3DataBlocks.prototype.getPrimitives())
+    ).concat(
+        Object.keys(Scratch3ProcedureBlocks.prototype.getPrimitives())
+    );
     var opcodes = Object.keys(this.runtime._primitives)
-        .concat(Object.keys(this.runtime._hats));
-    return filterToolbox(toolbox, opcodes);
+        .concat(Object.keys(this.runtime._hats))
+        .filter(function (opcode) {
+            return exclusions.indexOf(opcode) === -1;
+        });
+    return filterToolbox(toolbox, opcodes, false);
 };
 
 module.exports = VirtualMachine;


### PR DESCRIPTION
Temporary for a play test, exclude procedure, variable, list, say and think blocks from the palette when filtering the toolbox.

Resolves https://github.com/LLK/scratch-gui/issues/157 and https://github.com/LLK/scratch-gui/issues/158