### PR TITLE
Use sound ID instead of md5 for playing sounds

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -113,18 +113,18 @@ class Scratch3SoundBlocks {
     playSound (args, util) {
         const index = this._getSoundIndex(args.SOUND_MENU, util);
         if (index >= 0) {
-            const md5 = util.target.sprite.sounds[index].md5;
+            const soundId = util.target.sprite.sounds[index].soundId;
             if (util.target.audioPlayer === null) return;
-            util.target.audioPlayer.playSound(md5);
+            util.target.audioPlayer.playSound(soundId);
         }
     }
 
     playSoundAndWait (args, util) {
         const index = this._getSoundIndex(args.SOUND_MENU, util);
         if (index >= 0) {
-            const md5 = util.target.sprite.sounds[index].md5;
+            const soundId = util.target.sprite.sounds[index].soundId;
             if (util.target.audioPlayer === null) return;
-            return util.target.audioPlayer.playSound(md5);
+            return util.target.audioPlayer.playSound(soundId);
         }
     }
 

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -31,7 +31,10 @@ const loadSound = function (sound, runtime) {
                 {data: soundAsset.data}
             ));
         })
-        .then(() => sound);
+        .then(soundId => {
+            sound.soundId = soundId;
+            return sound;
+        });
 };
 
 module.exports = loadSound;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -334,6 +334,32 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * Get a sound buffer from the audio engine.
+     * @param {int} soundIndex - the index of the sound to be got.
+     * @return {AudioBuffer} the sound's audio buffer.
+     */
+    getSoundBuffer (soundIndex) {
+        const id = this.editingTarget.sprite.sounds[soundIndex].soundId;
+        if (id && this.runtime && this.runtime.audioEngine) {
+            return this.runtime.audioEngine.getSoundBuffer(id);
+        }
+        return null;
+    }
+
+    /**
+     * Update a sound buffer.
+     * @param {int} soundIndex - the index of the sound to be updated.
+     * @param {AudioBuffer} newBuffer - new audio buffer for the audio engine.
+     */
+    updateSoundBuffer (soundIndex, newBuffer) {
+        const id = this.editingTarget.sprite.sounds[soundIndex].soundId;
+        if (id && this.runtime && this.runtime.audioEngine) {
+            this.runtime.audioEngine.updateSoundBuffer(id, newBuffer);
+        }
+        this.emitTargetsUpdate();
+    }
+
+    /**
      * Delete a sound from the current editing target.
      * @param {int} soundIndex - the index of the sound to be removed.
      */

--- a/test/unit/blocks_sounds.js
+++ b/test/unit/blocks_sounds.js
@@ -17,14 +17,14 @@ const util = {
     target: {
         sprite: {
             sounds: [
-                {name: 'first name', md5: 'first md5'},
-                {name: 'second name', md5: 'second md5'},
-                {name: 'third name', md5: 'third md5'},
-                {name: '6', md5: 'fourth md5'}
+                {name: 'first name', soundId: 'first soundId'},
+                {name: 'second name', soundId: 'second soundId'},
+                {name: 'third name', soundId: 'third soundId'},
+                {name: '6', soundId: 'fourth soundId'}
             ]
         },
         audioPlayer: {
-            playSound: md5 => (playedSound = md5),
+            playSound: soundId => (playedSound = soundId),
             playDrumForBeats: drum => (playedDrum = drum)
         }
     }
@@ -33,37 +33,37 @@ const util = {
 test('playSound with a name string works', t => {
     const args = {SOUND_MENU: 'second name'};
     blocks.playSound(args, util);
-    t.strictEqual(playedSound, 'second md5');
+    t.strictEqual(playedSound, 'second soundId');
     t.end();
 });
 
 test('playSound with a number string works 1-indexed', t => {
     let args = {SOUND_MENU: '5'};
     blocks.playSound(args, util);
-    t.strictEqual(playedSound, 'first md5');
+    t.strictEqual(playedSound, 'first soundId');
 
     args = {SOUND_MENU: '1'};
     blocks.playSound(args, util);
-    t.strictEqual(playedSound, 'first md5');
+    t.strictEqual(playedSound, 'first soundId');
 
     args = {SOUND_MENU: '0'};
     blocks.playSound(args, util);
-    t.strictEqual(playedSound, 'fourth md5');
+    t.strictEqual(playedSound, 'fourth soundId');
     t.end();
 });
 
 test('playSound with a number works 1-indexed', t => {
     let args = {SOUND_MENU: 5};
     blocks.playSound(args, util);
-    t.strictEqual(playedSound, 'first md5');
+    t.strictEqual(playedSound, 'first soundId');
 
     args = {SOUND_MENU: 1};
     blocks.playSound(args, util);
-    t.strictEqual(playedSound, 'first md5');
+    t.strictEqual(playedSound, 'first soundId');
 
     args = {SOUND_MENU: 0};
     blocks.playSound(args, util);
-    t.strictEqual(playedSound, 'fourth md5');
+    t.strictEqual(playedSound, 'fourth soundId');
     t.end();
 });
 
@@ -71,7 +71,7 @@ test('playSound prioritizes sound index if given a number', t => {
     const args = {SOUND_MENU: 6};
     blocks.playSound(args, util);
     // Ignore the sound named '6', wrapClamp to the second instead
-    t.strictEqual(playedSound, 'second md5');
+    t.strictEqual(playedSound, 'second soundId');
     t.end();
 });
 
@@ -79,7 +79,7 @@ test('playSound prioritizes sound name if given a string', t => {
     const args = {SOUND_MENU: '6'};
     blocks.playSound(args, util);
     // Use the sound named '6', which is the fourth
-    t.strictEqual(playedSound, 'fourth md5');
+    t.strictEqual(playedSound, 'fourth soundId');
     t.end();
 });
 


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_

Uses the sound ID as it comes back from the audio engine (requires https://github.com/LLK/scratch-audio/pull/57) to play sounds. This is to set up for being able to edit sounds that have the same content without conflicts. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Updated the relevant sound block tests. 