### PR TITLE
Use category info that has colors when building menu blocks

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -433,7 +433,7 @@ class Runtime extends EventEmitter {
         for (const menuName in extensionInfo.menus) {
             if (extensionInfo.menus.hasOwnProperty(menuName)) {
                 const menuItems = extensionInfo.menus[menuName];
-                const convertedMenu = this._buildMenuForScratchBlocks(menuName, menuItems, extensionInfo);
+                const convertedMenu = this._buildMenuForScratchBlocks(menuName, menuItems, categoryInfo);
                 categoryInfo.menus.push(convertedMenu);
             }
         }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/704

### Proposed Changes

_Describe what this Pull Request does_

Use the `categoryInfo` object which has the colors required. It seems like this was a typo in the original code. Note how a few lines down categoryInfo is also passed to the other `build` function (correctly).

### Reason for Changes

_Explain why these changes should be made_

![image](https://user-images.githubusercontent.com/654102/32388480-32b9ddc0-c09e-11e7-8042-9d1efa4fad06.png)

![image](https://user-images.githubusercontent.com/654102/32388482-3463f17e-c09e-11e7-8c02-74f292cfe9ab.png)