### PR TITLE
Correctly deserialize HTML entities in block DOM

### DIFF
--- a/src/engine/adapter.js
+++ b/src/engine/adapter.js
@@ -156,7 +156,7 @@ const adapter = function (e) {
     if (typeof e !== 'object') return;
     if (typeof e.xml !== 'object') return;
 
-    return domToBlocks(html.parseDOM(e.xml.outerHTML));
+    return domToBlocks(html.parseDOM(e.xml.outerHTML, {decodeEntities: true}));
 };
 
 module.exports = adapter;

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -60,6 +60,12 @@
             "outerHTML":  "<block type='operator_equals' id='l^H_{8[DDyDW?m)HIt@b' x='100' y='362'><value name='OPERAND1'><shadow type='text' id='Ud@4y]bc./]uv~te?brb'><field name='TEXT'></field></shadow></value><value name='OPERAND2'><shadow type='text' id='p8[y..,[K;~G,k7]N;08'><field name='TEXT'></field></shadow></value></block>"
         }
     },
+    "createvariablewithentity": {
+        "name": "block",
+        "xml": {
+            "outerHTML":  "<block type='data_variable' id='/b?}ZGt/N5FmS2yw5GHZ' x='0' y='0'><field name='VARIABLE' id='k-q!YMpHim*lrSX)v(8t' variabletype=''>this &amp; that</field></block>"
+        }
+    },
     "createobscuredshadow": {
         "name": "block",
         "xml": {

--- a/test/unit/engine_adapter.js
+++ b/test/unit/engine_adapter.js
@@ -155,6 +155,24 @@ test('create with obscured shadow', t => {
     t.end();
 });
 
+test('create variable with entity in name', t => {
+    const result = adapter(events.createvariablewithentity);
+
+    t.ok(Array.isArray(result));
+    t.equal(result.length, 1);
+
+    t.type(result[0].id, 'string');
+    t.type(result[0].opcode, 'string');
+    t.type(result[0].fields, 'object');
+    t.type(result[0].fields.VARIABLE, 'object');
+    t.type(result[0].fields.VARIABLE.value, 'string');
+    t.equal(result[0].fields.VARIABLE.value, 'this & that');
+    t.type(result[0].inputs, 'object');
+    t.type(result[0].topLevel, 'boolean');
+    t.equal(result[0].topLevel, true);
+    t.end();
+});
+
 test('create with invalid block xml', t => {
     // Entirely invalid block XML
     const result = adapter(events.createinvalid);


### PR DESCRIPTION
Correctly deserialize HTML entities in block DOM, e.g. in variable names. Useful mainly for variable watchers.

### Resolves

LLK/scratch-gui#665

Variables with XML-like content were being parsed as code. PR LLK/scratch-blocks#1114 fixes the display on the Blockly side of things. The PR here takes care of it in the context of stage monitors.

### Proposed Changes

When parsing the block XML, pass the `decodeEntities` flag to `htmlparser2`.

### Reason for Changes

To fix the bug and display XML entities (which should be generated only by Blockly) as their visual equivalents.

### Test Coverage

Added a test to ensure that an entity is being decoded.
