### PR TITLE
Prevent imported local variables from being duplicated on the stage.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -255,7 +255,13 @@ class Blocks {
             });
             break;
         case 'var_create':
-            stage.createVariable(e.varId, e.varName);
+            // New variables being created by the user are all global.
+            // Check if this variable exists on the current target or stage.
+            // If not, create it on the stage.
+            // TODO create global and local variables when UI provides a way.
+            if (!optRuntime.getEditingTarget().lookupVariableById(e.varId)) {
+                stage.createVariable(e.varId, e.varName);
+            }
             break;
         case 'var_rename':
             stage.renameVariable(e.varId, e.newName);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes the problem with running projects with both local and global variables by preventing the `VAR_CREATE` from recreating existing local variables on the stage. 

You can test with projects like this one: https://scratch.mit.edu/projects/178966496/

### Proposed Changes

_Describe what this Pull Request does_

Check if a local variable with that ID exists already before calling "create" with it on the stage. 

The reason the variable gets created on the stage is that all variables created within scratch-blocks right now should be created as global variables. 
