### PR TITLE
Reduce clock precision

### DIFF
--- a/src/io/clock.js
+++ b/src/io/clock.js
@@ -17,7 +17,7 @@ class Clock {
         if (this._paused) {
             return this._pausedTime / 1000;
         }
-        return (this._projectTimer.timeElapsed() / 1000).toFixed(1);
+        return parseFloat((this._projectTimer.timeElapsed() / 1000).toFixed(1));
     }
 
     pause () {

--- a/src/io/clock.js
+++ b/src/io/clock.js
@@ -17,7 +17,7 @@ class Clock {
         if (this._paused) {
             return this._pausedTime / 1000;
         }
-        return this._projectTimer.timeElapsed() / 1000;
+        return (this._projectTimer.timeElapsed() / 1000).toFixed(1);
     }
 
     pause () {


### PR DESCRIPTION
### Resolves
fixed https://github.com/LLK/scratch-gui/issues/659 

### Proposed Changes
Limited clock accuracy to 1 decimal place by adding .tofix(1)

### Reason for Changes
in scratch 3, time was displayed to 1ms while in scratch 2, time is only displayed to 0.1 second. 

### Test Coverage
None