### PR TITLE
Ask/answer opcode implementation with runtime events.

### DIFF
--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -1,0 +1,34 @@
+const test = require('tap').test;
+const Sensing = require('../../src/blocks/scratch3_sensing');
+const Runtime = require('../../src/engine/runtime');
+
+test('getPrimitives', t => {
+    const rt = new Runtime();
+    const s = new Sensing(rt);
+    t.type(s.getPrimitives(), 'object');
+    t.end();
+});
+
+test('ask and answer', t => {
+    const rt = new Runtime();
+    const s = new Sensing(rt);
+
+    const expectedQuestion = 'a question';
+    const expectedAnswer = 'the answer';
+
+    // Test is written out of order because of promises, follow the (#) comments.
+    rt.addListener('QUESTION', question => {
+        // (2) Assert the question is correct, then emit the answer
+        t.strictEqual(question, expectedQuestion);
+        rt.emit('ANSWER', expectedAnswer);
+    });
+
+    // (1) Emit the question.
+    const promise = s.askAndWait({QUESTION: expectedQuestion});
+
+    // (3) Ask block resolves after the answer is emitted.
+    promise.then(() => {
+        t.strictEqual(s.getAnswer(), expectedAnswer);
+        t.end();
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Implements the first part of the VM implementation of ask/answer: emit QUESTION events with the asked question and bind ANSWER events to set the global answer reporter value. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a test for the sensing block code to test asking and answering questions. 


---

Future work will involve triggering a bubble instead of sending the question with the event if the sprite is visible. 