### PR TITLE
Use Scratch Storage to load sounds and Audio Engine to decode and register them

### DIFF
--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -226,11 +226,15 @@ var loadSound = function (sound, runtime) {
         log.error('No storage module present; cannot load sound asset: ', sound.md5);
         return;
     }
+    if (!runtime.audioEngine) {
+        log('No audio engine present; cannot load sound asset: ', sound.md5);
+        return;
+    }
     var idParts = sound.md5.split('.');
     var md5 = idParts[0];
     runtime.storage.load(AssetType.Sound, md5).then(function (soundAsset) {
         sound.data = soundAsset.data;
-        // @todo register sound.data with scratch-audio
+        runtime.audioEngine.decodeSound(sound);
     });
 };
 

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -227,7 +227,7 @@ var loadSound = function (sound, runtime) {
         return;
     }
     if (!runtime.audioEngine) {
-        log('No audio engine present; cannot load sound asset: ', sound.md5);
+        log.error('No audio engine present; cannot load sound asset: ', sound.md5);
         return;
     }
     var idParts = sound.md5.split('.');

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -75,9 +75,6 @@ RenderedTarget.prototype.initDrawable = function () {
     */
     this.audioPlayer = null;
     if (this.runtime && this.runtime.audioEngine) {
-        if (this.isOriginal) {
-            this.runtime.audioEngine.loadSounds(this.sprite.sounds);
-        }
         this.audioPlayer = this.runtime.audioEngine.createPlayer();
     }
 };


### PR DESCRIPTION
### Resolves

Addresses https://github.com/LLK/scratch-vm/issues/511

### Proposed Changes

Remove call to loadSounds from rendered-target. Scratch Storage loads the sounds, and passes the data to the audio engine to decode and register them. 

Depends on https://github.com/LLK/scratch-audio/pull/32

### Reason for Changes

Moving all asset loading to Scratch Storage.

### Test Coverage

No tests yet.