### PR TITLE
Remove all audio effects except pitch and pan

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -29,11 +29,7 @@ class Scratch3SoundBlocks {
             currentInstrument: 0,
             effects: {
                 pitch: 0,
-                pan: 0,
-                echo: 0,
-                reverb: 0,
-                fuzz: 0,
-                robot: 0
+                pan: 0
             }
         };
     }
@@ -68,11 +64,7 @@ class Scratch3SoundBlocks {
     static get EFFECT_RANGE () {
         return {
             pitch: {min: -600, max: 600},       // -5 to 5 octaves
-            pan: {min: -100, max: 100},         // 100% left to 100% right
-            echo: {min: 0, max: 100},           // 0 to max (75%) feedback
-            reverb: {min: 0, max: 100},         // wet/dry: 0 to 100% wet
-            fuzz: {min: 0, max: 100},           // wed/dry: 0 to 100% wet
-            robot: {min: 0, max: 600}           // 0 to 5 octaves
+            pan: {min: -100, max: 100}          // 100% left to 100% right
         };
     }
 


### PR DESCRIPTION
### Resolves

To address performance issues that cause the audio to drop out (as discussed [here](https://github.com/LLK/scratch-audio/issues/22) and [here](https://github.com/LLK/scratch-audio/issues/27)), we are removing the echo, reverb, fuzz and robot effects. 

Depends on this [PR](https://github.com/LLK/scratch-blocks/pull/966) in scratch-blocks.

### Proposed Changes

Remove the echo, reverb, fuzz, and robot effects.

### Reason for Changes

These effects create large numbers of webaudio nodes, which contributes to audio glitches.