### PR TITLE
Changing parsing of custom procedures for new style

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -152,10 +152,12 @@ class Blocks {
         for (const id in this._blocks) {
             if (!this._blocks.hasOwnProperty(id)) continue;
             const block = this._blocks[id];
-            if ((block.opcode === 'procedures_defnoreturn' ||
-                block.opcode === 'procedures_defreturn') &&
-                this._blocks[block.inputs.custom_block.block].mutation.proccode === name) {
-                return id;
+            if (block.opcode === 'procedures_defnoreturn' ||
+                block.opcode === 'procedures_defreturn') {
+                const internal = this._getCustomBlockInternal(block);
+                if (internal && internal.mutation.proccode === name) {
+                    return id; // The outer define block id
+                }
             }
         }
         return null;
@@ -544,6 +546,17 @@ class Blocks {
             }
         }
         return params;
+    }
+
+    /**
+     * Helper to get the corresponding internal procedure definition block
+     * @param {!object} defineBlock Outer define block.
+     * @return {!object} internal definition block which has the mutation.
+     */
+    _getCustomBlockInternal (defineBlock) {
+        if (defineBlock.inputs && defineBlock.inputs.custom_block) {
+            return this._blocks[defineBlock.inputs.custom_block.block];
+        }
     }
 
     /**

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -154,7 +154,7 @@ class Blocks {
             const block = this._blocks[id];
             if ((block.opcode === 'procedures_defnoreturn' ||
                 block.opcode === 'procedures_defreturn') &&
-                block.mutation.proccode === name) {
+                this._blocks[block.inputs.custom_block.block].mutation.proccode === name) {
                 return id;
             }
         }
@@ -170,8 +170,7 @@ class Blocks {
         for (const id in this._blocks) {
             if (!this._blocks.hasOwnProperty(id)) continue;
             const block = this._blocks[id];
-            if ((block.opcode === 'procedures_defnoreturn' ||
-                block.opcode === 'procedures_defreturn') &&
+            if (block.opcode === 'procedures_callnoreturn_internal' &&
                 block.mutation.proccode === name) {
                 return JSON.parse(block.mutation.argumentnames);
             }

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -148,6 +148,8 @@ const execute = function (sequencer, thread) {
     // Recursively evaluate input blocks.
     for (const inputName in inputs) {
         if (!inputs.hasOwnProperty(inputName)) continue;
+        // Do not evaluate the internal custom command block within definition
+        if (inputName === 'custom_block') continue;
         const input = inputs[inputName];
         const inputBlockId = input.block;
         // Is there no value for this input waiting in the stack frame?

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -225,7 +225,9 @@ class Sequencer {
             // Look for warp-mode flag on definition, and set the thread
             // to warp-mode if needed.
             const definitionBlock = thread.target.blocks.getBlock(definition);
-            const doWarp = definitionBlock.mutation.warp;
+            const innerBlock = thread.target.blocks.getBlock(
+                definitionBlock.inputs.custom_block.block);
+            const doWarp = innerBlock.mutation.warp;
             if (doWarp) {
                 thread.peekStackFrame().warpMode = true;
             } else if (isRecursive) {

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -481,14 +481,31 @@ const parseBlock = function (sb2block, getVariableId) {
         // Mutation for procedure definition:
         // store all 2.0 proc data.
         const procData = sb2block.slice(1);
-        activeBlock.mutation = {
-            tagName: 'mutation',
-            proccode: procData[0], // e.g., "abc %n %b %s"
-            argumentnames: JSON.stringify(procData[1]), // e.g. ['arg1', 'arg2']
-            argumentdefaults: JSON.stringify(procData[2]), // e.g., [1, 'abc']
-            warp: procData[3], // Warp mode, e.g., true/false.
-            children: []
+        // Create a new block and input metadata.
+        const inputUid = uid();
+        const inputName = 'custom_block';
+        activeBlock.inputs[inputName] = {
+            name: inputName,
+            block: inputUid,
+            shadow: inputUid
         };
+        activeBlock.children = [{
+            id: inputUid,
+            opcode: 'procedures_callnoreturn_internal',
+            inputs: {},
+            fields: {},
+            next: null,
+            shadow: true,
+            children: [],
+            mutation: {
+                tagName: 'mutation',
+                proccode: procData[0], // e.g., "abc %n %b %s"
+                argumentnames: JSON.stringify(procData[1]), // e.g. ['arg1', 'arg2']
+                argumentdefaults: JSON.stringify(procData[2]), // e.g., [1, 'abc']
+                warp: procData[3], // Warp mode, e.g., true/false.
+                children: []
+            }
+        }];
     } else if (oldOpcode === 'call') {
         // Mutation for procedure call:
         // string for proc code (e.g., "abc %n %b %s").

--- a/test/unit/engine_sequencer.js
+++ b/test/unit/engine_sequencer.js
@@ -156,7 +156,7 @@ test('stepToProcedure', t => {
 
     th.target.blocks.createBlock({
         id: 'internalId',
-        opcode: 'procedures_defnoreturn_internal',
+        opcode: 'procedures_callnoreturn_internal',
         mutation: {
             proccode: 'othercode'
         }

--- a/test/unit/engine_sequencer.js
+++ b/test/unit/engine_sequencer.js
@@ -153,9 +153,19 @@ test('stepToProcedure', t => {
     t.strictEquals(th.peekStack(), expectedBlock);
     s.stepToProcedure(th, 'faceCode');
     t.strictEquals(th.peekStack(), expectedBlock);
-    s.stepToProcedure(th, 'faceCode');
-    th.target.blocks.getBlock(th.stack[th.stack.length - 4]).mutation.proccode = 'othercode';
+
+    th.target.blocks.createBlock({
+        id: 'internalId',
+        opcode: 'procedures_defnoreturn_internal',
+        mutation: {
+            proccode: 'othercode'
+        }
+    });
     expectedBlock = th.stack[th.stack.length - 4];
+    th.target.blocks.getBlock(expectedBlock).inputs.custom_block = {
+        type: 'custom_block',
+        block: 'internalId'
+    };
     s.stepToProcedure(th, 'othercode');
     t.strictEquals(th.peekStack(), expectedBlock);
     


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/697 which allows us to display and run custom blocks correctly!

![image](https://user-images.githubusercontent.com/654102/31295278-004207a8-aaac-11e7-9aa4-d2d0b45a8158.png)

(the color change is actually a separate scratch-blocks change)

### Proposed Changes

_Describe what this Pull Request does_

Parse sb2 files according to the issue @rachel-fenichel filed. 

### Testing

@rschamp fixed tests!