### PR TITLE
Separate downloading from installation of sprite info

### DIFF
--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -7,7 +7,7 @@ var log = require('../util/log');
  * @property {string} md5 - the MD5 and extension of the sound to be loaded.
  * @property {Buffer} data - sound data will be written here once loaded.
  * @param {!Runtime} runtime - Scratch runtime, used to access the storage module.
- * @returns {!Promise} - a promise which will resolves to the sound when ready.
+ * @returns {!Promise} - a promise which will resolve to the sound when ready.
  */
 var loadSound = function (sound, runtime) {
     if (!runtime.storage) {

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -7,7 +7,7 @@ var log = require('../util/log');
  * @property {string} md5 - the MD5 and extension of the sound to be loaded.
  * @property {Buffer} data - sound data will be written here once loaded.
  * @param {!Runtime} runtime - Scratch runtime, used to access the storage module.
- * @returns {!Promise} - a promise which will resolve after sound is loaded
+ * @returns {!Promise} - a promise which will resolves to the sound when ready.
  */
 var loadSound = function (sound, runtime) {
     if (!runtime.storage) {
@@ -22,7 +22,9 @@ var loadSound = function (sound, runtime) {
     var md5 = idParts[0];
     return runtime.storage.load(AssetType.Sound, md5).then(function (soundAsset) {
         sound.data = soundAsset.data;
-        return runtime.audioEngine.decodeSound(sound);
+        return runtime.audioEngine.decodeSound(sound).then(function () {
+            return sound;
+        });
     });
 };
 

--- a/src/import/sb2import.js
+++ b/src/import/sb2import.js
@@ -29,7 +29,7 @@ var parseScratchObject = function (object, runtime, topLevel) {
     if (!object.hasOwnProperty('objName')) {
         // Watcher/monitor - skip this object until those are implemented in VM.
         // @todo
-        return null;
+        return Promise.resolve(null);
     }
     // Blocks container for this object.
     var blocks = new Blocks();

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -152,15 +152,22 @@ VirtualMachine.prototype.postIOData = function (device, data) {
  * @param {?string} json JSON string representing the project.
  */
 VirtualMachine.prototype.loadProject = function (json) {
-    this.clear();
+    var that = this;
     // @todo: Handle other formats, e.g., Scratch 1.4, Scratch 3.0.
-    sb2import(json, this.runtime);
-    // Select the first target for editing, e.g., the first sprite.
-    this.editingTarget = this.runtime.targets[1];
-    // Update the VM user's knowledge of targets and blocks on the workspace.
-    this.emitTargetsUpdate();
-    this.emitWorkspaceUpdate();
-    this.runtime.setEditingTarget(this.editingTarget);
+    sb2import(json, this.runtime).then(function (targets) {
+        that.clear();
+        for (var n = 0; n < targets.length; n++) {
+            that.runtime.targets.push(targets[n]);
+            that.runtime.targets[n].updateAllDrawableProperties();
+        }
+        // Select the first target for editing, e.g., the first sprite.
+        that.editingTarget = that.runtime.targets[1];
+
+        // Update the VM user's knowledge of targets and blocks on the workspace.
+        that.emitTargetsUpdate();
+        that.emitWorkspaceUpdate();
+        that.runtime.setEditingTarget(that.editingTarget);
+    });
 };
 
 /**
@@ -185,11 +192,15 @@ VirtualMachine.prototype.downloadProjectId = function (id) {
  */
 VirtualMachine.prototype.addSprite2 = function (json) {
     // Select new sprite.
-    this.editingTarget = sb2import(json, this.runtime, true);
-    // Update the VM user's knowledge of targets and blocks on the workspace.
-    this.emitTargetsUpdate();
-    this.emitWorkspaceUpdate();
-    this.runtime.setEditingTarget(this.editingTarget);
+    var that = this;
+    sb2import(json, this.runtime, true).then(function (targets) {
+        that.runtime.targets.push(targets[0]);
+        that.editingTarget = targets[0];
+        // Update the VM user's knowledge of targets and blocks on the workspace.
+        that.emitTargetsUpdate();
+        that.emitWorkspaceUpdate();
+        that.runtime.setEditingTarget(that.editingTarget);
+    });
 };
 
 /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -150,15 +150,18 @@ VirtualMachine.prototype.postIOData = function (device, data) {
 /**
  * Load a project from a Scratch 2.0 JSON representation.
  * @param {?string} json JSON string representing the project.
+ * @return {!Promise} Promise that resolves after targets are installed.
  */
 VirtualMachine.prototype.loadProject = function (json) {
     var that = this;
     // @todo: Handle other formats, e.g., Scratch 1.4, Scratch 3.0.
-    sb2import(json, this.runtime).then(function (targets) {
+    return sb2import(json, this.runtime).then(function (targets) {
         that.clear();
         for (var n = 0; n < targets.length; n++) {
-            that.runtime.targets.push(targets[n]);
-            that.runtime.targets[n].updateAllDrawableProperties();
+            if (targets[n] !== null) {
+                that.runtime.targets.push(targets[n]);
+                targets[n].updateAllDrawableProperties();
+            }
         }
         // Select the first target for editing, e.g., the first sprite.
         that.editingTarget = that.runtime.targets[1];

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -153,24 +153,23 @@ VirtualMachine.prototype.postIOData = function (device, data) {
  * @return {!Promise} Promise that resolves after targets are installed.
  */
 VirtualMachine.prototype.loadProject = function (json) {
-    var that = this;
     // @todo: Handle other formats, e.g., Scratch 1.4, Scratch 3.0.
     return sb2import(json, this.runtime).then(function (targets) {
-        that.clear();
+        this.clear();
         for (var n = 0; n < targets.length; n++) {
             if (targets[n] !== null) {
-                that.runtime.targets.push(targets[n]);
+                this.runtime.targets.push(targets[n]);
                 targets[n].updateAllDrawableProperties();
             }
         }
         // Select the first target for editing, e.g., the first sprite.
-        that.editingTarget = that.runtime.targets[1];
+        this.editingTarget = this.runtime.targets[1];
 
         // Update the VM user's knowledge of targets and blocks on the workspace.
-        that.emitTargetsUpdate();
-        that.emitWorkspaceUpdate();
-        that.runtime.setEditingTarget(that.editingTarget);
-    });
+        this.emitTargetsUpdate();
+        this.emitWorkspaceUpdate();
+        this.runtime.setEditingTarget(this.editingTarget);
+    }.bind(this));
 };
 
 /**
@@ -195,15 +194,14 @@ VirtualMachine.prototype.downloadProjectId = function (id) {
  */
 VirtualMachine.prototype.addSprite2 = function (json) {
     // Select new sprite.
-    var that = this;
     sb2import(json, this.runtime, true).then(function (targets) {
-        that.runtime.targets.push(targets[0]);
-        that.editingTarget = targets[0];
+        this.runtime.targets.push(targets[0]);
+        this.editingTarget = targets[0];
         // Update the VM user's knowledge of targets and blocks on the workspace.
-        that.emitTargetsUpdate();
-        that.emitWorkspaceUpdate();
-        that.runtime.setEditingTarget(that.editingTarget);
-    });
+        this.emitTargetsUpdate();
+        this.emitWorkspaceUpdate();
+        this.runtime.setEditingTarget(this.editingTarget);
+    }.bind(this));
 };
 
 /**

--- a/test/integration/complex.js
+++ b/test/integration/complex.js
@@ -60,38 +60,40 @@ test('complex', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-        // Post IO data
-        vm.postIOData('mouse', {
-            isDown: true,
-            x: 0,
-            y: 10,
-            canvasWidth: 100,
-            canvasHeight: 100
+            // Post IO data
+            vm.postIOData('mouse', {
+                isDown: true,
+                x: 0,
+                y: 10,
+                canvasWidth: 100,
+                canvasHeight: 100
+            });
+
+            // Add sprite
+            vm.addSprite2(sprite);
+
+            // Add backdrop
+            vm.addBackdrop(
+                '6b3d87ba2a7f89be703163b6c1d4c964.png',
+                {
+                    costumeName: 'baseball-field',
+                    baseLayerID: 26,
+                    baseLayerMD5: '6b3d87ba2a7f89be703163b6c1d4c964.png',
+                    bitmapResolution: 2,
+                    rotationCenterX: 480,
+                    rotationCenterY: 360
+                }
+            );
+
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
         });
-
-        // Add sprite
-        vm.addSprite2(sprite);
-
-        // Add backdrop
-        vm.addBackdrop(
-            '6b3d87ba2a7f89be703163b6c1d4c964.png',
-            {
-                costumeName: 'baseball-field',
-                baseLayerID: 26,
-                baseLayerMD5: '6b3d87ba2a7f89be703163b6c1d4c964.png',
-                bitmapResolution: 2,
-                rotationCenterX: 480,
-                rotationCenterY: 360
-            }
-        );
     });
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
 });

--- a/test/integration/control.js
+++ b/test/integration/control.js
@@ -25,8 +25,9 @@ test('control', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
+        });
     });
 
     // After two seconds, get playground data and stop

--- a/test/integration/data.js
+++ b/test/integration/data.js
@@ -24,13 +24,14 @@ test('data', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/event.js
+++ b/test/integration/event.js
@@ -25,13 +25,14 @@ test('event', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/hat-execution-order.js
+++ b/test/integration/hat-execution-order.js
@@ -29,13 +29,14 @@ test('complex', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/import_sb2.js
+++ b/test/integration/import_sb2.js
@@ -20,33 +20,33 @@ test('default', function (t) {
     // Create runtime instance & load SB2 into it
     var rt = new runtime();
     attachTestStorage(rt);
-    sb2(file, rt);
+    sb2(file, rt).then(function (targets) {
+        // Test
+        t.type(file, 'string');
+        t.type(rt, 'object');
+        t.type(targets, 'object');
 
-    // Test
-    t.type(file, 'string');
-    t.type(rt, 'object');
-    t.type(rt.targets, 'object');
+        t.ok(targets[0] instanceof renderedTarget);
+        t.type(targets[0].id, 'string');
+        t.type(targets[0].blocks, 'object');
+        t.type(targets[0].variables, 'object');
+        t.type(targets[0].lists, 'object');
 
-    t.ok(rt.targets[0] instanceof renderedTarget);
-    t.type(rt.targets[0].id, 'string');
-    t.type(rt.targets[0].blocks, 'object');
-    t.type(rt.targets[0].variables, 'object');
-    t.type(rt.targets[0].lists, 'object');
+        t.equal(targets[0].isOriginal, true);
+        t.equal(targets[0].currentCostume, 0);
+        t.equal(targets[0].isOriginal, true);
+        t.equal(targets[0].isStage, true);
 
-    t.equal(rt.targets[0].isOriginal, true);
-    t.equal(rt.targets[0].currentCostume, 0);
-    t.equal(rt.targets[0].isOriginal, true);
-    t.equal(rt.targets[0].isStage, true);
+        t.ok(targets[1] instanceof renderedTarget);
+        t.type(targets[1].id, 'string');
+        t.type(targets[1].blocks, 'object');
+        t.type(targets[1].variables, 'object');
+        t.type(targets[1].lists, 'object');
 
-    t.ok(rt.targets[1] instanceof renderedTarget);
-    t.type(rt.targets[1].id, 'string');
-    t.type(rt.targets[1].blocks, 'object');
-    t.type(rt.targets[1].variables, 'object');
-    t.type(rt.targets[1].lists, 'object');
-
-    t.equal(rt.targets[1].isOriginal, true);
-    t.equal(rt.targets[1].currentCostume, 0);
-    t.equal(rt.targets[1].isOriginal, true);
-    t.equal(rt.targets[1].isStage, false);
-    t.end();
+        t.equal(targets[1].isOriginal, true);
+        t.equal(targets[1].currentCostume, 0);
+        t.equal(targets[1].isOriginal, true);
+        t.equal(targets[1].isStage, false);
+        t.end();
+    });
 });

--- a/test/integration/looks.js
+++ b/test/integration/looks.js
@@ -25,13 +25,14 @@ test('looks', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/motion.js
+++ b/test/integration/motion.js
@@ -25,13 +25,14 @@ test('motion', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/pen.js
+++ b/test/integration/pen.js
@@ -24,13 +24,14 @@ test('pen', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/procedure.js
+++ b/test/integration/procedure.js
@@ -25,13 +25,14 @@ test('procedure', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/sensing.js
+++ b/test/integration/sensing.js
@@ -25,13 +25,14 @@ test('sensing', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });

--- a/test/integration/sound.js
+++ b/test/integration/sound.js
@@ -25,13 +25,14 @@ test('sound', function (t) {
         vm.clear();
         vm.setCompatibilityMode(false);
         vm.setTurboMode(false);
-        vm.loadProject(project);
-        vm.greenFlag();
-    });
+        vm.loadProject(project).then(function () {
+            vm.greenFlag();
 
-    // After two seconds, get playground data and stop
-    setTimeout(function () {
-        vm.getPlaygroundData();
-        vm.stopAll();
-    }, 2000);
+            // After two seconds, get playground data and stop
+            setTimeout(function () {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/278

### Proposed Changes

_Describe what this Pull Request does_

Changes the order of operations when loading a project so that the downloading of all sprite assets completes before installing the new targets into the runtime.

### Reason for Changes

_Explain why these changes should be made_

The introduction of scratch-storage made the loading happen in an indeterminate order, which caused some issues when loading projects / rendering sprites. This forces all downloading to complete before telling the GUI anything. 

### Test Coverage

_Please show how you have added tests to cover your changes_
Updated the tests to work correctly.