### PR TITLE
Fix rounded get size reporting

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -201,7 +201,7 @@ Scratch3LooksBlocks.prototype.goBackLayers = function (args, util) {
 };
 
 Scratch3LooksBlocks.prototype.getSize = function (args, util) {
-    return util.target.size;
+    return Math.round(util.target.size);
 };
 
 Scratch3LooksBlocks.prototype.getBackdropIndex = function () {


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/521

### Proposed Changes

Round the result from getSize

### Reason for Changes

To ensure backward compatibility with Scratch 2.0 where size is reported in integers

### Test Coverage

None