### PR TITLE
Fix extension hats

### DIFF
--- a/src/blocks/scratch3_wedo2.js
+++ b/src/blocks/scratch3_wedo2.js
@@ -245,7 +245,7 @@ class WeDo2 {
      * @return {number} - the latest value received from the distance sensor.
      */
     get distance () {
-        return this._sensors.distance;
+        return this._sensors.distance * 10;
     }
 
     /**
@@ -732,8 +732,10 @@ class Scratch3WeDo2Blocks {
     whenDistance (args) {
         switch (args.OP) {
         case '<':
+        case '&lt;':
             return this._device.distance < args.REFERENCE;
         case '>':
+        case '&gt;':
             return this._device.distance > args.REFERENCE;
         default:
             log.warn(`Unknown comparison operator in whenDistance: ${args.OP}`);
@@ -755,7 +757,7 @@ class Scratch3WeDo2Blocks {
      * @return {number} - the distance sensor's value, scaled to the [0,100] range.
      */
     getDistance () {
-        return this._device.distance * 10;
+        return this._device.distance;
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -409,6 +409,9 @@ class Runtime extends EventEmitter {
             const opcode = convertedBlock.json.type;
             categoryInfo.blocks.push(convertedBlock);
             this._primitives[opcode] = convertedBlock.info.func;
+            if (blockInfo.blockType === BlockType.HAT) {
+                this._hats[opcode] = {edgeActivated: true}; /** @TODO let extension specify this */
+            }
         }
 
         this.emit(Runtime.EXTENSION_ADDED, categoryInfo.blocks);
@@ -802,13 +805,14 @@ class Runtime extends EventEmitter {
 
             // If no fields are present, check inputs (horizontal blocks)
             if (Object.keys(hatFields).length === 0) {
+                hatFields = {}; // don't overwrite the block's actual fields list
                 const hatInputs = blocks.getInputs(block);
                 for (const input in hatInputs) {
                     if (!hatInputs.hasOwnProperty(input)) continue;
                     const id = hatInputs[input].block;
                     const inpBlock = blocks.getBlock(id);
                     const fields = blocks.getFields(inpBlock);
-                    hatFields = Object.assign(fields, hatFields);
+                    Object.assign(hatFields, fields);
                 }
             }
 


### PR DESCRIPTION
### Resolves

Resolves #705 

### Proposed Changes

These changes make extension hat blocks function. For now they are assumed to be edge-activated, but see #696.

This PR also includes a fix for what seems to be a long-standing issue affecting hats with more than one input. In this situation, the code to collect hat inputs would permanently assign new values to the block's `fields` list, causing problems in the runtime later on. This was a tricky bug to find since the symptom is so distant from the cause; this might be an argument for using `Object.freeze` and similar features.

As a side effect of fixing extension hat blocks I noticed that the WeDo 2.0 `whenDistance` block wasn't scaled correctly, so I fixed that too. I also put in a workaround for #580.

### Reason for Changes

Further progress on extensions & preparation for Monday's playtest.
