### PR TITLE
Offer unpacked code from package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "4"
+- "6"
 - "node"
 sudo: false
 cache:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/LLK/scratch-vm.git"
   },
-  "main": "./dist/node/scratch-vm.js",
+  "main": "./src/index.js",
   "scripts": {
     "build": "./node_modules/.bin/webpack --progress --colors --bail",
     "coverage": "./node_modules/.bin/tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",
@@ -23,23 +23,28 @@
     "watch": "./node_modules/.bin/webpack --progress --colors --watch",
     "version": "./node_modules/.bin/json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\""
   },
-  "devDependencies": {
+  "dependencies": {
     "adm-zip": "0.4.7",
+    "htmlparser2": "3.9.2",
+    "minilog": "3.1.0",
+    "promise": "7.1.1",
+    "scratch-audio": "latest",
+    "scratch-blocks": "latest",
+    "scratch-render": "latest"
+  },
+  "devDependencies": {
+    "babel-core": "^6.24.0",
     "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.4.1",
+    "babel-preset-es2015": "^6.24.0",
     "copy-webpack-plugin": "4.0.1",
     "eslint": "^3.16.0",
     "eslint-config-scratch": "^3.1.0",
     "expose-loader": "0.7.3",
     "gh-pages": "^0.12.0",
     "highlightjs": "^9.8.0",
-    "htmlparser2": "3.9.2",
     "json": "^9.0.4",
     "lodash.defaultsdeep": "4.6.0",
-    "minilog": "3.1.0",
-    "promise": "7.1.1",
-    "scratch-audio": "latest",
-    "scratch-blocks": "latest",
-    "scratch-render": "latest",
     "script-loader": "0.7.0",
     "stats.js": "^0.17.0",
     "tap": "^10.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,13 +9,28 @@ var base = {
         host: '0.0.0.0',
         port: process.env.PORT || 8073
     },
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
+    module: {
+        rules: [
+            {
+                // allow ES2015 in any *.js file under .../scratch-*/src/...
+                test: /[\\/]+scratch-[^\\/]+[\\/]+src[\\/]+.+\.js$/,
+                loader: 'babel-loader',
+                options: {
+                    presets: ['es2015']
+                }
+            }
+        ]
+    },
     plugins: [
         new webpack.optimize.UglifyJsPlugin({
             include: /\.min\.js$/,
             minimize: true
         })
-    ]
+    ],
+    resolve: {
+        symlinks: false
+    }
 };
 
 module.exports = [
@@ -37,19 +52,6 @@ module.exports = [
                     loader: 'expose-loader?VirtualMachine'
                 }
             ]
-        }
-    }),
-    // Node-compatible
-    defaultsDeep({}, base, {
-        target: 'node',
-        entry: {
-            'scratch-vm': './src/index.js'
-        },
-        output: {
-            library: 'VirtualMachine',
-            libraryTarget: 'commonjs2',
-            path: path.resolve(__dirname, 'dist/node'),
-            filename: '[name].js'
         }
     }),
     // Playground

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,8 +13,13 @@ var base = {
     module: {
         rules: [
             {
-                // allow ES2015 in any *.js file under .../scratch-*/src/...
-                test: /[\\/]+scratch-[^\\/]+[\\/]+src[\\/]+.+\.js$/,
+                include: [
+                    path.resolve(__dirname, 'node_modules', 'scratch-audio', 'src'),
+                    path.resolve(__dirname, 'node_modules', 'scratch-render', 'src'),
+                    path.resolve(__dirname, 'node_modules', 'scratch-storage', 'src'),
+                    path.resolve(__dirname, 'src')
+                ],
+                test: /\.js$/,
                 loader: 'babel-loader',
                 options: {
                     presets: ['es2015']

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,12 +51,12 @@ module.exports = [
             filename: '[name].js'
         },
         module: {
-            rules: [
+            rules: base.module.rules.concat([
                 {
                     test: require.resolve('./src/index.js'),
                     loader: 'expose-loader?VirtualMachine'
                 }
-            ]
+            ])
         }
     }),
     // Playground
@@ -84,7 +84,7 @@ module.exports = [
             filename: '[name].js'
         },
         module: {
-            loaders: [
+            rules: base.module.rules.concat([
                 {
                     test: require.resolve('./src/index.js'),
                     loader: 'expose-loader?VirtualMachine'
@@ -102,18 +102,18 @@ module.exports = [
                     loader: 'expose-loader?Blockly'
                 },
                 {
-                    test: require.resolve('scratch-audio'),
+                    test: path.resolve(__dirname, 'node_modules', 'scratch-audio', 'src', 'index.js'),
                     loader: 'expose-loader?AudioEngine'
                 },
                 {
-                    test: require.resolve('scratch-render'),
+                    test: path.resolve(__dirname, 'node_modules', 'scratch-render', 'src', 'index.js'),
                     loader: 'expose-loader?RenderWebGL'
                 },
                 {
-                    test: require.resolve('scratch-storage'),
+                    test: path.resolve(__dirname, 'node_modules', 'scratch-storage', 'src', 'index.js'),
                     loader: 'expose-loader?Scratch.Storage'
                 }
-            ]
+            ])
         },
         plugins: base.plugins.concat([
             new CopyWebpackPlugin([{


### PR DESCRIPTION
### Proposed Changes

This change declares `./src/index.js` as the "main" script in `package.json`, and stops building `dist/node/*` with webpack. This change also adjusts the webpack configuration for compatibility with similarly unpacked audio, render, and storage modules.

### Reason for Changes

This sets us up to build `scratch-gui` in a single step, allowing webpack to better optimize our files and reducing the duplication of code within our output bundles.

### Test Coverage

Test coverage has not changed: the tests were already using the unpacked source.
