### PR TITLE
Fix variable deserializing

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -100,7 +100,7 @@ const parseScratchObject = function (object, runtime) {
     const target = sprite.createClone();
     // Load target properties from JSON.
     if (object.hasOwnProperty('variables')) {
-        for (let j = 0; j < object.variables.length; j++) {
+        for (let j in object.variables) {
             const variable = object.variables[j];
             const newVariable = new Variable(
                 variable.id,


### PR DESCRIPTION
### Resolves

Fixes LLK/scratch-gui#461.

### Proposed Changes

Fixed a small error in the sb3 deserializer preventing variables from loading to the proper targets.

### Reason for Changes

Fixes above bug.

### Test Coverage

None, the sb3 save/load tests aren't written yet, so there was nothing to change.