### PR TITLE
Set/change pen color blocks with color, brightness, saturation, transparency

### DIFF
--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -13,7 +13,7 @@ const RenderedTarget = require('../sprites/rendered-target');
  * @enum {string}
  */
 const ColorParam = {
-    HUE: 'hue',
+    COLOR: 'color',
     SATURATION: 'saturation',
     BRIGHTNESS: 'brightness',
     TRANSPARENCY: 'transparency'
@@ -22,7 +22,7 @@ const ColorParam = {
 /**
  * @typedef {object} PenState - the pen state associated with a particular target.
  * @property {Boolean} penDown - tracks whether the pen should draw for this target.
- * @property {number} hue - the current hue of the pen.
+ * @property {number} color - the current color (hue) of the pen.
  * @property {number} shade - the current shade of the pen.
  * @property {PenAttributes} penAttributes - cached pen attributes for the renderer. This is the authoritative value for
  *   diameter but not for pen color.
@@ -68,7 +68,7 @@ class Scratch3PenBlocks {
     static get DEFAULT_PEN_STATE () {
         return {
             penDown: false,
-            hue: 33,
+            color: 33,
             saturation: 100,
             brightness: 100,
             shade: 50,
@@ -185,7 +185,7 @@ class Scratch3PenBlocks {
         }
     }
 
-    _wrapHue (value) {
+    _wrapColor (value) {
         return MathUtil.wrapClamp(value, 0, 100);
     }
 
@@ -267,7 +267,7 @@ class Scratch3PenBlocks {
                         COLOR_PARAM: {
                             type: ArgumentType.STRING,
                             menu: 'colorParam',
-                            defaultValue: ColorParam.HUE
+                            defaultValue: ColorParam.COLOR
                         },
                         VALUE: {
                             type: ArgumentType.NUMBER,
@@ -283,7 +283,7 @@ class Scratch3PenBlocks {
                         COLOR_PARAM: {
                             type: ArgumentType.STRING,
                             menu: 'colorParam',
-                            defaultValue: ColorParam.HUE
+                            defaultValue: ColorParam.COLOR
                         },
                         VALUE: {
                             type: ArgumentType.NUMBER,
@@ -316,7 +316,7 @@ class Scratch3PenBlocks {
             ],
             menus: {
                 colorParam:
-                    [ColorParam.HUE, ColorParam.SATURATION,
+                    [ColorParam.COLOR, ColorParam.SATURATION,
                     ColorParam.BRIGHTNESS, ColorParam.TRANSPARENCY]
             }
         };
@@ -393,21 +393,21 @@ class Scratch3PenBlocks {
         const penState = this._getPenState(util.target);
         const rgb = Cast.toRgbColorObject(args.COLOR);
         const hsv = Color.rgbToHsv(rgb);
-        penState.hue = (hsv.h / 360) * 100;
+        penState.color = (hsv.h / 360) * 100;
         penState.saturation = hsv.s * 100;
         penState.brightness = hsv.v * 100;
         this._updatePenColor(penState);
     }
 
     /**
-     * Update the cached color from the hue, saturation, brightness and transparency values
+     * Update the cached color from the color, saturation, brightness and transparency values
      * in the provided PenState object.
      * @param {PenState} penState - the pen state to update.
      * @private
      */
     _updatePenColor (penState) {
         let rgb = Color.hsvToRgb({
-            h: penState.hue * 360 / 100,
+            h: penState.color * 360 / 100,
             s: penState.saturation / 100,
             v: penState.brightness / 100
         });
@@ -420,8 +420,8 @@ class Scratch3PenBlocks {
     changePenColorParamBy (args, util) {
         const penState = this._getPenState(util.target);
         switch (args.COLOR_PARAM) {
-            case ColorParam.HUE:
-                penState.hue = this._wrapHue(penState.hue + Cast.toNumber(args.VALUE));
+            case ColorParam.COLOR:
+                penState.color = this._wrapColor(penState.color + Cast.toNumber(args.VALUE));
                 break;
             case ColorParam.SATURATION:
                 penState.saturation = this._clampColorParam(penState.saturation + Cast.toNumber(args.VALUE));
@@ -439,8 +439,8 @@ class Scratch3PenBlocks {
     setPenColorParamTo (args, util) {
         const penState = this._getPenState(util.target);
         switch (args.COLOR_PARAM) {
-            case ColorParam.HUE:
-                penState.hue = this._wrapHue(Cast.toNumber(args.VALUE));
+            case ColorParam.COLOR:
+                penState.color = this._wrapColor(Cast.toNumber(args.VALUE));
                 break;
             case ColorParam.SATURATION:
                 penState.saturation = this._clampColorParam(Cast.toNumber(args.VALUE));

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -415,42 +415,32 @@ class Scratch3PenBlocks {
         penState.penAttributes.color4f[3] = this._transparencyToAlpha(penState.transparency);
     }
 
-    changePenColorParamBy (args, util) {
-        const penState = this._getPenState(util.target);
-        switch (args.COLOR_PARAM) {
+    _setOrChangeColorParam (param, value, penState, change) {
+        switch (param) {
             case ColorParam.COLOR:
-                penState.color = this._wrapColor(penState.color + Cast.toNumber(args.VALUE));
+                penState.color = this._wrapColor(value + (change ? penState.color : 0));
                 break;
             case ColorParam.SATURATION:
-                penState.saturation = this._clampColorParam(penState.saturation + Cast.toNumber(args.VALUE));
+                penState.saturation = this._clampColorParam(value + (change ? penState.saturation : 0));
                 break;
             case ColorParam.BRIGHTNESS:
-                penState.brightness = this._clampColorParam(penState.brightness + Cast.toNumber(args.VALUE));
+                penState.brightness = this._clampColorParam(value + (change ? penState.brightness : 0));
                 break;
             case ColorParam.TRANSPARENCY:
-                penState.transparency = this._clampColorParam(penState.transparency + Cast.toNumber(args.VALUE));
+                penState.transparency = this._clampColorParam(value + (change ? penState.transparency : 0));
                 break;
         }
         this._updatePenColor(penState);
     }
 
+    changePenColorParamBy (args, util) {
+        const penState = this._getPenState(util.target);
+        this._setOrChangeColorParam(args.COLOR_PARAM, Cast.toNumber(args.VALUE), penState, true);
+    }
+
     setPenColorParamTo (args, util) {
         const penState = this._getPenState(util.target);
-        switch (args.COLOR_PARAM) {
-            case ColorParam.COLOR:
-                penState.color = this._wrapColor(Cast.toNumber(args.VALUE));
-                break;
-            case ColorParam.SATURATION:
-                penState.saturation = this._clampColorParam(Cast.toNumber(args.VALUE));
-                break;
-            case ColorParam.BRIGHTNESS:
-                penState.brightness = this._clampColorParam(Cast.toNumber(args.VALUE));
-                break;
-            case ColorParam.TRANSPARENCY:
-                penState.transparency = this._clampColorParam(Cast.toNumber(args.VALUE));
-                break;
-        }
-        this._updatePenColor(penState);
+        this._setOrChangeColorParam(args.COLOR_PARAM, Cast.toNumber(args.VALUE), penState, false);
     }
 
     /**

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -5,7 +5,7 @@ const Clone = require('../util/clone');
 const Color = require('../util/color');
 const MathUtil = require('../util/math-util');
 const RenderedTarget = require('../sprites/rendered-target');
-
+const log = require('../util/log');
 
 /**
  * Enum for pen color parameters.
@@ -431,6 +431,9 @@ class Scratch3PenBlocks {
             case ColorParam.TRANSPARENCY:
                 penState.transparency = this._clampColorParam(value + (change ? penState.transparency : 0));
                 break;
+            default:
+                log.warn(`Tried to set or change unknown color parameter: ${param}`);
+
         }
         this._updatePenColor(penState);
     }

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -246,15 +246,7 @@ class Scratch3PenBlocks {
             blocks: [
                 {
                     opcode: 'clear',
-                    blockType: BlockType.COMMAND,
-                    arguments: {
-                        NUM1: {
-                            type: ArgumentType.NUMBER
-                        },
-                        NUM2: {
-                            type: ArgumentType.NUMBER
-                        }
-                    }
+                    blockType: BlockType.COMMAND
                 },
                 {
                     opcode: 'stamp',

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -67,7 +67,7 @@ class Scratch3PenBlocks {
     static get DEFAULT_PEN_STATE () {
         return {
             penDown: false,
-            color: 33,
+            color: 66.66,
             saturation: 100,
             brightness: 100,
             transparency: 0,

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -383,6 +383,7 @@ class Scratch3PenBlocks {
 
     /**
      * The pen "set pen color to {color}" block sets the pen to a particular RGB color.
+     * The transparency is reset to 0.
      * @param {object} args - the block arguments.
      *  @property {int} COLOR - the color to set, expressed as a 24-bit RGB value (0xRRGGBB).
      * @param {object} util - utility object provided by the runtime.
@@ -394,6 +395,7 @@ class Scratch3PenBlocks {
         penState.color = (hsv.h / 360) * 100;
         penState.saturation = hsv.s * 100;
         penState.brightness = hsv.v * 100;
+        penState.transparency = 0;
         this._updatePenColor(penState);
     }
 

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -23,7 +23,6 @@ const ColorParam = {
  * @typedef {object} PenState - the pen state associated with a particular target.
  * @property {Boolean} penDown - tracks whether the pen should draw for this target.
  * @property {number} color - the current color (hue) of the pen.
- * @property {number} shade - the current shade of the pen.
  * @property {PenAttributes} penAttributes - cached pen attributes for the renderer. This is the authoritative value for
  *   diameter but not for pen color.
  */
@@ -71,7 +70,6 @@ class Scratch3PenBlocks {
             color: 33,
             saturation: 100,
             brightness: 100,
-            shade: 50,
             transparency: 0,
             penAttributes: {
                 color4f: [0, 0, 1, 1],

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -321,7 +321,7 @@ class Scratch3PenBlocks {
             menus: {
                 colorParam:
                     [ColorParam.COLOR, ColorParam.SATURATION,
-                    ColorParam.BRIGHTNESS, ColorParam.TRANSPARENCY]
+                        ColorParam.BRIGHTNESS, ColorParam.TRANSPARENCY]
             }
         };
     }
@@ -412,7 +412,7 @@ class Scratch3PenBlocks {
      * @private
      */
     _updatePenColor (penState) {
-        let rgb = Color.hsvToRgb({
+        const rgb = Color.hsvToRgb({
             h: penState.color * 360 / 100,
             s: penState.saturation / 100,
             v: penState.brightness / 100
@@ -433,21 +433,20 @@ class Scratch3PenBlocks {
      */
     _setOrChangeColorParam (param, value, penState, change) {
         switch (param) {
-            case ColorParam.COLOR:
-                penState.color = this._wrapColor(value + (change ? penState.color : 0));
-                break;
-            case ColorParam.SATURATION:
-                penState.saturation = this._clampColorParam(value + (change ? penState.saturation : 0));
-                break;
-            case ColorParam.BRIGHTNESS:
-                penState.brightness = this._clampColorParam(value + (change ? penState.brightness : 0));
-                break;
-            case ColorParam.TRANSPARENCY:
-                penState.transparency = this._clampColorParam(value + (change ? penState.transparency : 0));
-                break;
-            default:
-                log.warn(`Tried to set or change unknown color parameter: ${param}`);
-
+        case ColorParam.COLOR:
+            penState.color = this._wrapColor(value + (change ? penState.color : 0));
+            break;
+        case ColorParam.SATURATION:
+            penState.saturation = this._clampColorParam(value + (change ? penState.saturation : 0));
+            break;
+        case ColorParam.BRIGHTNESS:
+            penState.brightness = this._clampColorParam(value + (change ? penState.brightness : 0));
+            break;
+        case ColorParam.TRANSPARENCY:
+            penState.transparency = this._clampColorParam(value + (change ? penState.transparency : 0));
+            break;
+        default:
+            log.warn(`Tried to set or change unknown color parameter: ${param}`);
         }
         this._updatePenColor(penState);
     }

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -183,6 +183,12 @@ class Scratch3PenBlocks {
         }
     }
 
+    /**
+     * Wrap a color input into the range (0,100).
+     * @param {number} value - the value to be wrapped.
+     * @returns {number} the wrapped value.
+     * @private
+     */
     _wrapColor (value) {
         return MathUtil.wrapClamp(value, 0, 100);
     }
@@ -417,6 +423,14 @@ class Scratch3PenBlocks {
         penState.penAttributes.color4f[3] = this._transparencyToAlpha(penState.transparency);
     }
 
+    /**
+     * Set or change a single color parameter on the pen state, and update the pen color.
+     * @param {ColorParam} param - the name of the color parameter to set or change.
+     * @param {number} value - the value to set or change the param by.
+     * @param {PenState} penState - the pen state to update.
+     * @param {boolean} change - if true change param by value, if false set param to value.
+     * @private
+     */
     _setOrChangeColorParam (param, value, penState, change) {
         switch (param) {
             case ColorParam.COLOR:
@@ -438,11 +452,27 @@ class Scratch3PenBlocks {
         this._updatePenColor(penState);
     }
 
+    /**
+     * The "change pen {ColorParam} by {number}" block changes one of the pen's color parameters
+     * by a given amound.
+     * @param {object} args - the block arguments.
+     *  @property {ColorParam} COLOR_PARAM - the name of the selected color parameter.
+     *  @property {number} VALUE - the amount to change the selected parameter by.
+     * @param {object} util - utility object provided by the runtime.
+     */
     changePenColorParamBy (args, util) {
         const penState = this._getPenState(util.target);
         this._setOrChangeColorParam(args.COLOR_PARAM, Cast.toNumber(args.VALUE), penState, true);
     }
 
+    /**
+     * The "set pen {ColorParam} to {number}" block sets one of the pen's color parameters
+     * to a given amound.
+     * @param {object} args - the block arguments.
+     *  @property {ColorParam} COLOR_PARAM - the name of the selected color parameter.
+     *  @property {number} VALUE - the amount to set the selected parameter to.
+     * @param {object} util - utility object provided by the runtime.
+     */
     setPenColorParamTo (args, util) {
         const penState = this._getPenState(util.target);
         this._setOrChangeColorParam(args.COLOR_PARAM, Cast.toNumber(args.VALUE), penState, false);

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -185,18 +185,6 @@ class Scratch3PenBlocks {
         }
     }
 
-    /**
-     * Wrap a pen hue or shade values to the range (0,200).
-     * @param {number} value - the pen hue or shade value to the proper range.
-     * @returns {number} the wrapped value.
-     * @private
-     */
-    _wrapHueOrShade (value) {
-        value = value % 200;
-        if (value < 0) value += 200;
-        return value;
-    }
-
     _wrapHue (value) {
         return MathUtil.wrapClamp(value, 0, 100);
     }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-blocks/issues/1091
Resolves https://github.com/LLK/scratch-gui/issues/783

And progress on https://github.com/LLK/scratch-gui/issues/725

Note that testing these changes will require pulling a PR on Scratch-gui that updates the extension library modal: https://github.com/LLK/scratch-gui/pull/793

### Proposed Changes

Change the way the pen color is set to use a menu of four color parameters: color, brightness, saturation and transparency. All are scaled 0-100. Color is wrapped, the rest are clamped.

### Reason for Changes

The earlier version of pen color blocks used different blocks with different ranges for the color parameters (and the "shade" block combined saturation and brightness). This change simplifies the color parameters by putting them all into the same range. It also reduces the total number of pen blocks by putting the four parameters into a menu.