### PR TITLE
Stop all gfx reset

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -706,9 +706,10 @@ RenderedTarget.prototype.onGreenFlag = function () {
 
 /**
  * Called when the project receives a "stop all"
- * Stop all sounds
+ * Stop all sounds and clear graphic effects.
  */
 RenderedTarget.prototype.onStopAll = function () {
+    this.clearEffects();
     if (this.audioPlayer) {
         this.audioPlayer.stopAllSounds();
         this.audioPlayer.clearEffects();

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -11,3 +11,13 @@ test('clone effects', function (t) {
     t.ok(a.effects !== b.effects);
     t.end();
 });
+
+test('#stopAll clears graphics effects', function (t) {
+    var spr = new Sprite();
+    var a = new RenderedTarget(spr, null);
+    var effectName = 'brightness';
+    a.setEffect(effectName, 100);
+    a.onStopAll();
+    t.equals(a.effects[effectName], 0);
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

https://github.com/LLK/scratch-vm/issues/139

### Proposed Changes

_Describe what this Pull Request does_

Clears the graphics effects on stop all. This extends #199 which cleared graphics effects on green flag.

### Reason for Changes

_Explain why these changes should be made_

@thisandagain said
> To match Scratch 2.0, the stop button should also reset graphic effects.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test making sure that stopping resets an effect to 0. Let me know if you have any feedback about the way this test was implemented, I tried to just stick with what was already there. Better way might be to stub `clearEffects` and make sure that it is called after `stopAll`, rather than test a side effect of the `clearEffects` function, but I didn't see anything in the test harness for something like `t.wasCalled`. 

Here is what the change looks like.

what it does now.
![scratch-3-no-reset](https://cloud.githubusercontent.com/assets/654102/23630302/9d7d5224-0288-11e7-8789-cbb02be391a7.gif)

what scratch 2 does
![scratch-2-reset](https://cloud.githubusercontent.com/assets/654102/23630317/af6eb89c-0288-11e7-9693-c1b9b12963e9.gif)

what this PR does
![scratch-3-reset](https://cloud.githubusercontent.com/assets/654102/23630321/b50f0f04-0288-11e7-87ee-1cbba9a07f2c.gif)

