### PR TITLE
Write src/engine/execute so it can be optimized

### DIFF
--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -8,7 +8,11 @@ const {Map} = require('immutable');
  * @return {boolean} True if the value appears to be a Promise.
  */
 const isPromise = function (value) {
-    return value && value.then && typeof value.then === 'function';
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        typeof value.then === 'function'
+    );
 };
 
 /**


### PR DESCRIPTION
### Resolves

Related to #744, performance in execute and isPromise.

### Proposed Changes

Use explicit tests to detect if a value is a promise.

### Reason for Changes

Testing with implicitly casted `value` and `value.then` is deoptimizing
isPromise, which deoptimizes execute. In this case deoptimizing means
that the JavaScript VM cannot compile the functions into a form that
can be run faster.

### Test Coverage

Existing part of execute behaviour.
