### PR TITLE
Allow workerless extensions

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -459,10 +459,17 @@ class Runtime extends EventEmitter {
             const argInfo = blockInfo.arguments[placeholder] || {};
             const argTypeInfo = ArgumentTypeMap[argInfo.type] || {};
             const defaultValue = (typeof argInfo.defaultValue === 'undefined' ? '' : argInfo.defaultValue.toString());
+
+            // <value> is the ScratchBlocks name for a block input.
+            // The <shadow> is a placeholder for a reporter and is visible when there's no reporter in this input.
             inputList.push(`<value name="${placeholder}"><shadow type="${argTypeInfo.shadowType}">`);
+
+            // <field> is a text field that the user can type into. Some shadows, like the color picker, don't allow
+            // text input and therefore don't need a field element.
             if (argTypeInfo.fieldType) {
                 inputList.push(`<field name="${argTypeInfo.fieldType}">${defaultValue}</field>`);
             }
+
             inputList.push('</shadow></value>');
 
             return `%${argNum}`;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -33,6 +33,9 @@ const defaultBlockPackages = {
  */
 const ArgumentTypeMap = (() => {
     const map = {};
+    map[ArgumentType.COLOR] = {
+        shadowType: 'colour_picker'
+    };
     map[ArgumentType.NUMBER] = {
         shadowType: 'math_number',
         fieldType: 'NUM'
@@ -456,13 +459,11 @@ class Runtime extends EventEmitter {
             const argInfo = blockInfo.arguments[placeholder] || {};
             const argTypeInfo = ArgumentTypeMap[argInfo.type] || {};
             const defaultValue = (typeof argInfo.defaultValue === 'undefined' ? '' : argInfo.defaultValue.toString());
-            inputList.push(
-                `<value name="${placeholder}">` +
-                  `<shadow type="${argTypeInfo.shadowType}">` +
-                    `<field name="${argTypeInfo.fieldType}">${defaultValue}</field>` +
-                  '</shadow>' +
-                '</value>'
-            );
+            inputList.push(`<value name="${placeholder}"><shadow type="${argTypeInfo.shadowType}">`);
+            if (argTypeInfo.fieldType) {
+                inputList.push(`<field name="${argTypeInfo.fieldType}">${defaultValue}</field>`);
+            }
+            inputList.push('</shadow></value>');
 
             return `%${argNum}`;
         });

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -1,7 +1,8 @@
 const ArgumentType = {
     NUMBER: 'number',
     STRING: 'string',
-    BOOLEAN: 'Boolean'
+    BOOLEAN: 'Boolean',
+    COLOR: 'color'
 };
 
 module.exports = ArgumentType;

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -1,8 +1,8 @@
 const ArgumentType = {
-    NUMBER: 'number',
-    STRING: 'string',
     BOOLEAN: 'Boolean',
-    COLOR: 'color'
+    COLOR: 'color',
+    NUMBER: 'number',
+    STRING: 'string'
 };
 
 module.exports = ArgumentType;

--- a/src/extension-support/block-type.js
+++ b/src/extension-support/block-type.js
@@ -1,9 +1,9 @@
 const BlockType = {
-    COMMAND: 'command',
-    REPORTER: 'reporter',
     BOOLEAN: 'Boolean',
+    COMMAND: 'command',
+    CONDITIONAL: 'conditional',
     HAT: 'hat',
-    CONDITIONAL: 'conditional'
+    REPORTER: 'reporter'
 };
 
 module.exports = BlockType;

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -106,11 +106,12 @@ class ExtensionManager {
     /**
      * Register an internal (non-Worker) extension object
      * @param {object} extensionObject - the extension object to register
+     * @returns {Promise} resolved once the extension is fully registered or rejected on failure
      */
     _registerInternalExtension (extensionObject) {
         const extensionInfo = extensionObject.getInfo();
         const serviceName = `extension.internal.${extensionInfo.id}`;
-        dispatch.setService(serviceName, extensionObject)
+        return dispatch.setService(serviceName, extensionObject)
             .then(() => dispatch.call('extensions', 'registerExtensionService', serviceName));
     }
 

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -103,6 +103,17 @@ class ExtensionManager {
         }
     }
 
+    /**
+     * Register an internal (non-Worker) extension object
+     * @param {object} extensionObject - the extension object to register
+     */
+    _registerInternalExtension (extensionObject) {
+        const extensionInfo = extensionObject.getInfo();
+        const serviceName = `extension.internal.${extensionInfo.id}`;
+        dispatch.setService(serviceName, extensionObject)
+            .then(() => dispatch.call('extensions', 'registerExtensionService', serviceName));
+    }
+
     _registerExtensionInfo (serviceName, extensionInfo) {
         extensionInfo = this._prepareExtensionInfo(serviceName, extensionInfo);
         dispatch.call('runtime', '_registerExtensionPrimitives', extensionInfo).catch(e => {
@@ -162,6 +173,7 @@ class ExtensionManager {
         }, blockInfo);
         blockInfo.opcode = this._sanitizeID(blockInfo.opcode);
         blockInfo.func = blockInfo.func ? this._sanitizeID(blockInfo.func) : blockInfo.opcode;
+        blockInfo.text = blockInfo.text || blockInfo.opcode;
         blockInfo.func = dispatch.call.bind(dispatch, serviceName, blockInfo.func);
         return blockInfo;
     }

--- a/test/integration/internal-extension.js
+++ b/test/integration/internal-extension.js
@@ -1,0 +1,51 @@
+const test = require('tap').test;
+const Worker = require('tiny-worker');
+
+const dispatch = require('../../src/dispatch/central-dispatch');
+const VirtualMachine = require('../../src/virtual-machine');
+
+// By default Central Dispatch works with the Worker class built into the browser. Tell it to use TinyWorker instead.
+dispatch.workerClass = Worker;
+
+class TestInternalExtension {
+    constructor () {
+        this.status = {};
+        this.status.constructorCalled = true;
+    }
+
+    getInfo () {
+        this.status.getInfoCalled = true;
+        return {
+            id: 'test-internal-extension',
+            name: 'Test Internal Extension',
+            blocks: [
+                {
+                    opcode: 'go'
+                }
+            ]
+        };
+    }
+
+    go () {
+        this.status.goCalled = true;
+    }
+}
+
+test('internal extension', t => {
+    const vm = new VirtualMachine();
+
+    const extension = new TestInternalExtension();
+    t.ok(extension.status.constructorCalled);
+
+    t.notOk(extension.status.getInfoCalled);
+    return vm.extensionManager._registerInternalExtension(extension).then(() => {
+        t.ok(extension.status.getInfoCalled);
+
+        const func = vm.runtime.getOpcodeFunction('test-internal-extension.go');
+        t.type(func, 'function');
+
+        t.notOk(extension.status.goCalled);
+        func();
+        t.ok(extension.status.goCalled);
+    });
+});


### PR DESCRIPTION
### Resolves

This change lowers the priority of #644, such that we could wait until post-alpha to do that work. IMO we should do it sooner than that, but the advantage of this change is that internal work is no longer blocked on #644 and other similar items.

### Proposed Changes

This change adds a `_registerInternalExtension` method to the extension manager. This method is similar to the existing `loadExtensionURL` method, with two important differences:
- the new method takes an extension object instance (an object with a `getInfo()` method) instead of a URL, and
- the extension is registered as-is, likely in the same context as the extension manager, rather than sandboxing it in a web worker.

### Reason for Changes

This will allow us to convert the implementation of our existing blocks to use the extension system without having to build service interfaces first. We can later convert such extensions into "worker extensions" by implementing the necessary services, but that work is no longer prerequisite.

See 7fdaaaa25987eafdf9c841fcd79e05925aab6e5a to see a quick-and-dirty conversion of our pen blocks into an "internal" extension. After this conversion, the extension must be registered before use: `extensionManager._registerInternalExtension(new Scratch3PenBlocks(runtime));` would work.

### Test Coverage

A new integration test registers a small internal extension and calls a block implementation on that extension through the runtime. The test then verifies that the extension state is as expected -- and it does so in a way that wouldn't work in a worker context.