### PR TITLE
Fix ask-and-wait in stage

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -63,9 +63,9 @@ class Scratch3SensingBlocks {
         this._answer = answer;
         const questionObj = this._questionList.shift();
         if (questionObj) {
-            const [_question, resolve, target, wasVisible] = questionObj;
-            // If the target was visible when asked, hide the say bubble.
-            if (wasVisible) {
+            const [_question, resolve, target, wasVisible, wasStage] = questionObj;
+            // If the target was visible when asked, hide the say bubble unless the target was the stage.
+            if (wasVisible && !wasStage) {
                 this.runtime.emit('SAY', target, 'say', '');
             }
             resolve();
@@ -73,16 +73,16 @@ class Scratch3SensingBlocks {
         }
     }
 
-    _enqueueAsk (question, resolve, target, wasVisible) {
-        this._questionList.push([question, resolve, target, wasVisible]);
+    _enqueueAsk (question, resolve, target, wasVisible, wasStage) {
+        this._questionList.push([question, resolve, target, wasVisible, wasStage]);
     }
 
     _askNextQuestion () {
         if (this._questionList.length > 0) {
-            const [question, _resolve, target, wasVisible] = this._questionList[0];
+            const [question, _resolve, target, wasVisible, wasStage] = this._questionList[0];
             // If the target is visible, emit a blank question and use the
-            // say event to trigger a bubble.
-            if (wasVisible) {
+            // say event to trigger a bubble unless the target was the stage.
+            if (wasVisible && !wasStage) {
                 this.runtime.emit('SAY', target, 'say', question);
                 this.runtime.emit('QUESTION', '');
             } else {
@@ -100,7 +100,7 @@ class Scratch3SensingBlocks {
         const _target = util.target;
         return new Promise(resolve => {
             const isQuestionAsked = this._questionList.length > 0;
-            this._enqueueAsk(args.QUESTION, resolve, _target, _target.visible);
+            this._enqueueAsk(args.QUESTION, resolve, _target, _target.visible, _target.isStage);
             if (!isQuestionAsked) {
                 this._askNextQuestion();
             }


### PR DESCRIPTION
### Resolves

[Issue #816](https://github.com/LLK/scratch-vm/issues/816)

### Proposed Changes

When an ask-and-wait is executed in the Stage, the question text appears next to the input instead of in a speech bubble.

![image](https://user-images.githubusercontent.com/29558846/33232842-14940354-d1db-11e7-93c0-6cb715223fde.png)

### Reason for Changes

Scratch 2 does the same thing.

### Test Coverage

None.