### PR TITLE
Specify dataFormat when loading asset for import

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "scratch-audio": "^0.1.0-prerelease.0",
     "scratch-blocks": "^0.1.0-prerelease.0",
     "scratch-render": "^0.1.0-prerelease.0",
-    "scratch-storage": "^0.1.0",
+    "scratch-storage": "^0.2.0",
     "script-loader": "0.7.0",
     "stats.js": "^0.17.0",
     "tap": "^10.2.0",

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -1,3 +1,4 @@
+const StringUtil = require('../util/string-util');
 const log = require('../util/log');
 
 /**
@@ -19,17 +20,17 @@ const loadCostume = function (md5ext, costume, runtime) {
     }
 
     const AssetType = runtime.storage.AssetType;
-    const idParts = md5ext.split('.');
+    const idParts = StringUtil.splitFirst(md5ext, '.');
     const md5 = idParts[0];
-    const ext = idParts[1].toUpperCase();
-    const assetType = (ext === 'SVG') ? AssetType.ImageVector : AssetType.ImageBitmap;
+    const ext = idParts[1].toLowerCase();
+    const assetType = (ext === 'svg') ? AssetType.ImageVector : AssetType.ImageBitmap;
 
     const rotationCenter = [
         costume.rotationCenterX / costume.bitmapResolution,
         costume.rotationCenterY / costume.bitmapResolution
     ];
 
-    let promise = runtime.storage.load(assetType, md5).then(costumeAsset => {
+    let promise = runtime.storage.load(assetType, md5, ext).then(costumeAsset => {
         costume.assetId = costumeAsset.assetId;
         costume.assetType = assetType;
         return costumeAsset;

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -1,3 +1,4 @@
+const StringUtil = require('../util/string-util');
 const log = require('../util/log');
 
 /**
@@ -17,9 +18,10 @@ const loadSound = function (sound, runtime) {
         log.error('No audio engine present; cannot load sound asset: ', sound.md5);
         return Promise.resolve(sound);
     }
-    const idParts = sound.md5.split('.');
+    const idParts = StringUtil.splitFirst(sound.md5, '.');
     const md5 = idParts[0];
-    return runtime.storage.load(runtime.storage.AssetType.Sound, md5)
+    const ext = idParts[1].toLowerCase();
+    return runtime.storage.load(runtime.storage.AssetType.Sound, md5, ext)
         .then(soundAsset => {
             sound.assetId = soundAsset.assetId;
             sound.assetType = runtime.storage.AssetType.Sound;

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -34,7 +34,7 @@ const getAssetUrl = function (asset) {
         'internalapi/asset/',
         asset.assetId,
         '.',
-        asset.assetType.runtimeFormat,
+        asset.dataFormat,
         '/get/'
     ];
     return assetUrlParts.join('');

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -75,7 +75,7 @@ const parseScratchObject = function (object, runtime) {
             rotationCenterX: costumeSource.rotationCenterX,
             rotationCenterY: costumeSource.rotationCenterY
         };
-        const costumeMd5 = `${costumeSource.assetId}.${costumeSource.assetType.runtimeFormat}`;
+        const costumeMd5 = `${costumeSource.assetId}.${costumeSource.dataFormat}`;
         return loadCostume(costumeMd5, costume, runtime);
     });
     // Sounds from JSON

--- a/src/util/string-util.js
+++ b/src/util/string-util.js
@@ -12,6 +12,30 @@ class StringUtil {
         while (existingNames.indexOf(name + i) >= 0) i++;
         return name + i;
     }
+
+    /**
+     * Split a string on the first occurrence of a split character.
+     * @param {string} text - the string to split.
+     * @param {string} separator - split the text on this character.
+     * @returns {[string, string]} - the two parts of the split string, or [text, null] if no split character found.
+     * @example
+     * // returns ['foo', 'tar.gz']
+     * splitFirst('foo.tar.gz', '.');
+     * @example
+     * // returns ['foo', null]
+     * splitFirst('foo', '.');
+     * @example
+     * // returns ['foo', '']
+     * splitFirst('foo.', '.');
+     */
+    static splitFirst (text, separator) {
+        const index = text.indexOf(separator);
+        if (index >= 0) {
+            return [text.substring(0, index), text.substring(index + 1)];
+        } else {
+            return [text, null];
+        }
+    }
 }
 
 module.exports = StringUtil;

--- a/test/fixtures/attach-test-storage.js
+++ b/test/fixtures/attach-test-storage.js
@@ -26,7 +26,7 @@ const getAssetUrl = function (asset) {
         'internalapi/asset/',
         asset.assetId,
         '.',
-        asset.assetType.runtimeFormat,
+        asset.dataFormat,
         '/get/'
     ];
     return assetUrlParts.join('');

--- a/test/unit/util_string.js
+++ b/test/unit/util_string.js
@@ -1,6 +1,14 @@
 const test = require('tap').test;
 const StringUtil = require('../../src/util/string-util');
 
+test('splitFirst', t => {
+    t.deepEqual(StringUtil.splitFirst('asdf.1234', '.'), ['asdf', '1234']);
+    t.deepEqual(StringUtil.splitFirst('asdf.', '.'), ['asdf', '']);
+    t.deepEqual(StringUtil.splitFirst('.1234', '.'), ['', '1234']);
+    t.deepEqual(StringUtil.splitFirst('foo', '.'), ['foo', null]);
+    t.end();
+});
+
 test('withoutTrailingDigits', t => {
     t.strictEqual(StringUtil.withoutTrailingDigits('boeing747'), 'boeing');
     t.strictEqual(StringUtil.withoutTrailingDigits('boeing747 '), 'boeing747 ');


### PR DESCRIPTION
### Resolves

This is follow-up work on LLK/scratch-storage#7 and will not work correctly until that PR is merged.

### Proposed Changes

When importing a project we know the file extension for each asset to be loaded. This change provides that information to the storage system so that we can load assets which don't use the default.

In support of this change, there's a new function on `StringUtil` called `splitFirst`, which splits a string on the first instance of a separator character.

### Reason for Changes

Without these changes, assets with non-default file types fail to load. This includes JPEG format backdrops, for example.

### Test Coverage

This change includes unit tests for the new `StringUtil.splitFirst` function.