### PR TITLE
ChangeBlock uses id's of variable instead of name.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -296,7 +296,16 @@ class Blocks {
         case 'field':
             // Update block value
             if (!block.fields[args.name]) return;
-            block.fields[args.name].value = args.value;
+            if (args.name === 'VARIABLE') {
+                // Get variable name using the id in args.value.
+                const variable = optRuntime.getEditingTarget().lookupVariableById(args.value);
+                if (variable) {
+                    block.fields[args.name].value = variable.name;
+                    block.fields[args.name].id = args.value;
+                }
+            } else {
+                block.fields[args.name].value = args.value;
+            }
             break;
         case 'mutation':
             block.mutation = mutationAdapter(args.value);

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -982,6 +982,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Get the editing target.
+     * @return {?Target} The editing target.
+     */
+    getEditingTarget () {
+        return this._editingTarget;
+    }
+
+    /**
      * Tell the runtime to request a redraw.
      * Use after a clone/sprite has completed some visible operation on the stage.
      */

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -71,12 +71,27 @@ class Target extends EventEmitter {
 
     /**
      * Look up a variable object, and create it if one doesn't exist.
-     * Search begins for local variables; then look for globals.
      * @param {string} id Id of the variable.
      * @param {string} name Name of the variable.
      * @return {!Variable} Variable object.
      */
     lookupOrCreateVariable (id, name) {
+        const variable = this.lookupVariableById(id);
+        if (variable) return variable;
+        // No variable with this name exists - create it locally.
+        const newVariable = new Variable(id, name, 0, false);
+        this.variables[id] = newVariable;
+        return newVariable;
+    }
+
+    /**
+     * Look up a variable object.
+     * Search begins for local variables; then look for globals.
+     * @param {string} id Id of the variable.
+     * @param {string} name Name of the variable.
+     * @return {!Variable} Variable object.
+     */
+    lookupVariableById (id) {
         // If we have a local copy, return it.
         if (this.variables.hasOwnProperty(id)) {
             return this.variables[id];
@@ -88,10 +103,6 @@ class Target extends EventEmitter {
                 return stage.variables[id];
             }
         }
-        // No variable with this name exists - create it locally.
-        const newVariable = new Variable(id, name, 0, false);
-        this.variables[id] = newVariable;
-        return newVariable;
     }
 
     /**


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-vm/issues/628

### Proposed Changes

On a block change, checks if what we are changing is a variable, if it is we use the value (which is the variable id) to find the variable name and set the block's field VARIABLE id and value correctly.

### Reason for Changes

Without this, the value of the block's field VARIABLE would be set to the passed in id, instead of the name.

