### PR TITLE
Constant time check if a thread is in doneThreads

### DIFF
--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -84,13 +84,28 @@ class Sequencer {
             ranFirstTick = true;
         }
         // Filter inactive threads from `this.runtime.threads`.
-        this.runtime.threads = this.runtime.threads.filter((thread, i) => {
+        numActiveThreads = 0;
+        for (let i = 0; i < this.runtime.threads.length; i++) {
+            const thread = this.runtime.threads[i];
             if (doneThreads[i] === null) {
-                return false;
+                this.runtime.threads[numActiveThreads] = thread;
+                numActiveThreads++;
             }
-            return true;
-        });
-        return doneThreads.filter(Boolean);
+        }
+        this.runtime.threads.length = numActiveThreads;
+
+        // Filter undefined and null values from `doneThreads`.
+        let numDoneThreads = 0;
+        for (let i = 0; i < doneThreads.length; i++) {
+            const maybeThread = doneThreads[i];
+            if (maybeThread !== null) {
+                doneThreads[numDoneThreads] = maybeThread;
+                numDoneThreads++;
+            }
+        }
+        doneThreads.length = numDoneThreads;
+
+        return doneThreads;
     }
 
     /**


### PR DESCRIPTION
### Resolves

Related to #740 and #744.

Speeds up `Sequencer.stepThreads` in projects like https://scratch.mit.edu/projects/155128646/ and https://scratch.mit.edu/projects/14844969/ which use a lot threads.

### Proposed Changes

Maintain doneThreads as a list of null and done threads as runtime threads are iterated. This way any thread was done when it was interpreted will appear in the same index as it appear in the list of runtime threads to be able to do a constant time check if the thread was done at the right time.

After filtering the runtime threads, the done threads can be filtered done to just thread objects, filtering out all the null values.

### Reason for Changes

`indexOf` may need to step over all of the already `doneThreads` to know if it has been added previously. This adds up in projects that start and finish a lot of threads regularly.

### Test Coverage

This replaces existing behaviour to help the scratch-vm perform faster. It passes the existing engine_sequencer tests.
