### PR TITLE
Remove label generation for extensions

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -523,8 +523,6 @@ class Runtime extends EventEmitter {
         for (const categoryInfo of this._blockInfo) {
             const {name, color1, color2} = categoryInfo;
             xmlParts.push(`<category name="${name}" colour="${color1}" secondaryColour="${color2}">`);
-            // @todo only add this label for user-loaded extensions?
-            xmlParts.push(`<label text="${name}" web-class="extensionLabel"/>`);
             xmlParts.push.apply(xmlParts, categoryInfo.blocks.map(blockInfo => blockInfo.xml));
             xmlParts.push('</category>');
         }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the problem where there are duplicate labels when you add an extension in the GUI. 

### Proposed Changes

_Describe what this Pull Request does_

Don't manually generate labels when generating extension block xml. The blocks already handle this for all categories because of the all-in-one scrolling list.

