### PR TITLE
Use variable field instead of input shadow

### DIFF
--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -1191,9 +1191,8 @@ const specMap = {
         opcode: 'data_setvariableto',
         argMap: [
             {
-                type: 'input',
-                inputOp: 'data_variablemenu',
-                inputName: 'VARIABLE'
+                type: 'field',
+                fieldName: 'VARIABLE'
             },
             {
                 type: 'input',
@@ -1206,9 +1205,8 @@ const specMap = {
         opcode: 'data_changevariableby',
         argMap: [
             {
-                type: 'input',
-                inputOp: 'data_variablemenu',
-                inputName: 'VARIABLE'
+                type: 'field',
+                fieldName: 'VARIABLE'
             },
             {
                 type: 'input',
@@ -1221,9 +1219,8 @@ const specMap = {
         opcode: 'data_showvariable',
         argMap: [
             {
-                type: 'input',
-                inputOp: 'data_variablemenu',
-                inputName: 'VARIABLE'
+                type: 'field',
+                fieldName: 'VARIABLE'
             }
         ]
     },
@@ -1231,9 +1228,8 @@ const specMap = {
         opcode: 'data_hidevariable',
         argMap: [
             {
-                type: 'input',
-                inputOp: 'data_variablemenu',
-                inputName: 'VARIABLE'
+                type: 'field',
+                fieldName: 'VARIABLE'
             }
         ]
     },


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Required for https://github.com/LLK/scratch-blocks/pull/948 to work correctly. 

### Proposed Changes

_Describe what this Pull Request does_

Changes the specmap to see the variable dropdown as a field instead of a shadow.
