### PR TITLE
Switch to using number directly, instead of toNumber for costume switch

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -101,7 +101,7 @@ Scratch3LooksBlocks.prototype._setCostumeOrBackdrop = function (target,
                    requestedCostume === 'next backdrop') {
             target.setCostume(target.currentCostume + 1);
         } else {
-            var forcedNumber = Cast.toNumber(requestedCostume);
+            var forcedNumber = Number(requestedCostume);
             if (!isNaN(forcedNumber)) {
                 target.setCostume(optZeroIndex ?
                     forcedNumber : forcedNumber - 1);


### PR DESCRIPTION
### Resolves

Resolves #489

### Proposed Changes

Instead of using .toNumber which just calls number() and checks for NaN, just call number().

### Reason for Changes

So that you can get NaN when using unrecognized strings, so that it won't switch costume.

### Test Coverage

None added.
