### PR TITLE
Support legacy hue and shade pen blocks

### DIFF
--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -328,7 +328,8 @@ class Scratch3PenBlocks {
                             type: ArgumentType.NUMBER,
                             defaultValue: 1
                         }
-                    }
+                    },
+                    hideFromPalette: true
                 },
                 {
                     opcode: 'changePenShadeBy',
@@ -339,7 +340,8 @@ class Scratch3PenBlocks {
                             type: ArgumentType.NUMBER,
                             defaultValue: 1
                         }
-                    }
+                    },
+                    hideFromPalette: true
                 },
                 {
                     opcode: 'setPenHueToNumber',
@@ -350,7 +352,8 @@ class Scratch3PenBlocks {
                             type: ArgumentType.NUMBER,
                             defaultValue: 1
                         }
-                    }
+                    },
+                    hideFromPalette: true
                 },
                 {
                     opcode: 'changePenHueBy',
@@ -361,7 +364,8 @@ class Scratch3PenBlocks {
                             type: ArgumentType.NUMBER,
                             defaultValue: 1
                         }
-                    }
+                    },
+                    hideFromPalette: true
                 }
             ],
             menus: {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -630,8 +630,9 @@ class Runtime extends EventEmitter {
         const xmlParts = [];
         for (const categoryInfo of this._blockInfo) {
             const {name, color1, color2} = categoryInfo;
+            const paletteBlocks = categoryInfo.blocks.filter(block => !block.info.hideFromPalette);
             xmlParts.push(`<category name="${name}" colour="${color1}" secondaryColour="${color2}">`);
-            xmlParts.push.apply(xmlParts, categoryInfo.blocks.map(blockInfo => blockInfo.xml));
+            xmlParts.push.apply(xmlParts, paletteBlocks.map(block => block.xml));
             xmlParts.push('</category>');
         }
         return xmlParts.join('\n');

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -30,6 +30,7 @@ const builtinExtensions = {
  * @property {object.<string,ArgumentInfo>|undefined} arguments - information about this block's arguments, if any
  * @property {string|Function|undefined} func - the method for this block on the extension service (default: opcode)
  * @property {Array.<string>|undefined} filter - the list of targets for which this block should appear (default: all)
+ * @property {Boolean|undefined} hideFromPalette - true if should not be appear in the palette. (default false)
  */
 
 /**

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -535,7 +535,7 @@ const specMap = {
             {
                 type: 'input',
                 inputOp: 'math_number',
-                inputName: 'COLOR'
+                inputName: 'HUE'
             }
         ]
     },
@@ -545,7 +545,7 @@ const specMap = {
             {
                 type: 'input',
                 inputOp: 'math_number',
-                inputName: 'COLOR'
+                inputName: 'HUE'
             }
         ]
     },


### PR DESCRIPTION
_Paired with @ericrosenbaum on this._

### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-vm/issues/736

### Proposed Changes

_Describe what this Pull Request does_

Adds 4 legacy pen block definitions to the pen extension.

The `set/change hue` blocks can use the new HSV color model directly as `hue` is identically twice what the new `color` property is. 

The shade blocks are somewhat trickier. For the `set shade to <number>` block, we can use the old scratch 2 shade model code to create an RGB color based on the current hue and the given shade, and then decompose that to HSV.

For the `change shade by <number>`, I unfortunately needed to store the `shade` information in the color state because I couldn't reliably extract shade from HSV, and because the "ping-pong" wrapping of shade makes it impossible to correctly implement without some state tracking. So I stored an extra value in `penState._shade`, and update it in two places. First is when you use `set pen color to color`. This stores a rough estimate of shade (`brightness / 2`), which is the same as the scratch 2 behavior. The other is when shade is explicitly updated with `set/change shade`. 

Scratch 2 pen projects should work the same way they used to. One limitation is that using the new `set pen <saturation/brightness>` blocks will not update the stored shade value, as they are incompatible. I think that this is an acceptable limitation. 

---

The second commit hides the new legacy blocks from the palette. I introduced a new flag because I was unsure about the future of the `filter` attribute on extension blocks. @cwillisf let me know your thoughts on this.