### PR TITLE
Change wait to use a promise instead of being called every frame

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -1,5 +1,4 @@
 const Cast = require('../util/cast');
-const Timer = require('../util/timer');
 
 class Scratch3ControlBlocks {
     constructor (runtime) {

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -73,18 +73,13 @@ class Scratch3ControlBlocks {
         util.startBranch(1, true);
     }
 
-    wait (args, util) {
-        if (!util.stackFrame.timer) {
-            util.stackFrame.timer = new Timer();
-            util.stackFrame.timer.start();
-            util.yield();
-            this.runtime.requestRedraw();
-        } else {
-            const duration = Math.max(0, 1000 * Cast.toNumber(args.DURATION));
-            if (util.stackFrame.timer.timeElapsed() < duration) {
-                util.yield();
-            }
-        }
+    wait (args) {
+        const duration = Math.max(0, 1000 * Cast.toNumber(args.DURATION));
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, duration);
+        });
     }
 
     if (args, util) {


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-vm/issues/591
### Proposed Changes

Change wait block to work like wait beats block, use a promise which makes it not be called every frame

### Reason for Changes

Calling the wait function every frame with different random numbers generally causes it to finish after the smallest random number

