### PR TITLE
Fix say/think with non-string inputs

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -240,7 +240,7 @@ class Scratch3LooksBlocks {
 
     say (args, util) {
         // @TODO in 2.0 calling say/think resets the right/left bias of the bubble
-        this._updateBubble(util.target, 'say', args.MESSAGE);
+        this._updateBubble(util.target, 'say', String(args.MESSAGE));
     }
 
     sayforsecs (args, util) {
@@ -256,7 +256,7 @@ class Scratch3LooksBlocks {
     }
 
     think (args, util) {
-        this._updateBubble(util.target, 'think', args.MESSAGE);
+        this._updateBubble(util.target, 'think', String(args.MESSAGE));
     }
 
     thinkforsecs (args, util) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/817

### Proposed Changes

_Describe what this Pull Request does_

`String( <> )` things before say/thinking them.

### Reason for Changes

_Explain why these changes should be made_

These kinds of blocks didn't work before, now they do!

![image](https://user-images.githubusercontent.com/654102/32190876-98841786-bd85-11e7-9ad0-c86034e47fe7.png)
