### PR TITLE
Fix no-useless-call todo

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -114,7 +114,7 @@ class Scratch3SensingBlocks {
     }
 
     getKeyPressed (args, util) {
-        return util.ioQuery('keyboard', 'getKeyIsDown', args.KEY_OPTION);
+        return util.ioQuery('keyboard', 'getKeyIsDown', [args.KEY_OPTION]);
     }
 
     daysSince2000 () {

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -202,12 +202,7 @@ const execute = function (sequencer, thread) {
             // Find the I/O device and execute the query/function call.
             if (runtime.ioDevices[device] && runtime.ioDevices[device][func]) {
                 const devObject = runtime.ioDevices[device];
-                // @todo Figure out why eslint complains about no-useless-call
-                // no-useless-call can't tell if the call is useless for dynamic
-                // expressions... or something. Not exactly sure why it
-                // complains here.
-                // eslint-disable-next-line no-useless-call
-                return devObject[func].call(devObject, args);
+                return devObject[func].apply(devObject, args);
             }
         }
     });


### PR DESCRIPTION
The linter is correct that `devObject[func].call(devObject, args)` is unnecessary because it's equivalent to `devObject[func](args)`.

@tmickel probably either meant to allow passing an array of arguments to be applied, or to call the function with the provided argument. Since we probably want to be able to use multi-argument functions, use `apply` and fix the one place that uses `ioQuery` with an argument.
