### PR TITLE
Add back pen transparency from color number

### DIFF
--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -452,7 +452,7 @@ class Scratch3PenBlocks {
         penState.saturation = hsv.s * 100;
         penState.brightness = hsv.v * 100;
         if (rgb.hasOwnProperty('a')) {
-            penState.transparency = 100 * (1 - rgb.a / 255.0);
+            penState.transparency = 100 * (1 - (rgb.a / 255.0));
         } else {
             penState.transparency = 0;
         }

--- a/src/blocks/scratch3_pen.js
+++ b/src/blocks/scratch3_pen.js
@@ -451,7 +451,11 @@ class Scratch3PenBlocks {
         penState.color = (hsv.h / 360) * 100;
         penState.saturation = hsv.s * 100;
         penState.brightness = hsv.v * 100;
-        penState.transparency = 0;
+        if (rgb.hasOwnProperty('a')) {
+            penState.transparency = 100 * (1 - rgb.a / 255.0);
+        } else {
+            penState.transparency = 0;
+        }
 
         // Set the legacy "shade" value the same way scratch 2 did.
         penState._shade = penState.brightness / 2;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fix the dropped scratch2 pen transparency model to support imported projects. Uses the same code as used to be in the pen extension. 

![image](https://user-images.githubusercontent.com/654102/32400982-c69cb8b6-c0dd-11e7-88bf-2e6cbbe45049.png)

![image](https://user-images.githubusercontent.com/654102/32400983-c8b52976-c0dd-11e7-8979-79c078105d6e.png)
