### PR TITLE
Add sprite duplication method

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -2,6 +2,7 @@ const adapter = require('./adapter');
 const mutationAdapter = require('./mutation-adapter');
 const xmlEscape = require('../util/xml-escape');
 const MonitorRecord = require('./monitor-record');
+const Clone = require('../util/clone');
 
 /**
  * @fileoverview
@@ -178,6 +179,12 @@ class Blocks {
         return null;
     }
 
+    duplicate () {
+        const newBlocks = new Blocks();
+        newBlocks._blocks = Clone.simple(this._blocks);
+        newBlocks._scripts = Clone.simple(this._scripts);
+        return newBlocks;
+    }
     // ---------------------------------------------------------------------
 
     /**

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -32,12 +32,12 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
     return new Promise((resolve, reject) => {
         const imageElement = new Image();
         const onError = function () {
-                    // eslint-disable-next-line no-use-before-define
+            // eslint-disable-next-line no-use-before-define
             removeEventListeners();
             reject();
         };
         const onLoad = function () {
-                    // eslint-disable-next-line no-use-before-define
+            // eslint-disable-next-line no-use-before-define
             removeEventListeners();
             resolve(imageElement);
         };

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -2,47 +2,28 @@ const StringUtil = require('../util/string-util');
 const log = require('../util/log');
 
 /**
- * Load a costume's asset into memory asynchronously.
+ * Initialize a costume from an asset asynchronously.
  * Do not call this unless there is a renderer attached.
- * @param {string} md5ext - the MD5 and extension of the costume to be loaded.
  * @param {!object} costume - the Scratch costume object.
  * @property {int} skinId - the ID of the costume's render skin, once installed.
  * @property {number} rotationCenterX - the X component of the costume's origin.
  * @property {number} rotationCenterY - the Y component of the costume's origin.
  * @property {number} [bitmapResolution] - the resolution scale for a bitmap costume.
+ * @param {!Asset} costumeAsset - the asset of the costume loaded from storage.
  * @param {!Runtime} runtime - Scratch runtime, used to access the storage module.
  * @returns {?Promise} - a promise which will resolve after skinId is set, or null on error.
  */
-const loadCostume = function (md5ext, costume, runtime) {
-    if (!runtime.storage) {
-        log.error('No storage module present; cannot load costume asset: ', md5ext);
-        return Promise.resolve(costume);
-    }
-
-    const AssetType = runtime.storage.AssetType;
-    const idParts = StringUtil.splitFirst(md5ext, '.');
-    const md5 = idParts[0];
-    const ext = idParts[1].toLowerCase();
-    const assetType = (ext === 'svg') ? AssetType.ImageVector : AssetType.ImageBitmap;
-
-    return runtime.storage.load(assetType, md5, ext).then(costumeAsset => {
-        costume.dataFormat = ext;
-        return loadCostumeFromAsset(costume, costumeAsset, runtime);
-    });
-};
-
 const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
+    costume.assetId = costumeAsset.assetId;
+    if (!runtime.renderer) {
+        log.error('No rendering module present; cannot load costume: ', costume.name);
+        return costume;
+    }
+    const AssetType = runtime.storage.AssetType;
     const rotationCenter = [
         costume.rotationCenterX / costume.bitmapResolution,
         costume.rotationCenterY / costume.bitmapResolution
     ];
-
-    if (!runtime.renderer) {
-        log.error('No rendering module present; cannot load costume asset: ', md5ext);
-        return costume;
-    }
-    const AssetType = runtime.storage.AssetType;
-    costume.assetId = costumeAsset.assetId;
     if (costumeAsset.assetType === AssetType.ImageVector) {
         costume.skinId = runtime.renderer.createSVGSkin(costumeAsset.decodeText(), rotationCenter);
         return costume;
@@ -73,6 +54,37 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
     });
 };
 
-loadCostume.loadCostumeFromAsset = loadCostumeFromAsset;
+/**
+ * Load a costume's asset into memory asynchronously.
+ * Do not call this unless there is a renderer attached.
+ * @param {string} md5ext - the MD5 and extension of the costume to be loaded.
+ * @param {!object} costume - the Scratch costume object.
+ * @property {int} skinId - the ID of the costume's render skin, once installed.
+ * @property {number} rotationCenterX - the X component of the costume's origin.
+ * @property {number} rotationCenterY - the Y component of the costume's origin.
+ * @property {number} [bitmapResolution] - the resolution scale for a bitmap costume.
+ * @param {!Runtime} runtime - Scratch runtime, used to access the storage module.
+ * @returns {?Promise} - a promise which will resolve after skinId is set, or null on error.
+ */
+const loadCostume = function (md5ext, costume, runtime) {
+    if (!runtime.storage) {
+        log.error('No storage module present; cannot load costume asset: ', md5ext);
+        return Promise.resolve(costume);
+    }
 
-module.exports = loadCostume;
+    const AssetType = runtime.storage.AssetType;
+    const idParts = StringUtil.splitFirst(md5ext, '.');
+    const md5 = idParts[0];
+    const ext = idParts[1].toLowerCase();
+    const assetType = (ext === 'svg') ? AssetType.ImageVector : AssetType.ImageBitmap;
+
+    return runtime.storage.load(assetType, md5, ext).then(costumeAsset => {
+        costume.dataFormat = ext;
+        return loadCostumeFromAsset(costume, costumeAsset, runtime);
+    });
+};
+
+module.exports = {
+    loadCostume,
+    loadCostumeFromAsset
+};

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -2,6 +2,27 @@ const StringUtil = require('../util/string-util');
 const log = require('../util/log');
 
 /**
+ * Initialize a sound from an asset asynchronously.
+ * @param {!object} sound - the Scratch sound object.
+ * @property {string} md5 - the MD5 and extension of the sound to be loaded.
+ * @property {Buffer} data - sound data will be written here once loaded.
+ * @param {!Asset} soundAsset - the asset loaded from storage.
+ * @param {!Runtime} runtime - Scratch runtime, used to access the storage module.
+ * @returns {!Promise} - a promise which will resolve to the sound when ready.
+ */
+const loadSoundFromAsset = function (sound, soundAsset, runtime) {
+    sound.assetId = soundAsset.assetId;
+    return runtime.audioEngine.decodeSound(Object.assign(
+        {},
+        sound,
+        {data: soundAsset.data}
+    )).then(soundId => {
+        sound.soundId = soundId;
+        return sound;
+    });
+};
+
+/**
  * Load a sound's asset into memory asynchronously.
  * @param {!object} sound - the Scratch sound object.
  * @property {string} md5 - the MD5 and extension of the sound to be loaded.
@@ -28,17 +49,7 @@ const loadSound = function (sound, runtime) {
         });
 };
 
-const loadSoundFromAsset = function (sound, soundAsset, runtime) {
-    sound.assetId = soundAsset.assetId;
-    return runtime.audioEngine.decodeSound(Object.assign(
-        {},
-        sound,
-        {data: soundAsset.data}
-    )).then(soundId => {
-        sound.soundId = soundId;
-        return sound;
-    });
+module.exports = {
+    loadSound,
+    loadSoundFromAsset
 };
-
-loadSound.loadSoundFromAsset = loadSoundFromAsset;
-module.exports = loadSound;

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -23,18 +23,22 @@ const loadSound = function (sound, runtime) {
     const ext = idParts[1].toLowerCase();
     return runtime.storage.load(runtime.storage.AssetType.Sound, md5, ext)
         .then(soundAsset => {
-            sound.assetId = soundAsset.assetId;
             sound.dataFormat = ext;
-            return runtime.audioEngine.decodeSound(Object.assign(
-                {},
-                sound,
-                {data: soundAsset.data}
-            ));
-        })
-        .then(soundId => {
-            sound.soundId = soundId;
-            return sound;
+            return loadSoundFromAsset(sound, soundAsset, runtime);
         });
 };
 
+const loadSoundFromAsset = function (sound, soundAsset, runtime) {
+    sound.assetId = soundAsset.assetId;
+    return runtime.audioEngine.decodeSound(Object.assign(
+        {},
+        sound,
+        {data: soundAsset.data}
+    )).then(soundId => {
+        sound.soundId = soundId;
+        return sound;
+    });
+};
+
+loadSound.loadSoundFromAsset = loadSoundFromAsset;
 module.exports = loadSound;

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -15,8 +15,8 @@ const specMap = require('./sb2_specmap');
 const Variable = require('../engine/variable');
 const List = require('../engine/list');
 
-const loadCostume = require('../import/load-costume.js');
-const loadSound = require('../import/load-sound.js');
+const {loadCostume} = require('../import/load-costume.js');
+const {loadSound} = require('../import/load-sound.js');
 
 /**
  * Convert a Scratch 2.0 procedure string (e.g., "my_procedure %s %b %n")

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -10,8 +10,8 @@ const Sprite = require('../sprites/sprite');
 const Variable = require('../engine/variable');
 const List = require('../engine/list');
 
-const loadCostume = require('../import/load-costume.js');
-const loadSound = require('../import/load-sound.js');
+const {loadCostume} = require('../import/load-costume.js');
+const {loadSound} = require('../import/load-sound.js');
 
 /**
  * Serializes the specified VM runtime.

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -788,6 +788,33 @@ class RenderedTarget extends Target {
     }
 
     /**
+     * Make a duplicate using a duplicate sprite.
+     * @return {RenderedTarget} New clone.
+     */
+    duplicate () {
+        return this.sprite.duplicate().then(newSprite => {
+            const newTarget = newSprite.createClone();
+            // Copy all properties.
+            // @todo refactor with clone methods
+            newTarget.x = Math.random() * 400 / 2;
+            newTarget.y = Math.random() * 300 / 2;
+            newTarget.direction = this.direction;
+            newTarget.draggable = this.draggable;
+            newTarget.visible = this.visible;
+            newTarget.size = this.size;
+            newTarget.currentCostume = this.currentCostume;
+            newTarget.rotationStyle = this.rotationStyle;
+            newTarget.effects = JSON.parse(JSON.stringify(this.effects));
+            newTarget.variables = JSON.parse(JSON.stringify(this.variables));
+            newTarget.lists = JSON.parse(JSON.stringify(this.lists));
+            newTarget.initDrawable();
+            newTarget.updateAllDrawableProperties();
+            newTarget.goBehindOther(this);
+            return newTarget;
+        });
+    }
+
+    /**
      * Called when the project receives a "green flag."
      * For a rendered target, this clears graphic effects.
      */

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -1,5 +1,8 @@
 const RenderedTarget = require('./rendered-target');
 const Blocks = require('../engine/blocks');
+const {loadSoundFromAsset} = require('../import/load-sound');
+const {loadCostumeFromAsset} = require('../import/load-costume');
+const StringUtil = require('../util/string-util');
 
 class Sprite {
     /**
@@ -72,6 +75,33 @@ class Sprite {
         if (cloneIndex >= 0) {
             this.clones.splice(cloneIndex, 1);
         }
+    }
+
+    duplicate () {
+        const newSprite = new Sprite(null, this.runtime);
+
+        newSprite.blocks = this.blocks.duplicate();
+
+        const allNames = this.runtime.targets.map(t => t.name);
+        newSprite.name = StringUtil.unusedName(this.name, allNames);
+
+        const assetPromises = [];
+
+        newSprite.costumes = this.costumes.map(costume => {
+            const newCostume = Object.assign({}, costume);
+            const costumeAsset = this.runtime.storage.get(costume.assetId);
+            assetPromises.push(loadCostumeFromAsset(newCostume, costumeAsset, this.runtime));
+            return newCostume;
+        });
+
+        newSprite.sounds = this.sounds.map(sound => {
+            const newSound = Object.assign({}, sound);
+            const soundAsset = this.runtime.storage.get(sound.assetId);
+            assetPromises.push(loadSoundFromAsset(newSound, soundAsset, this.runtime));
+            return newSound;
+        });
+
+        return Promise.all(assetPromises).then(() => newSprite);
     }
 }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -445,23 +445,17 @@ class VirtualMachine extends EventEmitter {
      */
     duplicateSprite (targetId) {
         const target = this.runtime.getTargetById(targetId);
-
-        if (target) {
-            if (!target.isSprite()) {
-                throw new Error('Cannot duplicate non-sprite targets.');
-            }
-            const sprite = target.sprite;
-            if (!sprite) {
-                throw new Error('No sprite associated with this target.');
-            }
-
-            target.duplicate().then(newTarget => {
-                this.runtime.targets.push(newTarget);
-                this.setEditingTarget(newTarget.id);
-            });
-        } else {
+        if (!target) {
             throw new Error('No target with the provided id.');
+        } else if (!target.isSprite()) {
+            throw new Error('Cannot duplicate non-sprite targets.');
+        } else if (!target.sprite) {
+            throw new Error('No sprite associated with this target.');
         }
+        target.duplicate().then(newTarget => {
+            this.runtime.targets.push(newTarget);
+            this.setEditingTarget(newTarget.id);
+        });
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -6,8 +6,8 @@ const sb2 = require('./serialization/sb2');
 const sb3 = require('./serialization/sb3');
 const StringUtil = require('./util/string-util');
 
-const loadCostume = require('./import/load-costume.js');
-const loadSound = require('./import/load-sound.js');
+const {loadCostume} = require('./import/load-costume.js');
+const {loadSound} = require('./import/load-sound.js');
 
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -440,6 +440,31 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * Duplicate a sprite.
+     * @param {string} targetId ID of a target whose sprite to duplicate.
+     */
+    duplicateSprite (targetId) {
+        const target = this.runtime.getTargetById(targetId);
+
+        if (target) {
+            if (!target.isSprite()) {
+                throw new Error('Cannot duplicate non-sprite targets.');
+            }
+            const sprite = target.sprite;
+            if (!sprite) {
+                throw new Error('No sprite associated with this target.');
+            }
+
+            target.duplicate().then(newTarget => {
+                this.runtime.targets.push(newTarget);
+                this.setEditingTarget(newTarget.id);
+            });
+        } else {
+            throw new Error('No target with the provided id.');
+        }
+    }
+
+    /**
      * Set the audio engine for the VM/runtime
      * @param {!AudioEngine} audioEngine The audio engine to attach
      */

--- a/test/integration/sb3-roundtrip.js
+++ b/test/integration/sb3-roundtrip.js
@@ -2,8 +2,8 @@ const test = require('tap').test;
 
 const Blocks = require('../../src/engine/blocks');
 const Clone = require('../../src/util/clone');
-const loadCostume = require('../../src/import/load-costume');
-const loadSound = require('../../src/import/load-sound');
+const {loadCostume} = require('../../src/import/load-costume');
+const {loadSound} = require('../../src/import/load-sound');
 const makeTestStorage = require('../fixtures/make-test-storage');
 const Runtime = require('../../src/engine/runtime');
 const sb3 = require('../../src/serialization/sb3');


### PR DESCRIPTION
Adds a method to the VM to duplicate a sprite

There are several parts to duplicating a sprite
- [ ] Copying over all the properties (I may have missed some?)
- [ ] Copying over the blocks
- [ ] Copying the sounds
- [ ] Copying the costumes

For sounds and costumes, I made the duplicates load their costumes ands sounds from storage based on the asset ID. That means (at least for now) that to work properly, the asset id needs to correspond to the up-to-date version of the asset in storage. 

I plan to accomplish this by having the GUI update storage with the encoded asset whenever it makes a change, creating a new asset ID. The GUI already has the encoders required, and is the single point where assets are modified. My one concern with this plan is that a new asset id will be created, and the old asset will not be removed from memory.