### PR TITLE
Search for variables by name in "of" block

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -167,8 +167,10 @@ class Scratch3SensingBlocks {
 
         // Variables
         const varName = args.PROPERTY;
-        if (attrTarget.variables.hasOwnProperty(varName)) {
-            return attrTarget.variables[varName].value;
+        for (const id in attrTarget.variables) {
+            if (attrTarget.variables[id].name === varName) {
+                return attrTarget.variables[id].value;
+            }
         }
 
         // Otherwise, 0


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/llk/scratch-vm/issues/711

### Proposed Changes

_Describe what this Pull Request does_

Variables are no longer keyed by their name, they are now keyed by id. So now you have to find the variable with the right name. 

### Reason for Changes

_Explain why these changes should be made_

Bug in the sensing block after the big variables update. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested griffpatch's test example.

---

There is a bigger question about whether these blocks should get automatically updated when renaming variables, etc. I do not think we can really deal with that right now because of the way we do variables. 
