### PR TITLE
Fix sprite rename incrementing when renamed to itself

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -329,9 +329,8 @@ class VirtualMachine extends EventEmitter {
             }
             if (newName && RESERVED_NAMES.indexOf(newName) === -1) {
                 const names = this.runtime.targets
-                    .filter(runtimeTarget => runtimeTarget.isSprite())
+                    .filter(runtimeTarget => runtimeTarget.isSprite() && runtimeTarget.id !== target.id)
                     .map(runtimeTarget => runtimeTarget.sprite.name);
-
                 sprite.name = StringUtil.unusedName(newName, names);
             }
             this.emitTargetsUpdate();

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -94,3 +94,18 @@ test('renameSprite increments from existing sprite names', t => {
     t.equal(vm.runtime.targets[0].sprite.name, 'that name2');
     t.end();
 });
+
+test('renameSprite does not increment when renaming to the same name', t => {
+    const vm = new VirtualMachine();
+    vm.emitTargetsUpdate = () => {};
+    vm.runtime.targets = [{
+        id: 'id1',
+        isSprite: () => true,
+        sprite: {
+            name: 'this name'
+        }
+    }];
+    vm.renameSprite('id1', 'this name');
+    t.equal(vm.runtime.targets[0].sprite.name, 'this name');
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolves https://github.com/LLK/scratch-gui/issues/370

### Proposed Changes

_Describe what this Pull Request does_
Filter out your own sprite name when creating the list of names to consider "used" when renaming. 

### Reason for Changes

_Explain why these changes should be made_
See comment on https://github.com/LLK/scratch-gui/issues/370
### Test Coverage

_Please show how you have added tests to cover your changes_
Added a test for this case.