### PR TITLE
Fix sprite not drawing after being added

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -184,11 +184,12 @@ class VirtualMachine extends EventEmitter {
      * @param {string} json JSON string representing the sprite.
      */
     addSprite2 (json) {
-    // Select new sprite.
         sb2import(json, this.runtime, true).then(targets => {
             this.runtime.targets.push(targets[0]);
             this.editingTarget = targets[0];
-        // Update the VM user's knowledge of targets and blocks on the workspace.
+            this.editingTarget.updateAllDrawableProperties();
+
+            // Update the VM user's knowledge of targets and blocks on the workspace.
             this.emitTargetsUpdate();
             this.emitWorkspaceUpdate();
             this.runtime.setEditingTarget(this.editingTarget);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/546

### Proposed Changes

_Describe what this Pull Request does_

When we refactored the `sb2import` function we took the responsibility for updating drawable out of the import itself. I forgot to add it back to the caller function the way that I did on line 152 for `loadProject`. 

broken
![add-sprite--broken](https://cloud.githubusercontent.com/assets/654102/25490296/6b35b858-2b3a-11e7-8ede-607efcf19c6b.gif)

fixed
![add-sprite--fixed](https://cloud.githubusercontent.com/assets/654102/25490294/6907ec54-2b3a-11e7-95c9-cab68222ad7f.gif)