### PR TITLE
Fix undefined procedure execution

### DIFF
--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -27,11 +27,20 @@ class Scratch3ProcedureBlocks {
         if (!util.stackFrame.executed) {
             const procedureCode = args.mutation.proccode;
             const paramNames = util.getProcedureParamNames(procedureCode);
+
+            // If null, procedure could not be found, which can happen if custom
+            // block is dragged between sprites without the definition.
+            // Match Scratch 2.0 behavior and noop.
+            if (paramNames === null) {
+                return;
+            }
+
             for (let i = 0; i < paramNames.length; i++) {
                 if (args.hasOwnProperty(`input${i}`)) {
                     util.pushParam(paramNames[i], args[`input${i}`]);
                 }
             }
+
             util.stackFrame.executed = true;
             util.startProcedure(procedureCode);
         }

--- a/test/unit/blocks_procedures.js
+++ b/test/unit/blocks_procedures.js
@@ -1,0 +1,28 @@
+const test = require('tap').test;
+const Procedures = require('../../src/blocks/scratch3_procedures');
+
+const blocks = new Procedures(null);
+
+test('getPrimitives', t => {
+    t.type(blocks.getPrimitives(), 'object');
+    t.end();
+});
+
+// Originally inspired by https://github.com/LLK/scratch-gui/issues/809
+test('calling a custom block with no definition does not throw', t => {
+    const args = {
+        mutation: {
+            proccode: 'undefined proc'
+        }
+    };
+    const util = {
+        getProcedureParamNames: () => null,
+        stackFrame: {
+            executed: false
+        }
+    };
+    t.doesNotThrow(() => {
+        blocks.callNoReturn(args, util);
+    });
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/809, where a procedure is trying to be run without an accompanying define block. Generally you can't get into this state (deleting a procedure requires no other instances of the call block), but you can do it by dragging the custom block from one sprite to another, as happened in that project. 

### Proposed Changes

_Describe what this Pull Request does_

Like scratch 2, just noop if that happens.


### Reason for Changes

_Explain why these changes should be made_

So that these projects can run without crashing!

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a new test to the procedure block documenting this behavior
