### PR TITLE
⭐️ Fix the infinite loop in say/think ⭐️

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -125,7 +125,11 @@ class Scratch3LooksBlocks {
         } else {
             this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {
                 position: [
-                    bubbleState.onSpriteRight ? targetBounds.right : targetBounds.left - bubbleWidth,
+                    bubbleState.onSpriteRight ? (
+                        Math.min(stageBounds.right - bubbleWidth, targetBounds.right)
+                    ) : (
+                        Math.max(stageBounds.left, targetBounds.left - bubbleWidth)
+                    ),
                     Math.min(stageBounds.top, targetBounds.top + bubbleHeight)
                 ]
             });

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -114,10 +114,12 @@ class Scratch3LooksBlocks {
         const [bubbleWidth, bubbleHeight] = this.runtime.renderer.getSkinSize(bubbleState.drawableId);
         const targetBounds = target.getBounds();
         const stageBounds = this.runtime.getTargetForStage().getBounds();
-        if (bubbleState.onSpriteRight && bubbleWidth + targetBounds.right > stageBounds.right) {
+        if (bubbleState.onSpriteRight && bubbleWidth + targetBounds.right > stageBounds.right &&
+            (targetBounds.left - bubbleWidth > stageBounds.left)) { // Only flip if it would fit
             bubbleState.onSpriteRight = false;
             this._renderBubble(target);
-        } else if (!bubbleState.onSpriteRight && targetBounds.left - bubbleWidth < stageBounds.left) {
+        } else if (!bubbleState.onSpriteRight && targetBounds.left - bubbleWidth < stageBounds.left &&
+            (bubbleWidth + targetBounds.right < stageBounds.right)) { // Only flip if it would fit
             bubbleState.onSpriteRight = true;
             this._renderBubble(target);
         } else {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the infinite loop that results if.... (deep breath)... you try to say/think the chorus to "all star" by smash mouth. Strangely specific bug report? Yup, thank @ericrosenbaum 

Only flip the bubble if it would fit the other way. 

Fixes https://github.com/LLK/scratch-vm/issues/702