### PR TITLE
Fix shape of boolean tilt reporter

### DIFF
--- a/src/blocks/scratch3_wedo2.js
+++ b/src/blocks/scratch3_wedo2.js
@@ -544,7 +544,7 @@ class Scratch3WeDo2Blocks {
                 {
                     opcode: 'isTilted',
                     text: 'tilted [DIRECTION]?',
-                    blockType: BlockType.REPORTER,
+                    blockType: BlockType.BOOLEAN,
                     arguments: {
                         DIRECTION: {
                             type: ArgumentType.STRING,


### PR DESCRIPTION
The boolean reporter block for the Lego WeDo tilt sensor was incorrectly set to the round reporter shape. This sets it correctly to the boolean shape.