### PR TITLE
Send monitor opcode and block params instead of fixed label/categories

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -268,6 +268,25 @@ class Blocks {
     }
 
     /**
+     * Serialize block fields and input fields for reporting new monitors
+     * @param {!object} block Block to be paramified.
+     * @return {!object} object of param key/values.
+     */
+    getBlockParams (block) {
+        const params = {};
+        for (const key in block.fields) {
+            params[key] = block.fields[key].value;
+        }
+        for (const inputKey in block.inputs) {
+            const inputBlock = this._blocks[block.inputs[inputKey].block];
+            for (const key in inputBlock.fields) {
+                params[key] = inputBlock.fields[key].value;
+            }
+        }
+        return params;
+    }
+
+    /**
      * Block management: change block field values
      * @param {!object} args Blockly change event to be processed
      * @param {?Runtime} optRuntime Optional runtime to allow changeBlock to change VM state.
@@ -297,6 +316,7 @@ class Blocks {
                     // @todo(vm#564) this will collide if multiple sprites use same block
                     id: block.id,
                     opcode: block.opcode,
+                    params: this.getBlockParams(block),
                     // @todo(vm#565) for numerical values with decimals, some countries use comma
                     value: ''
                 });

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -278,7 +278,7 @@ class Blocks {
         const block = this._blocks[args.id];
         if (typeof block === 'undefined') return;
 
-        let wasMonitored = block.isMonitored;
+        const wasMonitored = block.isMonitored;
         switch (args.element) {
         case 'field':
             // Update block value
@@ -293,22 +293,17 @@ class Blocks {
             if (optRuntime && wasMonitored && !block.isMonitored) {
                 optRuntime.requestRemoveMonitor(block.id);
             } else if (optRuntime && !wasMonitored && block.isMonitored) {
-                optRuntime.requestAddMonitor(
-                    // Ensure that value is not undefined, since React requires it
-                    {
-                        // @todo(vm#564) this will collide if multiple sprites use same block
-                        id: block.id,
-                        category: 'data',
-                        // @todo(vm#565) how to handle translation here?
-                        label: block.opcode,
-                        // @todo(vm#565) for numerical values with decimals, some countries use comma
-                        value: '',
-                        x: 0,
-                        // @todo(vm#566) Don't require sending x and y when instantiating a
-                        // monitor. If it's not preset the GUI should decide.
-                        y: 0
-                    }
-                );
+                optRuntime.requestAddMonitor({
+                    // @todo(vm#564) this will collide if multiple sprites use same block
+                    id: block.id,
+                    opcode: block.opcode,
+                    // @todo(vm#565) for numerical values with decimals, some countries use comma
+                    value: '',
+                    // @todo(vm#566) Don't require sending x and y when instantiating a
+                    // monitor. If it's not preset the GUI should decide.
+                    x: 0,
+                    y: 0
+                });
             }
             break;
         }
@@ -370,7 +365,7 @@ class Blocks {
         }
     }
 
-    
+
     /**
      * Block management: run all blocks.
      * @param {!object} runtime Runtime to run all blocks in.

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -268,25 +268,6 @@ class Blocks {
     }
 
     /**
-     * Serialize block fields and input fields for reporting new monitors
-     * @param {!object} block Block to be paramified.
-     * @return {!object} object of param key/values.
-     */
-    getBlockParams (block) {
-        const params = {};
-        for (const key in block.fields) {
-            params[key] = block.fields[key].value;
-        }
-        for (const inputKey in block.inputs) {
-            const inputBlock = this._blocks[block.inputs[inputKey].block];
-            for (const key in inputBlock.fields) {
-                params[key] = inputBlock.fields[key].value;
-            }
-        }
-        return params;
-    }
-
-    /**
      * Block management: change block field values
      * @param {!object} args Blockly change event to be processed
      * @param {?Runtime} optRuntime Optional runtime to allow changeBlock to change VM state.
@@ -316,7 +297,7 @@ class Blocks {
                     // @todo(vm#564) this will collide if multiple sprites use same block
                     id: block.id,
                     opcode: block.opcode,
-                    params: this.getBlockParams(block),
+                    params: this._getBlockParams(block),
                     // @todo(vm#565) for numerical values with decimals, some countries use comma
                     value: ''
                 });
@@ -525,6 +506,24 @@ class Blocks {
     }
 
     // ---------------------------------------------------------------------
+    /**
+     * Helper to serialize block fields and input fields for reporting new monitors
+     * @param {!object} block Block to be paramified.
+     * @return {!object} object of param key/values.
+     */
+    _getBlockParams (block) {
+        const params = {};
+        for (const key in block.fields) {
+            params[key] = block.fields[key].value;
+        }
+        for (const inputKey in block.inputs) {
+            const inputBlock = this._blocks[block.inputs[inputKey].block];
+            for (const key in inputBlock.fields) {
+                params[key] = inputBlock.fields[key].value;
+            }
+        }
+        return params;
+    }
 
     /**
      * Helper to add a stack to `this._scripts`.

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -298,11 +298,7 @@ class Blocks {
                     id: block.id,
                     opcode: block.opcode,
                     // @todo(vm#565) for numerical values with decimals, some countries use comma
-                    value: '',
-                    // @todo(vm#566) Don't require sending x and y when instantiating a
-                    // monitor. If it's not preset the GUI should decide.
-                    x: 0,
-                    y: 0
+                    value: ''
                 });
             }
             break;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Goes to resolving https://github.com/LLK/scratch-gui/issues/375

### Proposed Changes

_Describe what this Pull Request does_

Send block opcode instead of a label, allowing the GUI to decide how to label, categorize and layout the monitors.