### PR TITLE
Stop emitting SPRITE_INFO_REPORT

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -197,7 +197,7 @@ class RenderedTarget extends Target {
             this.y = y;
         }
         this.emit(RenderedTarget.EVENT_TARGET_MOVED, this, oldX, oldY);
-        this.runtime.spriteInfoReport(this);
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**
@@ -240,7 +240,7 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         }
-        this.runtime.spriteInfoReport(this);
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**
@@ -250,7 +250,7 @@ class RenderedTarget extends Target {
     setDraggable (draggable) {
         if (this.isStage) return;
         this.draggable = !!draggable;
-        this.runtime.spriteInfoReport(this);
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**
@@ -287,7 +287,7 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         }
-        this.runtime.spriteInfoReport(this);
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**
@@ -386,7 +386,7 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         }
-        this.runtime.spriteInfoReport(this);
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**
@@ -411,7 +411,7 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         }
-        this.runtime.spriteInfoReport(this);
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**
@@ -483,7 +483,7 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         }
-        this.runtime.spriteInfoReport(this);
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -19,42 +19,41 @@ class VirtualMachine extends EventEmitter {
     constructor () {
         super();
 
-        const instance = this;
         /**
          * VM runtime, to store blocks, I/O devices, sprites/targets, etc.
          * @type {!Runtime}
          */
-        instance.runtime = new Runtime();
+        this.runtime = new Runtime();
         /**
          * The "currently editing"/selected target ID for the VM.
          * Block events from any Blockly workspace are routed to this target.
          * @type {!string}
          */
-        instance.editingTarget = null;
+        this.editingTarget = null;
         // Runtime emits are passed along as VM emits.
-        instance.runtime.on(Runtime.SCRIPT_GLOW_ON, glowData => {
-            instance.emit(Runtime.SCRIPT_GLOW_ON, glowData);
+        this.runtime.on(Runtime.SCRIPT_GLOW_ON, glowData => {
+            this.emit(Runtime.SCRIPT_GLOW_ON, glowData);
         });
-        instance.runtime.on(Runtime.SCRIPT_GLOW_OFF, glowData => {
-            instance.emit(Runtime.SCRIPT_GLOW_OFF, glowData);
+        this.runtime.on(Runtime.SCRIPT_GLOW_OFF, glowData => {
+            this.emit(Runtime.SCRIPT_GLOW_OFF, glowData);
         });
-        instance.runtime.on(Runtime.BLOCK_GLOW_ON, glowData => {
-            instance.emit(Runtime.BLOCK_GLOW_ON, glowData);
+        this.runtime.on(Runtime.BLOCK_GLOW_ON, glowData => {
+            this.emit(Runtime.BLOCK_GLOW_ON, glowData);
         });
-        instance.runtime.on(Runtime.BLOCK_GLOW_OFF, glowData => {
-            instance.emit(Runtime.BLOCK_GLOW_OFF, glowData);
+        this.runtime.on(Runtime.BLOCK_GLOW_OFF, glowData => {
+            this.emit(Runtime.BLOCK_GLOW_OFF, glowData);
         });
-        instance.runtime.on(Runtime.PROJECT_RUN_START, () => {
-            instance.emit(Runtime.PROJECT_RUN_START);
+        this.runtime.on(Runtime.PROJECT_RUN_START, () => {
+            this.emit(Runtime.PROJECT_RUN_START);
         });
-        instance.runtime.on(Runtime.PROJECT_RUN_STOP, () => {
-            instance.emit(Runtime.PROJECT_RUN_STOP);
+        this.runtime.on(Runtime.PROJECT_RUN_STOP, () => {
+            this.emit(Runtime.PROJECT_RUN_STOP);
         });
-        instance.runtime.on(Runtime.VISUAL_REPORT, visualReport => {
-            instance.emit(Runtime.VISUAL_REPORT, visualReport);
+        this.runtime.on(Runtime.VISUAL_REPORT, visualReport => {
+            this.emit(Runtime.VISUAL_REPORT, visualReport);
         });
-        instance.runtime.on(Runtime.SPRITE_INFO_REPORT, spriteInfo => {
-            instance.emit(Runtime.SPRITE_INFO_REPORT, spriteInfo);
+        this.runtime.on(Runtime.TARGETS_UPDATE, () => {
+            this.emitTargetsUpdate();
         });
 
         this.blockListener = this.blockListener.bind(this);


### PR DESCRIPTION
Instead, set the `_refreshTargets` flag, and emit a full target list at the end of the step.

This reduces the amount of work the GUI has to do to update the UI, since it can stop merging sprite data into its list of targets.

/cc @cwillisf @thisandagain @fsih 