### PR TITLE
Register extension with URL and category name

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -447,7 +447,11 @@ class Runtime extends EventEmitter {
             }
         }
 
-        this.emit(Runtime.EXTENSION_ADDED, categoryInfo.blocks.concat(categoryInfo.menus));
+        const blocksInfo = categoryInfo.blocks.concat(categoryInfo.menus);
+        blocksInfo.extensionURL = extensionInfo.id;
+        blocksInfo.categoryName = extensionInfo.name;
+
+        this.emit(Runtime.EXTENSION_ADDED, blocksInfo);
     }
 
     /**


### PR DESCRIPTION
### Resolves

This is support for https://github.com/LLK/scratch-gui/issues/821

### Proposed Changes

When emitting the EXTENSION_ADDED event, in addition to info about the blocks themselves, include the category name and URL.

### Reason for Changes

When the GUI receives this event, it can store the extension URL, in order to prevent loading duplicate copies of the extension. The GUI can also use the category name to ask the blocks flyout to scroll to that category.   

### Test Coverage

No tests added.