### PR TITLE
Clamp audio inputs

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -51,6 +51,18 @@ Scratch3SoundBlocks.BEAT_RANGE = {min: 0, max: 100};
  */
 Scratch3SoundBlocks.TEMPO_RANGE = {min: 20, max: 500};
 
+ /** The minimum and maximum values for each sound effect.
+ * @type {{effect:{min: number, max: number}}}
+ */
+Scratch3SoundBlocks.EFFECT_RANGE = {
+    pitch: {min: -600, max: 600},       // -5 to 5 octaves
+    pan: {min: -100, max: 100},         // 100% left to 100% right
+    echo: {min: 0, max: 100},           // 0 to max (75%) feedback
+    reverb: {min: 0, max: 100},         // wet/dry: 0 to 100% wet
+    fuzz: {min: 0, max: 100},           // wed/dry: 0 to 100% wet
+    robot: {min: 0, max: 600}           // 0 to 5 octaves
+};
+
 /**
  * @param {Target} target - collect sound state for this target.
  * @returns {SoundState} the mutable sound state associated with that target. This will be created if necessary.
@@ -193,25 +205,29 @@ Scratch3SoundBlocks.prototype.setInstrument = function (args, util) {
 };
 
 Scratch3SoundBlocks.prototype.setEffect = function (args, util) {
-    var effect = Cast.toString(args.EFFECT).toLowerCase();
-    var value = Cast.toNumber(args.VALUE);
-
-    var soundState = this._getSoundState(util.target);
-    if (!soundState.effects.hasOwnProperty(effect)) return;
-
-    soundState.effects[effect] = value;
-    if (util.target.audioPlayer === null) return;
-    util.target.audioPlayer.setEffect(effect, soundState.effects[effect]);
+    this._updateEffect(args, util, false);
 };
 
 Scratch3SoundBlocks.prototype.changeEffect = function (args, util) {
+    this._updateEffect(args, util, true);
+};
+
+Scratch3SoundBlocks.prototype._updateEffect = function (args, util, change) {
     var effect = Cast.toString(args.EFFECT).toLowerCase();
     var value = Cast.toNumber(args.VALUE);
 
     var soundState = this._getSoundState(util.target);
     if (!soundState.effects.hasOwnProperty(effect)) return;
 
-    soundState.effects[effect] += value;
+    if (change) {
+        soundState.effects[effect] += value;
+    } else {
+        soundState.effects[effect] = value;
+    }
+
+    var effectRange = Scratch3SoundBlocks.EFFECT_RANGE[effect];
+    soundState.effects[effect] = MathUtil.clamp(soundState.effects[effect], effectRange.min, effectRange.max);
+
     if (util.target.audioPlayer === null) return;
     util.target.audioPlayer.setEffect(effect, soundState.effects[effect]);
 };

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -40,6 +40,13 @@ Scratch3SoundBlocks.DEFAULT_SOUND_STATE = {
 Scratch3SoundBlocks.MIDI_NOTE_RANGE = {min: 36, max: 96}; // C2 to C7
 
 /**
+ * The minimum and maximum beat values, for clamping the duration of play note, play drum and rest.
+ * 100 beats at the default tempo of 60bpm is 100 seconds.
+ * @type {{min: number, max: number}}
+ */
+Scratch3SoundBlocks.BEAT_RANGE = {min: 0, max: 100};
+
+/**
  * @param {Target} target - collect sound state for this target.
  * @returns {SoundState} the mutable sound state associated with that target. This will be created if necessary.
  * @private
@@ -140,6 +147,7 @@ Scratch3SoundBlocks.prototype.playNoteForBeats = function (args, util) {
     var note = Cast.toNumber(args.NOTE);
     note = MathUtil.clamp(note, Scratch3SoundBlocks.MIDI_NOTE_RANGE.min, Scratch3SoundBlocks.MIDI_NOTE_RANGE.max);
     var beats = Cast.toNumber(args.BEATS);
+    beats = this._clampBeats(beats);
     var soundState = this._getSoundState(util.target);
     var inst = soundState.currentInstrument;
     var vol = soundState.volume;
@@ -153,14 +161,20 @@ Scratch3SoundBlocks.prototype.playDrumForBeats = function (args, util) {
     if (typeof this.runtime.audioEngine === 'undefined') return;
     drum = MathUtil.wrapClamp(drum, 0, this.runtime.audioEngine.numDrums);
     var beats = Cast.toNumber(args.BEATS);
+    beats = this._clampBeats(beats);
     if (util.target.audioPlayer === null) return;
     return util.target.audioPlayer.playDrumForBeats(drum, beats);
 };
 
 Scratch3SoundBlocks.prototype.restForBeats = function (args) {
     var beats = Cast.toNumber(args.BEATS);
+    beats = this._clampBeats(beats);
     if (typeof this.runtime.audioEngine === 'undefined') return;
     return this.runtime.audioEngine.waitForBeats(beats);
+};
+
+Scratch3SoundBlocks.prototype._clampBeats = function (beats) {
+    return MathUtil.clamp(beats, Scratch3SoundBlocks.BEAT_RANGE.min, Scratch3SoundBlocks.BEAT_RANGE.max);
 };
 
 Scratch3SoundBlocks.prototype.setInstrument = function (args, util) {

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -34,6 +34,12 @@ Scratch3SoundBlocks.DEFAULT_SOUND_STATE = {
 };
 
 /**
+ * The minimum and maximum MIDI note numbers, for clamping the input to play note.
+ * @type {{min: number, max: number}}
+ */
+Scratch3SoundBlocks.MIDI_NOTE_RANGE = {min: 36, max: 96}; // C2 to C7
+
+/**
  * @param {Target} target - collect sound state for this target.
  * @returns {SoundState} the mutable sound state associated with that target. This will be created if necessary.
  * @private
@@ -132,6 +138,7 @@ Scratch3SoundBlocks.prototype.stopAllSounds = function (args, util) {
 
 Scratch3SoundBlocks.prototype.playNoteForBeats = function (args, util) {
     var note = Cast.toNumber(args.NOTE);
+    note = MathUtil.clamp(note, Scratch3SoundBlocks.MIDI_NOTE_RANGE.min, Scratch3SoundBlocks.MIDI_NOTE_RANGE.max);
     var beats = Cast.toNumber(args.BEATS);
     var soundState = this._getSoundState(util.target);
     var inst = soundState.currentInstrument;

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -46,6 +46,11 @@ Scratch3SoundBlocks.MIDI_NOTE_RANGE = {min: 36, max: 96}; // C2 to C7
  */
 Scratch3SoundBlocks.BEAT_RANGE = {min: 0, max: 100};
 
+ /** The minimum and maximum tempo values, in bpm.
+ * @type {{min: number, max: number}}
+ */
+Scratch3SoundBlocks.TEMPO_RANGE = {min: 20, max: 500};
+
 /**
  * @param {Target} target - collect sound state for this target.
  * @returns {SoundState} the mutable sound state associated with that target. This will be created if necessary.
@@ -246,15 +251,21 @@ Scratch3SoundBlocks.prototype.getVolume = function (args, util) {
 };
 
 Scratch3SoundBlocks.prototype.setTempo = function (args) {
-    var value = Cast.toNumber(args.TEMPO);
-    if (typeof this.runtime.audioEngine === 'undefined') return;
-    this.runtime.audioEngine.setTempo(value);
+    var tempo = Cast.toNumber(args.TEMPO);
+    this._updateTempo(tempo);
 };
 
 Scratch3SoundBlocks.prototype.changeTempo = function (args) {
-    var value = Cast.toNumber(args.TEMPO);
+    var change = Cast.toNumber(args.TEMPO);
     if (typeof this.runtime.audioEngine === 'undefined') return;
-    this.runtime.audioEngine.changeTempo(value);
+    var tempo = change + this.runtime.audioEngine.currentTempo;
+    this._updateTempo(tempo);
+};
+
+Scratch3SoundBlocks.prototype._updateTempo = function (tempo) {
+    tempo = MathUtil.clamp(tempo, Scratch3SoundBlocks.TEMPO_RANGE.min, Scratch3SoundBlocks.TEMPO_RANGE.max);
+    if (typeof this.runtime.audioEngine === 'undefined') return;
+    this.runtime.audioEngine.setTempo(tempo);
 };
 
 Scratch3SoundBlocks.prototype.getTempo = function () {


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-vm/issues/503

Fixes https://github.com/LLK/scratch-vm/issues/502

### Proposed Changes

Clamp inputs to the sound blocks to reasonable ranges:

- Note value for the "play note" block, now clamped to 36 to 96, which is C2 to C7.
- Duration in beats for the "play note", "play drum", and "rest" blocks, now clamped to 0 to 100
- Tempo, now clamped to 20 to 500
- Audio effects, now clamped to different ranges:
- Pitch: -600 to 600, -5 to 5 octaves
- Pan:  -100 to 100, 100% left to 100% right
- Echo: 0 to 100, 0 to max feedback
- Reverb: 0 to 100, wet/dry %
- Fuzz: 0 to 100, wet/dry %
- Robot: 0 to 600, 0 to 5 octaves

### Reason for Changes

Generally, the inputs to the sound blocks should be clamped to reasonable ranges. In some cases, inputs outside this range caused errors or warnings.

### Test Coverage

No tests yet.