### PR TITLE
Get `Asset` and `AssetType` from storage instance

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -1,4 +1,3 @@
-const AssetType = require('scratch-storage').AssetType;
 const log = require('../util/log');
 
 /**
@@ -19,7 +18,7 @@ const loadCostume = function (md5ext, costume, runtime) {
         return Promise.resolve(costume);
     }
 
-
+    const AssetType = runtime.storage.AssetType;
     const idParts = md5ext.split('.');
     const md5 = idParts[0];
     const ext = idParts[1].toUpperCase();

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -1,4 +1,3 @@
-const AssetType = require('scratch-storage').AssetType;
 const log = require('../util/log');
 
 /**
@@ -20,7 +19,7 @@ const loadSound = function (sound, runtime) {
     }
     const idParts = sound.md5.split('.');
     const md5 = idParts[0];
-    return runtime.storage.load(AssetType.Sound, md5).then(soundAsset => {
+    return runtime.storage.load(runtime.storage.AssetType.Sound, md5).then(soundAsset => {
         sound.data = soundAsset.data;
         return runtime.audioEngine.decodeSound(sound).then(() => sound);
     });

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -47,7 +47,7 @@ window.onload = function () {
     Scratch.vm = vm;
 
     const storage = new Scratch.Storage();
-    const AssetType = Scratch.Storage.AssetType;
+    const AssetType = storage.AssetType;
     storage.addWebSource([AssetType.Project], getProjectUrl);
     storage.addWebSource([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], getAssetUrl);
     vm.attachStorage(storage);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -2,7 +2,6 @@ const EventEmitter = require('events');
 
 const log = require('./util/log');
 const Runtime = require('./engine/runtime');
-const ScratchStorage = require('scratch-storage');
 const sb2import = require('./import/sb2import');
 const StringUtil = require('./util/string-util');
 
@@ -10,8 +9,6 @@ const loadCostume = require('./import/load-costume.js');
 const loadSound = require('./import/load-sound.js');
 
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
-
-const AssetType = ScratchStorage.AssetType;
 
 /**
  * Handles connections between blocks, stage, and extensions.
@@ -170,12 +167,13 @@ class VirtualMachine extends EventEmitter {
      * @param {string} id - the ID of the project to download, as a string.
      */
     downloadProjectId (id) {
-        if (!this.runtime.storage) {
+        const storage = this.runtime.storage;
+        if (!storage) {
             log.error('No storage module present; cannot load project: ', id);
             return;
         }
         const vm = this;
-        const promise = this.runtime.storage.load(AssetType.Project, id);
+        const promise = storage.load(storage.AssetType.Project, id);
         promise.then(projectAsset => {
             vm.loadProject(projectAsset.decodeText());
         });

--- a/test/fixtures/attach-test-storage.js
+++ b/test/fixtures/attach-test-storage.js
@@ -38,7 +38,7 @@ var getAssetUrl = function (asset) {
  */
 var attachTestStorage = function (vm) {
     var storage = new ScratchStorage();
-    var AssetType = ScratchStorage.AssetType;
+    var AssetType = storage.AssetType;
     storage.addWebSource([AssetType.Project], getProjectUrl);
     storage.addWebSource([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], getAssetUrl);
     vm.attachStorage(storage);


### PR DESCRIPTION
### Proposed Changes

Access `Asset` and `AssetType` through an instance of `ScratchStorage`. Remove all instances of `require('scratch-storage')` from this repository.

This requires LLK/scratch-storage#9

### Reason for Changes

This change means `scratch-storage` is no longer built into the `scratch-vm` build output.

### Test Coverage

The existing storage-related test code has been updated.