### PR TITLE
Allow ask to use say bubble via events

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -23,10 +23,14 @@ class Scratch3LooksBlocks {
         this._onTargetMoved = this._onTargetMoved.bind(this);
         this._onResetBubbles = this._onResetBubbles.bind(this);
         this._onTargetWillExit = this._onTargetWillExit.bind(this);
+        this._updateBubble = this._updateBubble.bind(this);
 
         // Reset all bubbles on start/stop
         this.runtime.on('PROJECT_STOP_ALL', this._onResetBubbles);
         this.runtime.on('targetWasRemoved', this._onTargetWillExit);
+
+        // Enable other blocks to use bubbles like ask/answer
+        this.runtime.on('SAY', this._updateBubble);
     }
 
     /**

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -9,9 +9,10 @@ test('getPrimitives', t => {
     t.end();
 });
 
-test('ask and answer', t => {
+test('ask and answer with a hidden target', t => {
     const rt = new Runtime();
     const s = new Sensing(rt);
+    const util = {target: {visible: false}};
 
     const expectedQuestion = 'a question';
     const expectedAnswer = 'the answer';
@@ -24,11 +25,43 @@ test('ask and answer', t => {
     });
 
     // (1) Emit the question.
-    const promise = s.askAndWait({QUESTION: expectedQuestion});
+    const promise = s.askAndWait({QUESTION: expectedQuestion}, util);
 
     // (3) Ask block resolves after the answer is emitted.
     promise.then(() => {
         t.strictEqual(s.getAnswer(), expectedAnswer);
         t.end();
     });
+});
+
+test('ask and answer with a visible target', t => {
+    const rt = new Runtime();
+    const s = new Sensing(rt);
+    const util = {target: {visible: true}};
+
+    const expectedQuestion = 'a question';
+    const expectedAnswer = 'the answer';
+
+    rt.removeAllListeners('SAY'); // Prevent say blocks from executing
+
+    rt.addListener('SAY', (target, type, question) => {
+        // Should emit SAY with the question
+        t.strictEqual(question, expectedQuestion);
+    });
+
+    rt.addListener('QUESTION', question => {
+        // Question should be blank for a visible target
+        t.strictEqual(question, '');
+
+        // Remove the say listener and add a new one to assert bubble is cleared
+        // by setting say to empty string after answer is received.
+        rt.removeAllListeners('SAY');
+        rt.addListener('SAY', (target, type, text) => {
+            t.strictEqual(text, '');
+            t.end();
+        });
+        rt.emit('ANSWER', expectedAnswer);
+    });
+
+    s.askAndWait({QUESTION: expectedQuestion}, util);
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Completes the ask/answer feature by using say bubbles to show the question from an ask block when the sprite is visible. 

### Proposed Changes

_Describe what this Pull Request does_

Use events to communicate between looks/sensing blocks. 

![ask-with-bubbles](https://user-images.githubusercontent.com/654102/32557862-5fe72ede-c471-11e7-9eff-98adb96c7a2f.gif)

