### PR TITLE
Standardize repository settings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ var base = {
         host: '0.0.0.0',
         port: process.env.PORT || 8073
     },
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
     plugins: [
         new webpack.optimize.UglifyJsPlugin({
             include: /\.min\.js$/,


### PR DESCRIPTION
### Proposed Changes

This change ensures that the source map settings are similar to other Scratch 3.0 repositories. This was previously part of #508.
