### PR TITLE
Add variable creation and variable serialization

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -427,11 +427,7 @@ class Blocks {
      * @return {string} String of XML representing this object's blocks.
      */
     toXML () {
-        let xmlString = '<xml xmlns="http://www.w3.org/1999/xhtml">';
-        for (let i = 0; i < this._scripts.length; i++) {
-            xmlString += this.blockToXML(this._scripts[i]);
-        }
-        return `${xmlString}</xml>`;
+        return this._scripts.map(script => this.blockToXML(script)).join();
     }
 
     /**

--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -15,6 +15,10 @@ class Variable {
         this.value = value;
         this.isCloud = isCloud;
     }
+
+    toXML () {
+        return `<variable type="">${this.name}</variable>`;
+    }
 }
 
 module.exports = Variable;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -491,9 +491,18 @@ class VirtualMachine extends EventEmitter {
      * of the current editing target's blocks.
      */
     emitWorkspaceUpdate () {
-        this.emit('workspaceUpdate', {
-            xml: this.editingTarget.blocks.toXML()
-        });
+        // @todo Include variables scoped to editing target also.
+        const variableMap = this.runtime.getTargetForStage().variables;
+        const variables = Object.keys(variableMap).map(k => variableMap[k]);
+
+        const xmlString = `<xml xmlns="http://www.w3.org/1999/xhtml">
+                            <variables>
+                                ${variables.map(v => v.toXML()).join()}
+                            </variables>
+                            ${this.editingTarget.blocks.toXML()}
+                        </xml>`;
+
+        this.emit('workspaceUpdate', {xml: xmlString});
     }
 
     /**
@@ -537,6 +546,15 @@ class VirtualMachine extends EventEmitter {
      */
     postSpriteInfo (data) {
         this.editingTarget.postSpriteInfo(data);
+    }
+
+    /**
+     * Create a variable by name.
+     * @todo this only creates global variables by putting them on the stage
+     * @param {string} name The name of the variable
+     */
+    createVariable (name) {
+        this.runtime.getTargetForStage().lookupOrCreateVariable(name);
     }
 }
 


### PR DESCRIPTION
Explicitly create global variables (on the stage) and serialize variables when updating blockly. Depends on variable serialization from https://github.com/LLK/scratch-blocks/pull/903.

Will fix https://github.com/LLK/scratch-gui/issues/350