### PR TITLE
Only uglify if building for production.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 env:
   - NPM_SCRIPT="tap:unit -- --jobs=4"
   - NPM_SCRIPT="tap:integration -- --jobs=4"
+  - NODE_ENV=production
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ cache:
   directories:
   - node_modules
 install:
-- npm install
-- npm update
+- npm --production=false install
+- npm --production=false update
 script: npm run $NPM_SCRIPT
 jobs:
     include:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,12 +20,12 @@ const base = {
             }
         }]
     },
-    plugins: [
+    plugins: process.env.NODE_ENV === 'production' ? [
         new webpack.optimize.UglifyJsPlugin({
             include: /\.min\.js$/,
             minimize: true
         })
-    ]
+    ] : []
 };
 
 module.exports = [


### PR DESCRIPTION
Uglify was trying to run always, including the dev-server output, which
included es6 that broke uglifier.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/774

### Proposed Changes

_Describe what this Pull Request does_

Only uglify things when run in production environment. 

### Reason for Changes

_Explain why these changes should be made_

It was not possible to use the playground from a fresh install.

### Test Coverage

_Please show how you have added tests to cover your changes_

Ran the npm run start from clean install, no errors. 

---

The same problem exists on render, i'll update that repo with the same fix.