### PR TITLE
Improving test coverage

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -474,9 +474,12 @@ class VirtualMachine extends EventEmitter {
      */
     deleteSprite (targetId) {
         const target = this.runtime.getTargetById(targetId);
-        const targetIndexBeforeDelete = this.runtime.targets.map(t => t.id).indexOf(target.id);
+        // const targetIndexBeforeDelete = this.runtime.targets.map(t => t.id).indexOf(target.id);
+        // can't call target.id if target doesn't exist.
+        // moving below
 
         if (target) {
+            const targetIndexBeforeDelete = this.runtime.targets.map(t => t.id).indexOf(target.id);
             if (!target.isSprite()) {
                 throw new Error('Cannot delete non-sprite targets.');
             }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -474,9 +474,6 @@ class VirtualMachine extends EventEmitter {
      */
     deleteSprite (targetId) {
         const target = this.runtime.getTargetById(targetId);
-        // const targetIndexBeforeDelete = this.runtime.targets.map(t => t.id).indexOf(target.id);
-        // can't call target.id if target doesn't exist.
-        // moving below
 
         if (target) {
             const targetIndexBeforeDelete = this.runtime.targets.map(t => t.id).indexOf(target.id);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -509,6 +509,8 @@ class VirtualMachine extends EventEmitter {
     /**
      * Duplicate a sprite.
      * @param {string} targetId ID of a target whose sprite to duplicate.
+     * @returns {Promise} Promise that resolves when duplicated target has
+     *     been added to the runtime.
      */
     duplicateSprite (targetId) {
         const target = this.runtime.getTargetById(targetId);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -495,7 +495,11 @@ class VirtualMachine extends EventEmitter {
                 // Ensure editing target is switched if we are deleting it.
                 if (clone === currentEditingTarget) {
                     const nextTargetIndex = Math.min(this.runtime.targets.length - 1, targetIndexBeforeDelete);
-                    this.setEditingTarget(this.runtime.targets[nextTargetIndex].id);
+                    if (this.runtime.targets.length > 0){
+                        this.setEditingTarget(this.runtime.targets[nextTargetIndex].id);
+                    } else {
+                        this.editingTarget = null;
+                    }
                 }
             }
             // Sprite object should be deleted by GC.
@@ -518,7 +522,7 @@ class VirtualMachine extends EventEmitter {
         } else if (!target.sprite) {
             throw new Error('No sprite associated with this target.');
         }
-        target.duplicate().then(newTarget => {
+        return target.duplicate().then(newTarget => {
             this.runtime.targets.push(newTarget);
             this.setEditingTarget(newTarget.id);
         });

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -1,5 +1,8 @@
 const test = require('tap').test;
 const VirtualMachine = require('../../src/virtual-machine.js');
+const Target = require('../../src/engine/target.js');
+const Sprite = require('../../src/sprites/sprite.js');
+const RenderedTarget = require('../../src/sprites/rendered-target');
 
 test('renameSprite throws when there is no sprite with that id', t => {
     const vm = new VirtualMachine();
@@ -146,12 +149,135 @@ test('deleteSprite throws when there is no target with given id', t => {
             name: 'this name'
         }
     }];
-    vm.runtime.getTargetById = () => null;
     t.throws(
-        (() => vm.deleteSprite('id')),
+        (() => vm.deleteSprite('id1')),
         new Error ('No target with the provided id.')
     );
     t.end();
+});
+
+test('deleteSprite deletes a sprite when given id is associated with a known sprite', t => {
+    const vm = new VirtualMachine();
+    const spr = new Sprite(null, vm.runtime);
+    const currTarget = spr.createClone();
+
+    vm.runtime.targets = [currTarget];
+
+    t.equal(currTarget.sprite.clones.length, 1);
+    vm.deleteSprite(currTarget.id);
+    t.equal(currTarget.sprite.clones.length, 0);
+    t.end();
+});
+
+test('deleteSprite sets editing target as null when sprite being deleted is current editing target, and the only target in the runtime', t => {
+    const vm = new VirtualMachine();
+    const spr = new Sprite(null, vm.runtime);
+    const currTarget = spr.createClone();
+
+    vm.editingTarget = currTarget;
+    vm.runtime.targets = [currTarget];
+
+    vm.deleteSprite(currTarget.id);
+
+    t.equal(vm.runtime.targets.length, 0);
+    t.equal(vm.editingTarget, null);
+    t.end();
+});
+
+test('deleteSprite updates editingTarget when sprite being deleted is current editing target, and there is another target in the runtime', t => {
+    const vm = new VirtualMachine();
+    const spr1 = new Sprite(null, vm.runtime);
+    const spr2 = new Sprite(null, vm.runtime);
+    const currTarget = spr1.createClone();
+    const otherTarget = spr2.createClone();
+
+    vm.emitWorkspaceUpdate = () => null;
+
+    vm.runtime.targets = [currTarget, otherTarget];
+    vm.editingTarget = currTarget;
+
+    t.equal(vm.runtime.targets.length, 2);
+    vm.deleteSprite(currTarget.id);
+    t.equal(vm.runtime.targets.length, 1);
+    t.equal(vm.editingTarget.id, otherTarget.id);
+
+    // now let's try them in the other order in the runtime.targets list
+
+    // can't reuse deleted targets
+    const currTarget2 = spr1.createClone();
+    const otherTarget2 = spr2.createClone();
+
+    vm.runtime.targets = [otherTarget2, currTarget2];
+    vm.editingTarget = currTarget2;
+
+    t.equal(vm.runtime.targets.length, 2);
+    vm.deleteSprite(currTarget2.id);
+    t.equal(vm.editingTarget.id, otherTarget2.id);
+    t.equal(vm.runtime.targets.length, 1);
+
+    t.end();
+});
+
+
+
+test('duplicateSprite throws when there is no target with given id', t => {
+    const vm = new VirtualMachine();
+    vm.runtime.targets = [{
+        id: 'id',
+        isSprite: () => true,
+        sprite: {
+            name: 'this name'
+        }
+    }];
+    t.throws(
+        (() => vm.duplicateSprite('id1')),
+        new Error('No target with the provided id')
+    );
+    t.end();
+});
+
+test('duplicateSprite throws when used on a non-sprite target', t => {
+    const vm = new VirtualMachine();
+    vm.runtime.targets = [{
+        id: 'id',
+        isSprite: () => false
+    }];
+    t.throws(
+        (() => vm.duplicateSprite('id')),
+        new Error('Cannot duplicate non-sprite targets.')
+    );
+    t.end();
+});
+
+test('duplicateSprite throws when there is no sprite for the given target', t => {
+    const vm = new VirtualMachine();
+    vm.runtime.targets = [{
+        id: 'id',
+        isSprite: () => true,
+        sprite: null
+    }];
+    t.throws(
+        (() => vm.duplicateSprite('id')),
+        new Error ('No sprite associated with this target.')
+    );
+    t.end();
+});
+
+test('duplicateSprite duplicates a sprite when given id is associated with known sprite', t => {
+    const vm = new VirtualMachine();
+    const spr = new Sprite(null, vm.runtime);
+    const currTarget = spr.createClone();
+    vm.editingTarget = currTarget;
+
+    vm.emitWorkspaceUpdate = () => null;
+
+    vm.runtime.targets = [currTarget];
+    t.equal(vm.runtime.targets.length, 1);
+    vm.duplicateSprite(currTarget.id).then(() => {
+        t.equal(vm.runtime.targets.length, 2);
+        t.end();
+    });
+
 });
 
 test('emitWorkspaceUpdate', t => {

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -1,8 +1,6 @@
 const test = require('tap').test;
 const VirtualMachine = require('../../src/virtual-machine.js');
-const Target = require('../../src/engine/target.js');
 const Sprite = require('../../src/sprites/sprite.js');
-const RenderedTarget = require('../../src/sprites/rendered-target');
 
 test('renameSprite throws when there is no sprite with that id', t => {
     const vm = new VirtualMachine();
@@ -121,7 +119,7 @@ test('deleteSprite throws when used on a non-sprite target', t => {
     }];
     t.throws(
         (() => vm.deleteSprite('id')),
-        new Error ('Cannot delete non-sprite targets.')
+        new Error('Cannot delete non-sprite targets.')
     );
     t.end();
 });
@@ -135,7 +133,7 @@ test('deleteSprite throws when there is no sprite for the given target', t => {
     }];
     t.throws(
         (() => vm.deleteSprite('id')),
-        new Error ('No sprite associated with this target.')
+        new Error('No sprite associated with this target.')
     );
     t.end();
 });
@@ -151,7 +149,7 @@ test('deleteSprite throws when there is no target with given id', t => {
     }];
     t.throws(
         (() => vm.deleteSprite('id1')),
-        new Error ('No target with the provided id.')
+        new Error('No target with the provided id.')
     );
     t.end();
 });
@@ -169,7 +167,8 @@ test('deleteSprite deletes a sprite when given id is associated with a known spr
     t.end();
 });
 
-test('deleteSprite sets editing target as null when sprite being deleted is current editing target, and the only target in the runtime', t => {
+// eslint-disable-next-line max-len
+test('deleteSprite sets editing target as null when given sprite is current editing target, and the only target in the runtime', t => {
     const vm = new VirtualMachine();
     const spr = new Sprite(null, vm.runtime);
     const currTarget = spr.createClone();
@@ -184,6 +183,7 @@ test('deleteSprite sets editing target as null when sprite being deleted is curr
     t.end();
 });
 
+// eslint-disable-next-line max-len
 test('deleteSprite updates editingTarget when sprite being deleted is current editing target, and there is another target in the runtime', t => {
     const vm = new VirtualMachine();
     const spr1 = new Sprite(null, vm.runtime);
@@ -217,8 +217,6 @@ test('deleteSprite updates editingTarget when sprite being deleted is current ed
 
     t.end();
 });
-
-
 
 test('duplicateSprite throws when there is no target with given id', t => {
     const vm = new VirtualMachine();
@@ -258,7 +256,7 @@ test('duplicateSprite throws when there is no sprite for the given target', t =>
     }];
     t.throws(
         (() => vm.duplicateSprite('id')),
-        new Error ('No sprite associated with this target.')
+        new Error('No sprite associated with this target.')
     );
     t.end();
 });

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -110,6 +110,50 @@ test('renameSprite does not increment when renaming to the same name', t => {
     t.end();
 });
 
+test('deleteSprite throws when used on a non-sprite target', t => {
+    const vm = new VirtualMachine();
+    vm.runtime.targets = [{
+        id: 'id',
+        isSprite: () => false
+    }];
+    t.throws(
+        (() => vm.deleteSprite('id')),
+        new Error ('Cannot delete non-sprite targets.')
+    );
+    t.end();
+});
+
+test('deleteSprite throws when there is no sprite for the given target', t => {
+    const vm = new VirtualMachine();
+    vm.runtime.targets = [{
+        id: 'id',
+        isSprite: () => true,
+        sprite: null
+    }];
+    t.throws(
+        (() => vm.deleteSprite('id')),
+        new Error ('No sprite associated with this target.')
+    );
+    t.end();
+});
+
+test('deleteSprite throws when there is no target with given id', t => {
+    const vm = new VirtualMachine();
+    vm.runtime.targets = [{
+        id: 'id',
+        isSprite: () => true,
+        sprite: {
+            name: 'this name'
+        }
+    }];
+    vm.runtime.getTargetById = () => null;
+    t.throws(
+        (() => vm.deleteSprite('id')),
+        new Error ('No target with the provided id.')
+    );
+    t.end();
+});
+
 test('emitWorkspaceUpdate', t => {
     const vm = new VirtualMachine();
     vm.runtime.targets = [


### PR DESCRIPTION
### Resolves

Improved test coverage for src/virtual-machine.js.

### Proposed Changes

Adding unit tests for deleteSprite and duplicateSprite functions.
Modifies these functions in the source file to address minor bugs found during testing:
- [In `deleteSprite`] accessing target.id before checking that it's null
- [In `deleteSprite`] resetting current editing target to null if last target gets deleted
- [In `duplicateSprite`] returning a promise for use in testing

### Reason for Changes

Testing is good. ~10% more coverage of this file.
