### PR TITLE
Select target after drag end

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -36,6 +36,13 @@ class VirtualMachine extends EventEmitter {
          * @type {Target}
          */
         this.editingTarget = null;
+
+        /**
+         * The currently dragging target, for redirecting IO data.
+         * @type {Target}
+         */
+        this._dragTarget = null;
+
         // Runtime emits are passed along as VM emits.
         this.runtime.on(Runtime.SCRIPT_GLOW_ON, glowData => {
             this.emit(Runtime.SCRIPT_GLOW_ON, glowData);
@@ -692,8 +699,8 @@ class VirtualMachine extends EventEmitter {
     startDrag (targetId) {
         const target = this.runtime.getTargetById(targetId);
         if (target) {
+            this._dragTarget = target;
             target.startDrag();
-            this.setEditingTarget(target.id);
         }
     }
 
@@ -703,15 +710,23 @@ class VirtualMachine extends EventEmitter {
      */
     stopDrag (targetId) {
         const target = this.runtime.getTargetById(targetId);
-        if (target) target.stopDrag();
+        if (target) {
+            this._dragTarget = null;
+            target.stopDrag();
+            this.setEditingTarget(target.id);
+        }
     }
 
     /**
-     * Post/edit sprite info for the current editing target.
+     * Post/edit sprite info for the current editing target or the drag target.
      * @param {object} data An object with sprite info data to set.
      */
     postSpriteInfo (data) {
-        this.editingTarget.postSpriteInfo(data);
+        if (this._dragTarget) {
+            this._dragTarget.postSpriteInfo(data);
+        } else {
+            this.editingTarget.postSpriteInfo(data);
+        }
     }
 }
 


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_

Change the way drags are handled by the VM in order to delay selecting the editing target until after the drag has finished. This is the behavior in scratch 2, and it also improves perceived performance by delaying the blocks reload (and other editing target updates) until after dragging. 

### Reason for Changes

_Explain why these changes should be made_

It is really annoying to have the whole UI feel like it freezes when I drag a sprite. This was a rage-driven feature.

Scratch 2 behavior
![select-after-drag--s2](https://user-images.githubusercontent.com/654102/33085304-56a05f9e-ceb2-11e7-9501-4cb6b5d36918.gif)

Scratch 3 behavior on develop
![select-after-drag--s3-develop](https://user-images.githubusercontent.com/654102/33085309-5b79ef80-ceb2-11e7-981a-457b9f4097dd.gif)

Scratch 3 after this PR 
![select-after-drag--s3-fixed](https://user-images.githubusercontent.com/654102/33085322-646f9e6e-ceb2-11e7-800e-cc97b2fc0ff8.gif)

### Test Coverage

_Please show how you have added tests to cover your changes_

Added tests for start/stop drag behavior. 