### PR TITLE
Change MAX_CLONES to 301 for slightly better Scratch 2.0 compatibility

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -226,7 +226,7 @@ Runtime.THREAD_STEP_INTERVAL_COMPATIBILITY = 1000 / 30;
  * How many clones can be created at a time.
  * @const {number}
  */
-Runtime.MAX_CLONES = 300;
+Runtime.MAX_CLONES = 301;
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Scratch 2.0 allowed up to 301 clones, as opposed to the 300 currently specified in `src/engine/runtime.js`.

### Related Issues

LLK/scratch-vm#159