### PR TITLE
Report sound costume data

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -441,6 +441,14 @@ RenderedTarget.prototype.getCostumes = function () {
 };
 
 /**
+ * Get full sound list
+ * @return {object[]} list of sounds
+ */
+RenderedTarget.prototype.getSounds = function () {
+    return this.sprite.sounds;
+};
+
+/**
  * Update all drawable properties for this rendered target.
  * Use when a batch has changed, e.g., when the drawable is first created.
  */
@@ -767,6 +775,8 @@ RenderedTarget.prototype.toJSON = function () {
         direction: this.direction,
         draggable: this.draggable,
         costume: this.getCurrentCostume(),
+        costumes: this.getCostumes(),
+        sounds: this.getSounds(),
         costumeCount: this.getCostumes().length,
         visible: this.visible,
         rotationStyle: this.rotationStyle

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -21,3 +21,33 @@ test('#stopAll clears graphics effects', function (t) {
     t.equals(a.effects[effectName], 0);
     t.end();
 });
+
+test('#getCostumes returns the costumes', function (t) {
+    var spr = new Sprite();
+    var a = new RenderedTarget(spr, null);
+    var costumes = [1, 2, 3];
+    a.sprite.costumes = costumes;
+    t.equals(a.getCostumes(), costumes);
+    t.end();
+});
+
+test('#getSounds returns the sounds', function (t) {
+    var spr = new Sprite();
+    var a = new RenderedTarget(spr, null);
+    var sounds = [1, 2, 3];
+    a.sprite.sounds = sounds;
+    t.equals(a.getSounds(), sounds);
+    t.end();
+});
+
+test('#toJSON returns the sounds and costumes', function (t) {
+    var spr = new Sprite();
+    var a = new RenderedTarget(spr, null);
+    var sounds = [1, 2, 3];
+    var costumes = ['a', 'b', 'c'];
+    a.sprite.sounds = sounds;
+    a.sprite.costumes = costumes;
+    t.same(a.toJSON().sounds, sounds);
+    t.same(a.toJSON().costumes, costumes);
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/515

### Proposed Changes

_Describe what this Pull Request does_

Includes all costume and sound data in the `toJSON` method, in order to provide that data to the GUI. 

### Reason for Changes

_Explain why these changes should be made_

Previously only the current costume data was reported. With the new sound and costume tabs in gui, we also need to report all costume and sound data from the VM. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Added unit test for covering the new methods. 
