### PR TITLE
Fix so that size is set in float to ensure backward compatibility with Scratch 2.0

### DIFF
--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -33,6 +33,7 @@
             <canvas id="scratch-stage" style="width: 480px; height: 360px;"></canvas><br />
             x: <input id='sinfo-x' />
             y: <input id='sinfo-y' /><br />
+            size: <input id='sinfo-size' /><br />
             dir: <input id='sinfo-direction' />
             rotation style: <input id='sinfo-rotationstyle' /><br />
             visible: <input id='sinfo-visible' />

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -187,6 +187,7 @@ window.onload = function () {
         if (data.id !== selectedTarget.value) return; // Not the editingTarget
         document.getElementById('sinfo-x').value = data.x;
         document.getElementById('sinfo-y').value = data.y;
+        document.getElementById('sinfo-size').value = data.size;
         document.getElementById('sinfo-direction').value = data.direction;
         document.getElementById('sinfo-rotationstyle').value = data.rotationStyle;
         document.getElementById('sinfo-visible').value = data.visible;

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -298,14 +298,14 @@ RenderedTarget.prototype.setSize = function (size) {
         // Clamp to scales relative to costume and stage size.
         // See original ScratchSprite.as:setSize.
         var costumeSize = this.renderer.getSkinSize(this.drawableID);
-        var origW = Math.round(costumeSize[0]);
-        var origH = Math.round(costumeSize[1]);
+        var origW = costumeSize[0];
+        var origH = costumeSize[1];
         var minScale = Math.min(1, Math.max(5 / origW, 5 / origH));
         var maxScale = Math.min(
             (1.5 * this.runtime.constructor.STAGE_WIDTH) / origW,
             (1.5 * this.runtime.constructor.STAGE_HEIGHT) / origH
         );
-        this.size = Math.round(MathUtil.clamp(size / 100, minScale, maxScale) * 100);
+        this.size = MathUtil.clamp(size / 100, minScale, maxScale) * 100;
         var renderedDirectionScale = this._getRenderedDirectionAndScale();
         this.renderer.updateDrawableProperties(this.drawableID, {
             direction: renderedDirectionScale.direction,

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -764,6 +764,7 @@ RenderedTarget.prototype.toJSON = function () {
         isStage: this.isStage,
         x: this.x,
         y: this.y,
+        size: this.size,
         direction: this.direction,
         draggable: this.draggable,
         costume: this.getCurrentCostume(),


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/521
https://github.com/LLK/scratch-gui/issues/211

### Proposed Changes

Represent sprite size as float instead of integer

### Reason for Changes

Scratch 2.0 represent size as float, this change will ensure backward compatibility 

### Test Coverage

None. I did try to add a integration test, but I would need some pointers on how I could write a test for this issue.