### PR TITLE
Add costume dataURI to costumes from storage

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -16,13 +16,9 @@ var log = require('../util/log');
 var loadCostume = function (md5ext, costume, runtime) {
     if (!runtime.storage) {
         log.error('No storage module present; cannot load costume asset: ', md5ext);
-        return Promise.resolve(null);
+        return Promise.resolve(costume);
     }
 
-    if (!runtime.renderer) {
-        log.error('No rendering module present; cannot load costume asset: ', md5ext);
-        return Promise.resolve(null);
-    }
 
     var idParts = md5ext.split('.');
     var md5 = idParts[0];
@@ -38,6 +34,13 @@ var loadCostume = function (md5ext, costume, runtime) {
         costume.url = costumeAsset.encodeDataURI();
         return costumeAsset;
     });
+
+    if (!runtime.renderer) {
+        log.error('No rendering module present; cannot load costume asset: ', md5ext);
+        return promise.then(function () {
+            return costume;
+        });
+    }
 
     if (assetType === AssetType.ImageVector) {
         promise = promise.then(function (costumeAsset) {

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -34,11 +34,15 @@ var loadCostume = function (md5ext, costume, runtime) {
         costume.rotationCenterY / costume.bitmapResolution
     ];
 
-    var promise = runtime.storage.load(assetType, md5);
+    var promise = runtime.storage.load(assetType, md5).then(function (costumeAsset) {
+        costume.url = costumeAsset.encodeDataURI();
+        return costumeAsset;
+    });
 
     if (assetType === AssetType.ImageVector) {
         promise = promise.then(function (costumeAsset) {
             costume.skinId = runtime.renderer.createSVGSkin(costumeAsset.decodeText(), rotationCenter);
+            return costume;
         });
     } else {
         promise = promise.then(function (costumeAsset) {
@@ -63,6 +67,7 @@ var loadCostume = function (md5ext, costume, runtime) {
             });
         }).then(function (imageElement) {
             costume.skinId = runtime.renderer.createBitmapSkin(imageElement, costume.bitmapResolution, rotationCenter);
+            return costume;
         });
     }
     return promise;

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -53,6 +53,7 @@ var parseScratchObject = function (object, runtime, topLevel) {
                 rotationCenterY: costumeSource.rotationCenterY,
                 skinId: null
             };
+            sprite.costumes.push(costume);
             costumePromises.push(loadCostume(costumeSource.baseLayerMD5, costume, runtime));
         }
     }

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -53,11 +53,7 @@ var parseScratchObject = function (object, runtime, topLevel) {
                 rotationCenterY: costumeSource.rotationCenterY,
                 skinId: null
             };
-            var costumePromise = loadCostume(costumeSource.baseLayerMD5, costume, runtime);
-            if (costumePromise) {
-                costumePromises.push(costumePromise);
-            }
-            sprite.costumes.push(costume);
+            costumePromises.push(loadCostume(costumeSource.baseLayerMD5, costume, runtime));
         }
     }
     // Sounds from JSON
@@ -138,7 +134,12 @@ var parseScratchObject = function (object, runtime, topLevel) {
         }
     }
     target.isStage = topLevel;
-    Promise.all(costumePromises).then(function () {
+    Promise.all(costumePromises).then(function (costumes) {
+        sprite.costumes = costumes.filter(
+            function (c) {
+                return c !== null;
+            }
+        );
         target.updateAllDrawableProperties();
     });
     // The stage will have child objects; recursively process them.

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -136,11 +136,7 @@ var parseScratchObject = function (object, runtime, topLevel) {
     }
     target.isStage = topLevel;
     Promise.all(costumePromises).then(function (costumes) {
-        sprite.costumes = costumes.filter(
-            function (c) {
-                return c !== null;
-            }
-        );
+        sprite.costumes = costumes;
         target.updateAllDrawableProperties();
     });
     // The stage will have child objects; recursively process them.

--- a/test/integration/complex.js
+++ b/test/integration/complex.js
@@ -40,14 +40,17 @@ test('complex', function (t) {
                 rotationStyle: 'all around',
                 visible: true
             });
-            vm.addCostume({
-                costumeName: 'costume1',
-                baseLayerID: 0,
-                baseLayerMD5: 'f9a1c175dbe2e5dee472858dd30d16bb.svg',
-                bitmapResolution: 1,
-                rotationCenterX: 47,
-                rotationCenterY: 55
-            });
+            vm.addCostume(
+                'f9a1c175dbe2e5dee472858dd30d16bb.svg',
+                {
+                    costumeName: 'costume1',
+                    baseLayerID: 0,
+                    baseLayerMD5: 'f9a1c175dbe2e5dee472858dd30d16bb.svg',
+                    bitmapResolution: 1,
+                    rotationCenterX: 47,
+                    rotationCenterY: 55
+                }
+            );
         }
     });
 
@@ -73,14 +76,17 @@ test('complex', function (t) {
         vm.addSprite2(sprite);
 
         // Add backdrop
-        vm.addBackdrop({
-            costumeName: 'baseball-field',
-            baseLayerID: 26,
-            baseLayerMD5: '6b3d87ba2a7f89be703163b6c1d4c964.png',
-            bitmapResolution: 2,
-            rotationCenterX: 480,
-            rotationCenterY: 360
-        });
+        vm.addBackdrop(
+            '6b3d87ba2a7f89be703163b6c1d4c964.png',
+            {
+                costumeName: 'baseball-field',
+                baseLayerID: 26,
+                baseLayerMD5: '6b3d87ba2a7f89be703163b6c1d4c964.png',
+                bitmapResolution: 2,
+                rotationCenterX: 480,
+                rotationCenterY: 360
+            }
+        );
     });
 
     // After two seconds, get playground data and stop


### PR DESCRIPTION
When costumes are fetched from storage, add the dataURI of the costume data to the costume, so that the GUI can use it in turn.

Also fix some tests that were calling addCostume and addBackdrop incorrectly (not sure how the tests passed before).

Re-arrange loadCostume, so that the returned costume contains as much data as loadCostume can provide.

Towards #515, LLK/scratch-gui#279
/cc @cwillisf 

![bitmoji](https://render.bitstrips.com/v2/cpanel/9946310-102286145_1-s1-v1.png?transparent=1&palette=1&width=246)