### PR TITLE
Switch from parseInt to Math.floor

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -85,7 +85,7 @@ class Scratch3OperatorsBlocks {
         if (low === high) return low;
         // If both arguments are ints, truncate the result to an int.
         if (Cast.isInt(args.FROM) && Cast.isInt(args.TO)) {
-            return low + parseInt(Math.random() * ((high + 1) - low), 10);
+            return low + Math.floor(Math.random() * ((high + 1) - low));
         }
         return (Math.random() * (high - low)) + low;
     }
@@ -107,7 +107,7 @@ class Scratch3OperatorsBlocks {
     length (args) {
         return Cast.toString(args.STRING).length;
     }
-    
+
     contains (args) {
         const format = function (string) {
             return Cast.toString(string).toLowerCase();


### PR DESCRIPTION
### Resolves

Resolves #601

### Proposed Changes

Switches from parseInt to Math.floor

### Reason for Changes

ParseInt cannot handle integers greater than 1e21 because such numbers are expressed in scientific notation. Consequently, it retrieves only the first digit. Math.floor performs truncation correctly.

### Test Coverage

None added.

### Special Note

Both parseInt and floor return NaN when asked to parse very large (or low) numbers because they are cast to infinity (or negative infinity). It's unclear if this is the desired behavior as it's consistent with scratch 2 but not technically correct. Perhaps a check should be added to provide a helpful error.