### PR TITLE
Implement message dispatch system

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "socket.io-client": "1.7.3",
     "stats.js": "^0.17.0",
     "tap": "^10.2.0",
+    "tiny-worker": "^2.1.1",
     "webpack": "^2.4.1",
     "webpack-dev-server": "^2.4.1"
   }

--- a/src/dispatch/central-dispatch.js
+++ b/src/dispatch/central-dispatch.js
@@ -1,0 +1,173 @@
+const log = require('../util/log');
+
+/**
+ * This class serves as the central broker for message dispatch. It expects to operate on the main thread / Window and
+ * it must be informed of any Worker threads which will participate in the messaging system. From any context in the
+ * messaging system, the dispatcher's "call" method can call any method on any "service" provided in any participating
+ * context. The dispatch system will forward function arguments and return values across worker boundaries as needed.
+ * @see {WorkerDispatch}
+ */
+class CentralDispatch {
+    constructor () {
+        /**
+         * List of callback registrations for promises waiting for a response from a call to a service on another
+         * worker. A callback registration is an array of [resolve,reject] Promise functions.
+         * Calls to services on this worker don't enter this list.
+         * @type {Array.<[Function,Function]>}
+         */
+        this.callbacks = [];
+
+        /**
+         * The next callback ID to be used.
+         * @type {int}
+         */
+        this.nextCallback = 0;
+
+        /**
+         * Map of channel name to worker or local service provider.
+         * If the entry is a Worker, the service is provided by an object on that worker.
+         * Otherwise, the service is provided locally and methods on the service will be called directly.
+         * @see {setService}
+         * @type {object.<Worker|object>}
+         */
+        this.services = {};
+
+        /**
+         * List of workers attached to this dispatcher.
+         * @type {Array}
+         */
+        this.workers = [];
+    }
+
+    /**
+     * Call a particular method on a particular service, regardless of whether that service is provided locally or on
+     * a worker. If the service is provided by a worker, the `args` will be copied using the Structured Clone
+     * algorithm, except for any items which are also in the `transfer` list. Ownership of those items will be
+     * transferred to the worker, and they should not be used after this call.
+     * @example
+     *      dispatcher.call('vm', 'setData', 'cat', 42);
+     *      // this finds the worker for the 'vm' service, then on that worker calls:
+     *      vm.setData('cat', 42);
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    call (service, method, ...args) {
+        return this.transferCall(service, method, null, ...args);
+    }
+
+    /**
+     * Call a particular method on a particular service, regardless of whether that service is provided locally or on
+     * a worker. If the service is provided by a worker, the `args` will be copied using the Structured Clone
+     * algorithm, except for any items which are also in the `transfer` list. Ownership of those items will be
+     * transferred to the worker, and they should not be used after this call.
+     * @example
+     *      dispatcher.transferCall('vm', 'setData', [myArrayBuffer], 'cat', myArrayBuffer);
+     *      // this finds the worker for the 'vm' service, transfers `myArrayBuffer` to it, then on that worker calls:
+     *      vm.setData('cat', myArrayBuffer);
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {Array} [transfer] - objects to be transferred instead of copied. Must be present in `args` to be useful.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    transferCall (service, method, transfer, ...args) {
+        return new Promise((resolve, reject) => {
+            if (this.services.hasOwnProperty(service)) {
+                const provider = this.services[service];
+                if (provider instanceof Worker) {
+                    const callbackId = this.nextCallback++;
+                    this.callbacks[callbackId] = [resolve, reject];
+                    if (transfer) {
+                        provider.postMessage([service, method, callbackId, args], transfer);
+                    } else {
+                        provider.postMessage([service, method, callbackId, args]);
+                    }
+                } else {
+                    const result = provider[method].apply(provider, args);
+                    resolve(result);
+                }
+            } else {
+                reject(new Error(`Service not found: ${service}`));
+            }
+        });
+    }
+
+    /**
+     * Set a local object as the global provider of the specified service.
+     * @param {string} service - a globally unique string identifying this service. Examples: 'vm', 'gui', 'extension9'.
+     * @param {object} provider - a local object which provides this service.
+     * WARNING: Any method on the provider can be called from any worker within the dispatch system.
+     */
+    setService (service, provider) {
+        if (this.services.hasOwnProperty(service)) {
+            log.warn(`Replacing existing service provider for ${service}`);
+        }
+        this.services[service] = provider;
+    }
+
+    /**
+     * Add a worker to the message dispatch system. The worker must implement a compatible message dispatch framework.
+     * The dispatcher will immediately attempt to "handshake" with the worker.
+     * @param {Worker} worker - the worker to add into the dispatch system.
+     */
+    addWorker (worker) {
+        if (this.workers.indexOf(worker) === -1) {
+            this.workers.push(worker);
+            worker.onmessage = this._onMessage.bind(this);
+            worker.postMessage('dispatch-handshake');
+        } else {
+            log.warn('Ignoring attempt to add duplicate worker');
+        }
+    }
+
+    /**
+     * Handle a message event received from a connected worker.
+     * @param {MessageEvent} event - the message event to be handled.
+     * @private
+     */
+    _onMessage (event) {
+        const worker = event.target;
+        const [service, method, callbackId, ...args] = /** @type {[string, string, *]} */ event.data;
+        if (service === 'dispatch') {
+            switch (method) {
+            case '_callback':
+                this._callback(callbackId, ...args);
+                break;
+            case 'setService':
+                this.setService(args[0], worker);
+                break;
+            }
+        } else {
+            this.call(service, method, ...args).then(
+                result => {
+                    worker.postMessage(['dispatch', '_callback', callbackId, result]);
+                },
+                error => {
+                    worker.postMessage(['dispatch', '_callback', callbackId, null, error]);
+                });
+        }
+    }
+
+    /**
+     * Handle a callback from a worker. This should only be called as the result of a message from a worker.
+     * @param {int} callbackId - the ID of the callback to call.
+     * @param {*} result - if `error` is not truthy, resolve the callback promise with this value.
+     * @param {*} [error] - if this is truthy, reject the callback promise with this value.
+     * @private
+     */
+    _callback (callbackId, result, error) {
+        const [resolve, reject] = this.callbacks[callbackId];
+        if (error) {
+            reject(error);
+        } else {
+            resolve(result);
+        }
+    }
+}
+
+const dispatch = new CentralDispatch();
+module.exports = dispatch;
+self.Scratch = self.Scratch || {};
+self.Scratch.dispatch = dispatch;

--- a/src/dispatch/shared-dispatch.js
+++ b/src/dispatch/shared-dispatch.js
@@ -1,0 +1,217 @@
+const log = require('../util/log');
+
+/**
+ * @typedef {object} DispatchCallMessage - a message to the dispatch system representing a service method call
+ * @property {*} responseId - send a response message with this response ID. See {@link DispatchResponseMessage}
+ * @property {string} service - the name of the service to be called
+ * @property {string} method - the name of the method to be called
+ * @property {Array|undefined} args - the arguments to be passed to the method
+ */
+
+/**
+ * @typedef {object} DispatchResponseMessage - a message to the dispatch system representing the results of a call
+ * @property {*} responseId - a copy of the response ID from the call which generated this response
+ * @property {*|undefined} error - if this is truthy, then it contains results from a failed call (such as an exception)
+ * @property {*|undefined} result - if error is not truthy, then this contains the return value of the call (if any)
+ */
+
+/**
+ * @typedef {DispatchCallMessage|DispatchResponseMessage} DispatchMessage
+ * Any message to the dispatch system.
+ */
+
+/**
+ * The SharedDispatch class is responsible for dispatch features shared by
+ * {@link CentralDispatch} and {@link WorkerDispatch}.
+ */
+class SharedDispatch {
+    constructor () {
+        /**
+         * List of callback registrations for promises waiting for a response from a call to a service on another
+         * worker. A callback registration is an array of [resolve,reject] Promise functions.
+         * Calls to local services don't enter this list.
+         * @type {Array.<[Function,Function]>}
+         */
+        this.callbacks = [];
+
+        /**
+         * The next response ID to be used.
+         * @type {int}
+         */
+        this.nextResponseId = 0;
+    }
+
+    /**
+     * Call a particular method on a particular service, regardless of whether that service is provided locally or on
+     * a worker. If the service is provided by a worker, the `args` will be copied using the Structured Clone
+     * algorithm, except for any items which are also in the `transfer` list. Ownership of those items will be
+     * transferred to the worker, and they should not be used after this call.
+     * @example
+     *      dispatcher.call('vm', 'setData', 'cat', 42);
+     *      // this finds the worker for the 'vm' service, then on that worker calls:
+     *      vm.setData('cat', 42);
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    call (service, method, ...args) {
+        return this.transferCall(service, method, null, ...args);
+    }
+
+    /**
+     * Call a particular method on a particular service, regardless of whether that service is provided locally or on
+     * a worker. If the service is provided by a worker, the `args` will be copied using the Structured Clone
+     * algorithm, except for any items which are also in the `transfer` list. Ownership of those items will be
+     * transferred to the worker, and they should not be used after this call.
+     * @example
+     *      dispatcher.transferCall('vm', 'setData', [myArrayBuffer], 'cat', myArrayBuffer);
+     *      // this finds the worker for the 'vm' service, transfers `myArrayBuffer` to it, then on that worker calls:
+     *      vm.setData('cat', myArrayBuffer);
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {Array} [transfer] - objects to be transferred instead of copied. Must be present in `args` to be useful.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    transferCall (service, method, transfer, ...args) {
+        try {
+            const {provider, isRemote} = this._getServiceProvider(service);
+            if (provider) {
+                if (isRemote) {
+                    return this._remoteTransferCall(provider, service, method, transfer, ...args);
+                }
+
+                const result = provider[method].apply(provider, args);
+                return Promise.resolve(result);
+            }
+            return Promise.reject(new Error(`Service not found: ${service}`));
+        } catch (e) {
+            return Promise.reject(e);
+        }
+    }
+
+    /**
+     * Like {@link call}, but force the call to be posted through a particular communication channel.
+     * @param {object} provider - send the call through this object's `postMessage` function.
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    _remoteCall (provider, service, method, ...args) {
+        return this._remoteTransferCall(provider, service, method, null, ...args);
+    }
+
+    /**
+     * Like {@link transferCall}, but force the call to be posted through a particular communication channel.
+     * @param {object} provider - send the call through this object's `postMessage` function.
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {Array} [transfer] - objects to be transferred instead of copied. Must be present in `args` to be useful.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    _remoteTransferCall (provider, service, method, transfer, ...args) {
+        return new Promise((resolve, reject) => {
+            const responseId = this._storeCallbacks(resolve, reject);
+            if (transfer) {
+                provider.postMessage({service, method, responseId, args}, transfer);
+            } else {
+                provider.postMessage({service, method, responseId, args});
+            }
+        });
+    }
+
+    /**
+     * Store callback functions pending a response message.
+     * @param {Function} resolve - function to call if the service method returns.
+     * @param {Function} reject - function to call if the service method throws.
+     * @returns {*} - a unique response ID for this set of callbacks. See {@link _deliverResponse}.
+     * @protected
+     */
+    _storeCallbacks (resolve, reject) {
+        const responseId = this.nextResponseId++;
+        this.callbacks[responseId] = [resolve, reject];
+        return responseId;
+    }
+
+    /**
+     * Deliver call response from a worker. This should only be called as the result of a message from a worker.
+     * @param {int} responseId - the response ID of the callback set to call.
+     * @param {DispatchResponseMessage} message - the message containing the response value(s).
+     * @protected
+     */
+    _deliverResponse (responseId, message) {
+        try {
+            const [resolve, reject] = this.callbacks[responseId];
+            delete this.callbacks[responseId];
+            if (message.error) {
+                reject(message.error);
+            } else {
+                resolve(message.result);
+            }
+        } catch (e) {
+            log.error(`Dispatch callback failed: ${JSON.stringify(e)}`);
+        }
+    }
+
+    /**
+     * Handle a message event received from a connected worker.
+     * @param {Worker} worker - the worker which sent the message, or the global object if running in a worker.
+     * @param {MessageEvent} event - the message event to be handled.
+     * @protected
+     */
+    _onMessage (worker, event) {
+        /** @type {DispatchMessage} */
+        const message = event.data;
+        message.args = message.args || [];
+        let promise;
+        if (message.service) {
+            if (message.service === 'dispatch') {
+                promise = this._onDispatchMessage(worker, message);
+            } else {
+                promise = this.call(message.service, message.method, ...message.args);
+            }
+        } else if (typeof message.responseId === 'undefined') {
+            log.error(`Dispatch caught malformed message from a worker: ${JSON.stringify(event)}`);
+        } else {
+            this._deliverResponse(message.responseId, message);
+        }
+        if (promise) {
+            if (typeof message.responseId === 'undefined') {
+                log.error(`Dispatch message missing required response ID: ${JSON.stringify(event)}`);
+            } else {
+                promise.then(
+                    result => worker.postMessage({responseId: message.responseId, result}),
+                    error => worker.postMessage({responseId: message.responseId, error})
+                );
+            }
+        }
+    }
+
+    /**
+     * Fetch the service provider object for a particular service name.
+     * @abstract
+     * @param {string} service - the name of the service to look up
+     * @returns {{provider:(object|Worker), isRemote:boolean}} - the means to contact the service, if found
+     * @protected
+     */
+    _getServiceProvider (service) {
+        throw new Error(`Could not get provider for ${service}: _getServiceProvider not implemented`);
+    }
+
+    /**
+     * Handle a call message sent to the dispatch service itself
+     * @abstract
+     * @param {Worker} worker - the worker which sent the message.
+     * @param {DispatchCallMessage} message - the message to be handled.
+     * @returns {Promise|undefined} - a promise for the results of this operation, if appropriate
+     * @private
+     */
+    _onDispatchMessage (worker, message) {
+        throw new Error(`Unimplemented dispatch message handler cannot handle ${message.method} method`);
+    }
+}
+
+module.exports = SharedDispatch;

--- a/src/dispatch/worker-dispatch.js
+++ b/src/dispatch/worker-dispatch.js
@@ -117,18 +117,17 @@ class WorkerDispatch {
 
     /**
      * Set a local object as the global provider of the specified service.
+     * WARNING: Any method on the provider can be called from any worker within the dispatch system.
      * @param {string} service - a globally unique string identifying this service. Examples: 'vm', 'gui', 'extension9'.
      * @param {object} provider - a local object which provides this service.
-     * WARNING: Any method on the provider can be called from any worker within the dispatch system.
+     * @returns {Promise} - a promise which will resolve once the service is registered.
      */
     setService (service, provider) {
         if (this.services.hasOwnProperty(service)) {
             log.warn(`Replacing existing service provider for ${service}`);
         }
         this.services[service] = provider;
-        this.waitForConnection.then(() => {
-            this.call('dispatch', 'setService', service);
-        });
+        return this.waitForConnection.then(() => this.call('dispatch', 'setService', service));
     }
 
     /**

--- a/src/dispatch/worker-dispatch.js
+++ b/src/dispatch/worker-dispatch.js
@@ -1,0 +1,190 @@
+const log = require('../util/log');
+
+/**
+ * This class provides a Worker with the means to participate in the message dispatch system managed by CentralDispatch.
+ * From any context in the messaging system, the dispatcher's "call" method can call any method on any "service"
+ * provided in any participating context. The dispatch system will forward function arguments and return values across
+ * worker boundaries as needed.
+ * @see {CentralDispatch}
+ */
+class WorkerDispatch {
+    constructor () {
+        /**
+         * List of callback registrations for promises waiting for a response from a call to a service on another
+         * worker. A callback registration is an array of [resolve,reject] Promise functions.
+         * Calls to services on this worker don't enter this list.
+         * @type {Array.<[Function,Function]>}
+         */
+        this.callbacks = [];
+
+        /**
+         * This promise will be resolved when we have successfully connected to central dispatch.
+         * @type {Promise}
+         * @see {waitForConnection}
+         * @private
+         */
+        this._connectionPromise = new Promise(resolve => {
+            this._onConnect = resolve;
+        }).then(() => {
+            self.onmessage = this._onMessage.bind(this);
+        });
+
+        /**
+         * The next callback ID to be used.
+         * @type {int}
+         */
+        this.nextCallback = 0;
+
+        /**
+         * Map of service name to local service provider.
+         * If a service is not listed here, it is assumed to be provided by another context (another Worker or the main
+         * thread).
+         * @see {setService}
+         * @type {object}
+         */
+        this.services = {};
+
+        self.onmessage = this._onHandshake.bind(this);
+    }
+
+    /**
+     * @returns {Promise} a promise which will resolve upon connection to central dispatch. If you need to make a call
+     * immediately on "startup" you can attach a 'then' to this promise.
+     * @example
+     *      dispatch.waitForConnection.then(() => {
+     *          dispatch.call('myService', 'hello');
+     *      })
+     */
+    get waitForConnection () {
+        return this._connectionPromise;
+    }
+
+    /**
+     * Call a particular method on a particular service, regardless of whether that service is provided locally or on
+     * a worker. If the service is provided by a worker, the `args` will be copied using the Structured Clone
+     * algorithm, except for any items which are also in the `transfer` list. Ownership of those items will be
+     * transferred to the worker, and they should not be used after this call.
+     * @example
+     *      dispatcher.call('vm', 'setData', 'cat', 42);
+     *      // this finds the worker for the 'vm' service, then on that worker calls:
+     *      vm.setData('cat', 42);
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    call (service, method, ...args) {
+        return this.transferCall(service, method, null, ...args);
+    }
+
+    /**
+     * Call a particular method on a particular service, regardless of whether that service is provided locally or on
+     * a worker. If the service is provided by a worker, the `args` will be copied using the Structured Clone
+     * algorithm, except for any items which are also in the `transfer` list. Ownership of those items will be
+     * transferred to the worker, and they should not be used after this call.
+     * @example
+     *      dispatcher.transferCall('vm', 'setData', [myArrayBuffer], 'cat', myArrayBuffer);
+     *      // this finds the worker for the 'vm' service, transfers `myArrayBuffer` to it, then on that worker calls:
+     *      vm.setData('cat', myArrayBuffer);
+     * @param {string} service - the name of the service.
+     * @param {string} method - the name of the method.
+     * @param {Array} [transfer] - objects to be transferred instead of copied. Must be present in `args` to be useful.
+     * @param {*} [args] - the arguments to be copied to the method, if any.
+     * @returns {Promise} - a promise for the return value of the service method.
+     */
+    transferCall (service, method, transfer, ...args) {
+        return new Promise((resolve, reject) => {
+            if (this.services.hasOwnProperty(service)) {
+                const provider = this.services[service];
+                const result = provider[method].apply(provider, args);
+                resolve(result);
+            } else {
+                const callbackId = this.nextCallback++;
+                this.callbacks[callbackId] = [resolve, reject];
+                if (transfer) {
+                    self.postMessage([service, method, callbackId, ...args], transfer);
+                } else {
+                    self.postMessage([service, method, callbackId, ...args]);
+                }
+            }
+        });
+    }
+
+    /**
+     * Set a local object as the global provider of the specified service.
+     * @param {string} service - a globally unique string identifying this service. Examples: 'vm', 'gui', 'extension9'.
+     * @param {object} provider - a local object which provides this service.
+     * WARNING: Any method on the provider can be called from any worker within the dispatch system.
+     */
+    setService (service, provider) {
+        if (this.services.hasOwnProperty(service)) {
+            log.warn(`Replacing existing service provider for ${service}`);
+        }
+        this.services[service] = provider;
+        this.waitForConnection.then(() => {
+            this.call('dispatch', 'setService', service);
+        });
+    }
+
+    /**
+     * Message handler active until the dispatcher handshake arrives.
+     * @param {MessageEvent} event - the message event to be handled.
+     * @private
+     */
+    _onHandshake (event) {
+        const message = event.data;
+        if (message === 'dispatch-handshake') {
+            this._onConnect();
+        } else {
+            log.error(`WorkerDispatch received unexpected message before handshake: ${JSON.stringify(message)}`);
+        }
+    }
+
+    /**
+     * Message handler active after the dispatcher handshake. This only handles method calls.
+     * @param {MessageEvent} event - the message event to be handled.
+     * @private
+     */
+    _onMessage (event) {
+        const [service, method, callbackId, ...args] = /** @type {[string, string, *]} */ event.data;
+        if (service === 'dispatch') {
+            switch (method) {
+            case '_callback':
+                this._callback(callbackId, ...args);
+                break;
+            case '_terminate':
+                self.close();
+                break;
+            }
+        } else {
+            this.call(service, method, ...args).then(
+                result => {
+                    self.postMessage(['dispatch', '_callback', callbackId, result]);
+                },
+                error => {
+                    self.postMessage(['dispatch', '_callback', callbackId, null, error]);
+                });
+        }
+    }
+
+    /**
+     * Handle a callback from a worker. This should only be called as the result of a message from a worker.
+     * @param {int} callbackId - the ID of the callback to call.
+     * @param {*} result - if `error` is not truthy, resolve the callback promise with this value.
+     * @param {*} [error] - if this is truthy, reject the callback promise with this value.
+     * @private
+     */
+    _callback (callbackId, result, error) {
+        const [resolve, reject] = this.callbacks[callbackId];
+        if (error) {
+            reject(error);
+        } else {
+            resolve(result);
+        }
+    }
+}
+
+const dispatch = new WorkerDispatch();
+module.exports = dispatch;
+self.Scratch = self.Scratch || {};
+self.Scratch.dispatch = dispatch;

--- a/test/fixtures/dispatch-test-service.js
+++ b/test/fixtures/dispatch-test-service.js
@@ -10,11 +10,6 @@ class DispatchTestService {
     throwException () {
         throw new Error('This is a test exception thrown by DispatchTest');
     }
-
-    close () {
-        // eslint-disable-next-line no-undef
-        self.close();
-    }
 }
 
 module.exports = DispatchTestService;

--- a/test/fixtures/dispatch-test-service.js
+++ b/test/fixtures/dispatch-test-service.js
@@ -8,7 +8,7 @@ class DispatchTestService {
     }
 
     throwException () {
-        throw new Error('This is a test exception thrown by LocalDispatchTest');
+        throw new Error('This is a test exception thrown by DispatchTest');
     }
 
     close () {

--- a/test/fixtures/dispatch-test-service.js
+++ b/test/fixtures/dispatch-test-service.js
@@ -1,0 +1,20 @@
+class DispatchTestService {
+    returnFortyTwo () {
+        return 42;
+    }
+
+    doubleArgument (x) {
+        return 2 * x;
+    }
+
+    throwException () {
+        throw new Error('This is a test exception thrown by LocalDispatchTest');
+    }
+
+    close () {
+        // eslint-disable-next-line no-undef
+        self.close();
+    }
+}
+
+module.exports = DispatchTestService;

--- a/test/fixtures/dispatch-test-worker-shim.js
+++ b/test/fixtures/dispatch-test-worker-shim.js
@@ -1,0 +1,19 @@
+const Module = require('module');
+
+const callsite = require('callsite');
+const path = require('path');
+
+const oldRequire = Module.prototype.require;
+Module.prototype.require = function (target) {
+    if (target.indexOf('/') === -1) {
+        return oldRequire.apply(this, arguments);
+    }
+
+    const stack = callsite();
+    const callerFile = stack[2].getFileName();
+    const callerDir = path.dirname(callerFile);
+    target = path.resolve(callerDir, target);
+    return oldRequire.call(this, target);
+};
+
+oldRequire(path.resolve(__dirname, 'dispatch-test-worker'));

--- a/test/fixtures/dispatch-test-worker.js
+++ b/test/fixtures/dispatch-test-worker.js
@@ -1,8 +1,11 @@
 const dispatch = require('../../src/dispatch/worker-dispatch');
 const DispatchTestService = require('./dispatch-test-service');
+const log = require('../../src/util/log');
 
 dispatch.setService('RemoteDispatchTest', new DispatchTestService());
 
 dispatch.waitForConnection.then(() => {
-    dispatch.call('test', 'onWorkerReady');
+    dispatch.call('test', 'onWorkerReady').catch(e => {
+        log(`Test worker failed to call onWorkerReady: ${JSON.stringify(e)}`);
+    });
 });

--- a/test/fixtures/dispatch-test-worker.js
+++ b/test/fixtures/dispatch-test-worker.js
@@ -1,0 +1,8 @@
+const dispatch = require('../../src/dispatch/worker-dispatch');
+const DispatchTestService = require('./dispatch-test-service');
+
+dispatch.setService('RemoteDispatchTest', new DispatchTestService());
+
+dispatch.waitForConnection.then(() => {
+    dispatch.call('test', 'onWorkerReady');
+});

--- a/test/unit/dispatch.js
+++ b/test/unit/dispatch.js
@@ -1,0 +1,61 @@
+const DispatchTestService = require('../fixtures/dispatch-test-service');
+const Worker = require('tiny-worker');
+
+const dispatch = require('../../src/dispatch/central-dispatch');
+const path = require('path');
+const test = require('tap').test;
+
+
+// By default Central Dispatch works with the Worker class built into the browser. Tell it to use TinyWorker instead.
+dispatch.workerClass = Worker;
+
+const runServiceTest = function (serviceName, t) {
+    const promises = [];
+
+    promises.push(dispatch.call(serviceName, 'returnFortyTwo').then(x => {
+        t.equal(x, 42);
+    }));
+
+    promises.push(dispatch.call(serviceName, 'doubleArgument', 9).then(x => {
+        t.equal(x, 18);
+    }));
+
+    promises.push(dispatch.call(serviceName, 'doubleArgument', 123).then(x => {
+        t.equal(x, 246);
+    }));
+
+    // I tried using `t.rejects` here but ran into https://github.com/tapjs/node-tap/issues/384
+    promises.push(dispatch.call(serviceName, 'throwException')
+        .then(() => {
+            t.fail('exception was not propagated as expected');
+        }, () => {
+            t.pass('exception was propagated as expected');
+        }));
+
+    return Promise.all(promises);
+};
+
+test('local', t => {
+    dispatch.setService('LocalDispatchTest', new DispatchTestService());
+
+    return runServiceTest('LocalDispatchTest', t);
+});
+
+test('remote', t => {
+    const fixturesDir = path.resolve(__dirname, '../fixtures');
+    const worker = new Worker('./test/fixtures/dispatch-test-worker-shim.js', null, {cwd: fixturesDir});
+    dispatch.addWorker(worker);
+
+    const waitForWorker = new Promise(resolve => {
+        dispatch.setService('test', {
+            onWorkerReady: resolve
+        });
+    });
+
+    return waitForWorker
+        .then(() => runServiceTest('RemoteDispatchTest', t))
+        .then(() => {
+            // Allow some time for the worker to finish, then terminate it
+            setTimeout(() => dispatch.call('RemoteDispatchTest', 'close'), 10);
+        });
+});


### PR DESCRIPTION
### Proposed Changes

This message dispatch system allows a "service" to register itself under a particular name, and then anyone can call any method on that service from any context (the main "window" thread or any worker). Return values are passed back through promise resolution.

### Reason for Changes

This will make it much easier to put extensions inside workers: we can expose any services needed by extensions through this message dispatch system, but otherwise extensions will be unable to interact with the editor. If we find that it's necessary, we could even add some form of permissions to the message dispatch system with relatively little work.

### Test Coverage

New tests cover the basics of the message dispatch system. Because the system is built around web workers, which aren't present in our Node.js-based testing process, I added the `tiny-worker` library. This library emulates web workers by running multiple Node processes.

Unfortunately this exposes the difference between webpack's build-time handling and Node's run-time handling of `require` statements. The `dispatch-test-worker-shim.js` file monkey-patches `require` **in the worker only** to deal with these differences.