### PR TITLE
Execute monitors on a given target ID when block is sprite-specific

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -244,10 +244,10 @@ class Scratch3LooksBlocks {
 
     getMonitored () {
         return {
-            size: {isSpriteSpecific: true},
-            costumeorder: {isSpriteSpecific: true},
-            backdroporder: {},
-            backdropname: {}
+            looks_size: {isSpriteSpecific: true},
+            looks_costumeorder: {isSpriteSpecific: true},
+            looks_backdroporder: {},
+            looks_backdropname: {}
         };
     }
 

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -242,6 +242,15 @@ class Scratch3LooksBlocks {
         };
     }
 
+    getMonitored () {
+        return {
+            size: {isSpriteSpecific: true},
+            costumeorder: {isSpriteSpecific: true},
+            backdroporder: {},
+            backdropname: {}
+        };
+    }
+
     say (args, util) {
         // @TODO in 2.0 calling say/think resets the right/left bias of the bubble
         this._updateBubble(util.target, 'say', String(args.MESSAGE));

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -40,9 +40,9 @@ class Scratch3MotionBlocks {
 
     getMonitored () {
         return {
-            xposition: {isSpriteSpecific: true},
-            yposition: {isSpriteSpecific: true},
-            direction: {isSpriteSpecific: true}
+            motion_xposition: {isSpriteSpecific: true},
+            motion_yposition: {isSpriteSpecific: true},
+            motion_direction: {isSpriteSpecific: true}
         };
     }
 

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -38,6 +38,14 @@ class Scratch3MotionBlocks {
         };
     }
 
+    getMonitored () {
+        return {
+            xposition: {isSpriteSpecific: true},
+            yposition: {isSpriteSpecific: true},
+            direction: {isSpriteSpecific: true}
+        };
+    }
+
     moveSteps (args, util) {
         const steps = Cast.toNumber(args.STEPS);
         const radians = MathUtil.degToRad(90 - util.target.direction);

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -51,11 +51,11 @@ class Scratch3SensingBlocks {
 
     getMonitored () {
         return {
-            answer: {},
-            loudness: {},
-            timer: {},
-            of: {},
-            current: {}
+            sensing_answer: {},
+            sensing_loudness: {},
+            sensing_timer: {},
+            sensing_of: {},
+            sensing_current: {}
         };
     }
 

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -49,6 +49,16 @@ class Scratch3SensingBlocks {
         };
     }
 
+    getMonitored () {
+        return {
+            answer: {},
+            loudness: {},
+            timer: {},
+            of: {},
+            current: {}
+        };
+    }
+
     _onAnswer (answer) {
         this._answer = answer;
         const questionObj = this._questionList.shift();

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -103,6 +103,12 @@ class Scratch3SoundBlocks {
         };
     }
 
+    getMonitored () {
+        return {
+            volume: {}
+        };
+    }
+
     playSound (args, util) {
         const index = this._getSoundIndex(args.SOUND_MENU, util);
         if (index >= 0) {

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -105,7 +105,7 @@ class Scratch3SoundBlocks {
 
     getMonitored () {
         return {
-            volume: {}
+            sound_volume: {}
         };
     }
 

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -327,7 +327,11 @@ class Blocks {
             break;
         case 'checkbox':
             block.isMonitored = args.value;
-            block.targetId = args.isSpriteSpecific ? this._getTargetIdFromBlockId(block.id) : null;
+            if (optRuntime) {
+                const isSpriteSpecific = optRuntime.monitorBlockInfo.hasOwnProperty(block.opcode) &&
+                    optRuntime.monitorBlockInfo[block.opcode].isSpriteSpecific;
+                block.targetId = isSpriteSpecific ? optRuntime.getEditingTarget().id : null;
+            }
             if (optRuntime && wasMonitored && !block.isMonitored) {
                 optRuntime.requestRemoveMonitor(block.id);
             } else if (optRuntime && !wasMonitored && block.isMonitored) {
@@ -414,11 +418,6 @@ class Blocks {
                 runtime.addMonitorScript(blockId, targetId ? runtime.getTargetById(targetId) : null);
             }
         });
-    }
-
-    _getTargetIdFromBlockId (blockId) {
-        // First word of block ID. See makeToolboxXML in scratch-gui
-        return blockId.split('_')[0];
     }
 
     /**

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -334,6 +334,7 @@ class Blocks {
                 optRuntime.requestAddMonitor(MonitorRecord({
                     // @todo(vm#564) this will collide if multiple sprites use same block
                     id: block.id,
+                    targetId: block.targetId,
                     spriteName: block.targetId ? optRuntime.getTargetById(block.targetId).getName() : null,
                     opcode: block.opcode,
                     params: this._getBlockParams(block),

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -226,8 +226,7 @@ class Blocks {
                 id: e.blockId,
                 element: e.element,
                 name: e.name,
-                value: e.newValue,
-                isSpriteSpecific: e.isSpriteSpecific
+                value: e.newValue
             }, optRuntime);
             break;
         case 'move':

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -68,8 +68,10 @@ const handleReport = function (
                 sequencer.runtime.visualReport(currentBlockId, resolvedValue);
             }
             if (thread.updateMonitor) {
+                const targetId = sequencer.runtime.monitorBlocks.getBlock(currentBlockId).targetId;
                 sequencer.runtime.requestUpdateMonitor(Map({
                     id: currentBlockId,
+                    spriteName: targetId ? sequencer.runtime.getTargetById(targetId).getName() : null,
                     value: String(resolvedValue)
                 }));
             }

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -69,6 +69,10 @@ const handleReport = function (
             }
             if (thread.updateMonitor) {
                 const targetId = sequencer.runtime.monitorBlocks.getBlock(currentBlockId).targetId;
+                if (targetId && !sequencer.runtime.getTargetById(targetId)) {
+                    // Target no longer exists
+                    return;
+                }
                 sequencer.runtime.requestUpdateMonitor(Map({
                     id: currentBlockId,
                     spriteName: targetId ? sequencer.runtime.getTargetById(targetId).getName() : null,

--- a/src/engine/monitor-record.js
+++ b/src/engine/monitor-record.js
@@ -2,6 +2,8 @@ const {Record} = require('immutable');
 
 const MonitorRecord = Record({
     id: null,
+    /** Present only if the monitor is sprite-specific, such as x position */
+    spriteName: null,
     opcode: null,
     value: null,
     params: null

--- a/src/engine/monitor-record.js
+++ b/src/engine/monitor-record.js
@@ -4,6 +4,8 @@ const MonitorRecord = Record({
     id: null,
     /** Present only if the monitor is sprite-specific, such as x position */
     spriteName: null,
+    /** Present only if the monitor is sprite-specific, such as x position */
+    targetId: null,
     opcode: null,
     value: null,
     params: null

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -232,9 +232,6 @@ class Runtime extends EventEmitter {
         // Register all given block packages.
         this._registerBlockPackages();
 
-        // Populate monitorBlockInfo
-        this._registerMonitorInfo();
-
         // Register and initialize "IO devices", containers for processing
         // I/O related data.
         /** @type {Object.<string, Object>} */
@@ -407,6 +404,10 @@ class Runtime extends EventEmitter {
                         }
                     }
                 }
+                // Collect monitored from package.
+                if (packageObject.getMonitored) {
+                    this.monitorBlockInfo = Object.assign({}, this.monitorBlockInfo, packageObject.getMonitored());
+                }
             }
         }
     }
@@ -459,22 +460,6 @@ class Runtime extends EventEmitter {
         }
 
         this.emit(Runtime.EXTENSION_ADDED, categoryInfo.blocks.concat(categoryInfo.menus));
-    }
-
-    /**
-     * Populate this.monitorBlockInfo
-     */
-    _registerMonitorInfo () {
-        for (const packageName in defaultBlockPackages) {
-            if (defaultBlockPackages.hasOwnProperty(packageName)) {
-                // @todo pass a different runtime depending on package privilege?
-                const packageObject = new (defaultBlockPackages[packageName])(this);
-                // Collect monitored from package.
-                if (packageObject.getMonitored) {
-                    this.monitorBlockInfo = Object.assign({}, this.monitorBlockInfo, packageObject.getMonitored());
-                }
-            }
-        }
     }
 
     /**
@@ -864,7 +849,7 @@ class Runtime extends EventEmitter {
     /**
      * Enqueue a script that when finished will update the monitor for the block.
      * @param {!string} topBlockId ID of block that starts the script.
-     * @param {?string} optTarget target Target to run script on. If not supplied, uses editing target.
+     * @param {?Target} optTarget target Target to run script on. If not supplied, uses editing target.
      */
     addMonitorScript (topBlockId, optTarget) {
         if (!optTarget) optTarget = this._editingTarget;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1288,6 +1288,15 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Removes all monitors with the given target ID from the state. Does nothing if
+     * the monitor already does not exist in the state.
+     * @param {!string} targetId Remove all monitors with given target ID.
+     */
+    requestRemoveMonitorByTargetId (targetId) {
+        this._monitorState = this._monitorState.filterNot(value => value.targetId === targetId);
+    }
+
+    /**
      * Get a target by its id.
      * @param {string} targetId Id of target to find.
      * @return {?Target} The target, if found.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -177,6 +177,13 @@ class Runtime extends EventEmitter {
         this._refreshTargets = false;
 
         /**
+         * Map to look up all monitor block information by opcode.
+         * @type {object}
+         * @private
+         */
+        this.monitorBlockInfo = {};
+
+        /**
          * Ordered map of all monitors, which are MonitorReporter objects.
          */
         this._monitorState = OrderedMap({});
@@ -224,6 +231,9 @@ class Runtime extends EventEmitter {
 
         // Register all given block packages.
         this._registerBlockPackages();
+
+        // Populate monitorBlockInfo
+        this._registerMonitorInfo();
 
         // Register and initialize "IO devices", containers for processing
         // I/O related data.
@@ -449,6 +459,22 @@ class Runtime extends EventEmitter {
         }
 
         this.emit(Runtime.EXTENSION_ADDED, categoryInfo.blocks.concat(categoryInfo.menus));
+    }
+
+    /**
+     * Populate this.monitorBlockInfo
+     */
+    _registerMonitorInfo () {
+        for (const packageName in defaultBlockPackages) {
+            if (defaultBlockPackages.hasOwnProperty(packageName)) {
+                // @todo pass a different runtime depending on package privilege?
+                const packageObject = new (defaultBlockPackages[packageName])(this);
+                // Collect monitored from package.
+                if (packageObject.getMonitored) {
+                    this.monitorBlockInfo = Object.assign({}, this.monitorBlockInfo, packageObject.getMonitored());
+                }
+            }
+        }
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -838,7 +838,7 @@ class Runtime extends EventEmitter {
     /**
      * Enqueue a script that when finished will update the monitor for the block.
      * @param {!string} topBlockId ID of block that starts the script.
-     * @param {?string} optTarget target ID for target to run script on. If not supplied, uses editing target.
+     * @param {?string} optTarget target Target to run script on. If not supplied, uses editing target.
      */
     addMonitorScript (topBlockId, optTarget) {
         if (!optTarget) optTarget = this._editingTarget;
@@ -1260,7 +1260,7 @@ class Runtime extends EventEmitter {
      * @param {!MonitorRecord} monitor Monitor to add.
      */
     requestAddMonitor (monitor) {
-        this._monitorState = this._monitorState.set(monitor.id, monitor);
+        this._monitorState = this._monitorState.set(monitor.get('id'), monitor);
     }
 
     /**
@@ -1271,9 +1271,10 @@ class Runtime extends EventEmitter {
      *     the old monitor will keep its old value.
      */
     requestUpdateMonitor (monitor) {
-        if (this._monitorState.has(monitor.get('id'))) {
+        const id = monitor.get('id');
+        if (this._monitorState.has(id)) {
             this._monitorState =
-                this._monitorState.set(monitor.get('id'), this._monitorState.get(monitor.get('id')).merge(monitor));
+                this._monitorState.set(id, this._monitorState.get(id).merge(monitor));
         }
     }
 

--- a/src/util/uid.js
+++ b/src/util/uid.js
@@ -6,9 +6,10 @@
  * Legal characters for the unique ID.
  * Should be all on a US keyboard.  No XML special characters or control codes.
  * Removed $ due to issue 251.
+ * Removed _ which denotes word separation in XML.
  * @private
  */
-const soup_ = '!#%()*+,-./:;=?@[]^_`{|}~' +
+const soup_ = '!#%()*+,-./:;=?@[]^`{|}~' +
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 /**

--- a/src/util/uid.js
+++ b/src/util/uid.js
@@ -6,10 +6,9 @@
  * Legal characters for the unique ID.
  * Should be all on a US keyboard.  No XML special characters or control codes.
  * Removed $ due to issue 251.
- * Removed _ which denotes word separation in XML.
  * @private
  */
-const soup_ = '!#%()*+,-./:;=?@[]^`{|}~' +
+const soup_ = '!#%()*+,-./:;=?@[]^_`{|}~' +
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -484,6 +484,7 @@ class VirtualMachine extends EventEmitter {
             if (!sprite) {
                 throw new Error('No sprite associated with this target.');
             }
+            this.runtime.requestRemoveMonitorByTargetId(targetId);
             const currentEditingTarget = this.editingTarget;
             for (let i = 0; i < sprite.clones.length; i++) {
                 const clone = sprite.clones[i];
@@ -574,9 +575,44 @@ class VirtualMachine extends EventEmitter {
      * @param {!Blockly.Event} e Any Blockly event.
      */
     monitorBlockListener (e) {
+        const tempMonitoredBlocks = [
+            'volume',
+            'tempo',
+            'answer',
+            'loudness',
+            'videoon',
+            'timer',
+            'of',
+            'current',
+            'username',
+            'xposition',
+            'yposition',
+            'direction',
+            'size',
+            'backdropname',
+            'costumeorder',
+            'backdroporder'
+        ];
+        const tempMonitoredPerSpriteBlocks = [
+            'xposition',
+            'yposition',
+            'direction',
+            'size',
+            'costumeorder'
+        ];
         // Filter events by type, since monitor blocks only need to listen to these events.
         // Monitor blocks shouldn't be destroyed when flyout blocks are deleted.
         if (['create', 'change'].indexOf(e.type) !== -1) {
+            // TEMPORARY ----
+            let blockType = e.blockId.split('_');
+            blockType = blockType[blockType.length - 1];
+            if (tempMonitoredBlocks.indexOf(blockType) === -1) {
+                return;
+            }
+            if (tempMonitoredPerSpriteBlocks.indexOf(blockType) !== -1) {
+                e.isSpriteSpecific = true;
+            }
+            // -----
             this.runtime.monitorBlocks.blocklyListen(e, this.runtime);
         }
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -578,15 +578,6 @@ class VirtualMachine extends EventEmitter {
         // Filter events by type, since monitor blocks only need to listen to these events.
         // Monitor blocks shouldn't be destroyed when flyout blocks are deleted.
         if (['create', 'change'].indexOf(e.type) !== -1) {
-            let blockType = e.blockId.split('_');
-            blockType = blockType[blockType.length - 1];
-            if (!this.runtime.monitorBlockInfo.hasOwnProperty(blockType)) {
-                return;
-            }
-            if (!this.runtime.monitorBlockInfo.hasOwnProperty(blockType) ||
-                this.runtime.monitorBlockInfo[blockType].isSpriteSpecific) {
-                e.isSpriteSpecific = true;
-            }
             this.runtime.monitorBlocks.blocklyListen(e, this.runtime);
         }
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -575,44 +575,18 @@ class VirtualMachine extends EventEmitter {
      * @param {!Blockly.Event} e Any Blockly event.
      */
     monitorBlockListener (e) {
-        const tempMonitoredBlocks = [
-            'volume',
-            'tempo',
-            'answer',
-            'loudness',
-            'videoon',
-            'timer',
-            'of',
-            'current',
-            'username',
-            'xposition',
-            'yposition',
-            'direction',
-            'size',
-            'backdropname',
-            'costumeorder',
-            'backdroporder'
-        ];
-        const tempMonitoredPerSpriteBlocks = [
-            'xposition',
-            'yposition',
-            'direction',
-            'size',
-            'costumeorder'
-        ];
         // Filter events by type, since monitor blocks only need to listen to these events.
         // Monitor blocks shouldn't be destroyed when flyout blocks are deleted.
         if (['create', 'change'].indexOf(e.type) !== -1) {
-            // TEMPORARY ----
             let blockType = e.blockId.split('_');
             blockType = blockType[blockType.length - 1];
-            if (tempMonitoredBlocks.indexOf(blockType) === -1) {
+            if (!this.runtime.monitorBlockInfo.hasOwnProperty(blockType)) {
                 return;
             }
-            if (tempMonitoredPerSpriteBlocks.indexOf(blockType) !== -1) {
+            if (!this.runtime.monitorBlockInfo.hasOwnProperty(blockType) ||
+                this.runtime.monitorBlockInfo[blockType].isSpriteSpecific) {
                 e.isSpriteSpecific = true;
             }
-            // -----
             this.runtime.monitorBlocks.blocklyListen(e, this.runtime);
         }
     }


### PR DESCRIPTION
Working towards https://github.com/LLK/scratch-vm/issues/564

- Move data about whether a block is a monitor/sprite specific into src/blocks files
- Use that information to pass targetId and spriteName into monitors that are sprite-specific
- Also stop adding non-monitors to runtime.monitorBlocks, which would accumulate infinite blocks before