### PR TITLE
Add public API for costume and sound renaming 

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -288,6 +288,19 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * Rename a costume on the current editing target.
+     * @param {int} costumeIndex - the index of the costume to be renamed.
+     * @param {string} newName - the desired new name of the costume (will be modified if already in use).
+     */
+    renameCostume (costumeIndex, newName) {
+        const usedNames = this.editingTarget.sprite.costumes
+            .filter((costume, index) => costumeIndex !== index)
+            .map(costume => costume.name);
+        this.editingTarget.sprite.costumes[costumeIndex].name = StringUtil.unusedName(newName, usedNames);
+        this.emitTargetsUpdate();
+    }
+
+    /**
      * Delete a costume from the current editing target.
      * @param {int} costumeIndex - the index of the costume to be removed.
      */
@@ -305,6 +318,19 @@ class VirtualMachine extends EventEmitter {
             this.editingTarget.sprite.sounds.push(soundObject);
             this.emitTargetsUpdate();
         });
+    }
+
+    /**
+     * Rename a sound on the current editing target.
+     * @param {int} soundIndex - the index of the sound to be renamed.
+     * @param {string} newName - the desired new name of the sound (will be modified if already in use).
+     */
+    renameSound (soundIndex, newName) {
+        const usedNames = this.editingTarget.sprite.sounds
+            .filter((sound, index) => soundIndex !== index)
+            .map(sound => sound.name);
+        this.editingTarget.sprite.sounds[soundIndex].name = StringUtil.unusedName(newName, usedNames);
+        this.emitTargetsUpdate();
     }
 
     /**

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -109,3 +109,41 @@ test('renameSprite does not increment when renaming to the same name', t => {
     t.equal(vm.runtime.targets[0].sprite.name, 'this name');
     t.end();
 });
+
+test('renameSound sets the sound name', t => {
+    const vm = new VirtualMachine();
+    vm.editingTarget = {
+        sprite: {
+            sounds: [{name: 'first'}, {name: 'second'}]
+        }
+    };
+    vm.renameSound(0, 'hello');
+    t.equal(vm.editingTarget.sprite.sounds[0].name, 'hello');
+    t.equal(vm.editingTarget.sprite.sounds[1].name, 'second');
+    // Make sure renaming to same name doesn't increment
+    vm.renameSound(0, 'hello');
+    t.equal(vm.editingTarget.sprite.sounds[0].name, 'hello');
+    // But renaming to used name does increment
+    vm.renameSound(1, 'hello');
+    t.equal(vm.editingTarget.sprite.sounds[1].name, 'hello2');
+    t.end();
+});
+
+test('renameCostume sets the costume name', t => {
+    const vm = new VirtualMachine();
+    vm.editingTarget = {
+        sprite: {
+            costumes: [{name: 'first'}, {name: 'second'}]
+        }
+    };
+    vm.renameCostume(0, 'hello');
+    t.equal(vm.editingTarget.sprite.costumes[0].name, 'hello');
+    t.equal(vm.editingTarget.sprite.costumes[1].name, 'second');
+    // Make sure renaming to same name doesn't increment
+    vm.renameCostume(0, 'hello');
+    t.equal(vm.editingTarget.sprite.costumes[0].name, 'hello');
+    // But renaming to used name does increment
+    vm.renameCostume(1, 'hello');
+    t.equal(vm.editingTarget.sprite.costumes[1].name, 'hello2');
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-vm/issues/630

### Proposed Changes

_Describe what this Pull Request does_
Adds public `renameCostume` and `renameSound` methods to the `virtual-machine` object. This will support the sound and costume editors in the GUI. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Added tests for the usage of these methods, including tests to make sure that duplicate naming is handled correctly.

---

Questions for the reviewer (particularly @rschamp):

1. Can you think of a way to DRY up the `unusedName` code? It is now repeated in three places (rename sprites, costumes and sounds) and the way it works is always the same (gather up the other names, then use `unusedName(newName, otherNames)`
2. Should this renaming be done by the target instead of directly by the VM? @rschamp I know you previously suggested this for some other piece of code, but I'm forgetting exactly when. 
