### PR TITLE
Fix the next thread is skipped after clone deleted

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -590,6 +590,7 @@ class Runtime extends EventEmitter {
                 continue;
             }
             if (this.threads[i].target === target) {
+                this.threads[i].isKilled = true;
                 this._removeThread(this.threads[i]);
             }
         }

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -69,6 +69,9 @@ class Sequencer {
                     // Normal-mode thread: step.
                     this.stepThread(activeThread);
                     activeThread.warpTimer = null;
+                    if (activeThread.isKilled) {
+                        i--;    // if the thread is removed from the list (killed), do not increase index
+                    }
                 }
                 if (activeThread.status === Thread.STATUS_RUNNING) {
                     numActiveThreads++;

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -31,6 +31,12 @@ class Thread {
         this.status = 0; /* Thread.STATUS_RUNNING */
 
         /**
+         * Whether the thread is killed in the middle of execution.
+         * @type {boolean}
+         */
+        this.isKilled = false;
+
+        /**
          * Target of this thread.
          * @type {?Target}
          */


### PR DESCRIPTION
This resolved scratch-gui [issue 206](https://github.com/LLK/scratch-gui/issues/206).

Problem:
When a clone is deleted, its thread is removed from the thread
list; but the index "i" in the execution for-loop will still +1,
making the next thread skipped.

Changes:
Added a flag "isKilled" on a thread;
Set the flag when a thread is removed from the thread list;
reduce the "i" counter if the thread of the current loop is removed

### Test Coverage

No test affected.
