### PR TITLE
the right quots is missing in blockToXML

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -407,7 +407,7 @@ class Blocks {
                 id="${block.id}"
                 type="${block.opcode}"
                 ${block.topLevel ?
-                    `x="${block.x} y="${block.y}` :
+                    `x="${block.x}" y="${block.y}"` :
                     ''
                 }
             >`;


### PR DESCRIPTION
the right quote is missing in blockToXML, it will result in the following code execution errors

        vm.on('workspaceUpdate', function (data) {
            workspace.clear();
            var dom = Blockly.Xml.textToDom(data.xml);
            Blockly.Xml.domToWorkspace(dom, workspace);
        });