### PR TITLE
Fixed xml import/export in Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var VirtualMachine = require('scratch-vm');
 var vm = new VirtualMachine();
 
 // Block events
-workspace.addChangeListener(vm.blockListener);
+Scratch.workspace.addChangeListener(vm.blockListener);
 
 // Run threads
 vm.start();

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -72,7 +72,7 @@
     <script>
         function toXml() {
             var output = document.getElementById('importExport');
-            var xml = Blockly.Xml.workspaceToDom(workspace);
+            var xml = Blockly.Xml.workspaceToDom(Scratch.workspace);
             output.value = Blockly.Xml.domToPrettyText(xml);
             output.focus();
             output.select();
@@ -81,7 +81,7 @@
           function fromXml() {
             var input = document.getElementById('importExport');
             var xml = Blockly.Xml.textToDom(input.value);
-            Blockly.Xml.domToWorkspace(workspace, xml);
+            Blockly.Xml.domToWorkspace(Scratch.workspace, xml);
           }
     </script>
 </body>


### PR DESCRIPTION
### Resolves

#523

### Proposed Changes

Use `Scratch.workspace` instead of `workspace` since it's now removed from the global scope

### Reason for Changes

Fix xml import/export in Playground

### Test Coverage

None
