### PR TITLE
Add [string] contains [string] block

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -109,8 +109,10 @@ class Scratch3OperatorsBlocks {
     }
     
     contains (args) {
-        return Cast.toString(args.STRING1).toLowerCase()
-            .includes(Cast.toString(args.STRING2).toLowerCase());
+        const format = function (string) {
+            return Cast.toString(string).toLowerCase()
+        }
+        return format(args.STRING1).includes(format(args.STRING2))
     }
 
     mod (args) {

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -30,6 +30,7 @@ class Scratch3OperatorsBlocks {
             operator_join: this.join,
             operator_letter_of: this.letterOf,
             operator_length: this.length,
+            operator_contains: this.contains,
             operator_mod: this.mod,
             operator_round: this.round,
             operator_mathop: this.mathop
@@ -105,6 +106,10 @@ class Scratch3OperatorsBlocks {
 
     length (args) {
         return Cast.toString(args.STRING).length;
+    }
+    
+    contains (args) {
+        return Cast.toString(args.STRING1).includes(Cast.toString(args.STRING2));
     }
 
     mod (args) {

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -110,9 +110,9 @@ class Scratch3OperatorsBlocks {
     
     contains (args) {
         const format = function (string) {
-            return Cast.toString(string).toLowerCase()
-        }
-        return format(args.STRING1).includes(format(args.STRING2))
+            return Cast.toString(string).toLowerCase();
+        };
+        return format(args.STRING1).includes(format(args.STRING2));
     }
 
     mod (args) {

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -109,7 +109,7 @@ class Scratch3OperatorsBlocks {
     }
     
     contains (args) {
-        return Cast.toString(args.STRING1).includes(Cast.toString(args.STRING2));
+        return Cast.toString(args.STRING1).toLowerCase().includes(Cast.toString(args.STRING2).toLowerCase());
     }
 
     mod (args) {

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -109,7 +109,8 @@ class Scratch3OperatorsBlocks {
     }
     
     contains (args) {
-        return Cast.toString(args.STRING1).toLowerCase().includes(Cast.toString(args.STRING2).toLowerCase());
+        return Cast.toString(args.STRING1).toLowerCase()
+            .includes(Cast.toString(args.STRING2).toLowerCase());
     }
 
     mod (args) {

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -141,6 +141,13 @@ test('length', t => {
     t.end();
 });
 
+test('contains', t => {
+    t.strictEqual(blocks.contains({STRING1: 'hello world', STRING2: 'hello'}), true);
+    t.strictEqual(blocks.contains({STRING1: 'foo', STRING2: 'bar'}), false);
+    t.strictEqual(blocks.contains({STRING1: 'HeLLo world', STRING2: 'hello'}), true);
+    t.end();
+});
+
 test('mod', t => {
     t.strictEqual(blocks.mod({NUM1: 1, NUM2: 1}), 0);
     t.strictEqual(blocks.mod({NUM1: 3, NUM2: 6}), 3);


### PR DESCRIPTION
### Resolves

LLK/scratch-gui#601

### Proposed Changes

Adds `contains` as a block to `scratch-vm/src/blocks/scratch3_operators.js` - it returns `string1.includes(string2)`

This block is also added to the blocks list in LLK/scratch-blocks#1045