### PR TITLE
Fix update emitting for new costumes

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -645,7 +645,6 @@ class Runtime extends EventEmitter {
      * inactive threads after each iteration.
      */
     _step () {
-        this._refreshTargets = false;
         // Find all edge-activated hats, and add them to threads to be evaluated.
         for (const hatType in this._hats) {
             if (!this._hats.hasOwnProperty(hatType)) continue;
@@ -663,7 +662,10 @@ class Runtime extends EventEmitter {
             // @todo: Only render when this.redrawRequested or clones rendered.
             this.renderer.draw();
         }
-        if (this._refreshTargets) this.emit(Runtime.TARGETS_UPDATE);
+        if (this._refreshTargets) {
+            this.emit(Runtime.TARGETS_UPDATE);
+            this._refreshTargets = false;
+        }
     }
 
     /**


### PR DESCRIPTION
### Resolves

Fixes an issue where adding a costume from the library does not update the costume tab list. 

### Proposed Changes

~~This PR emits a targets update event directly. Previously it relied on the fact that `setCostume` eventually called `emitTargetsUpdate`, but now those operations are requested instead of emitted directly. However, this is an operation that we do want to emit directly.~~

Update: see @rschamp comment below. The real cause of this was a race condition with refreshTargets code in runtime#_step. Gifs still depict the new behavior. 

Here is the old behavior. You can see that the costume doesn't show up until you do something else.
![add-costume-no-refresh](https://cloud.githubusercontent.com/assets/654102/26057566/3ebee1b6-3948-11e7-84fa-314e30d423d1.gif)


With this change, the costume shows up on its own. 
![add-costume-force-refresh](https://cloud.githubusercontent.com/assets/654102/26057592/4d816df4-3948-11e7-8145-3e173303d941.gif)
