### PR TITLE
Convert music extension menu values to string

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -103,7 +103,7 @@ class Scratch3MusicBlocks {
         return info.map((entry, index) => {
             const obj = {};
             obj.text = entry.name;
-            obj.value = index + 1;
+            obj.value = String(index + 1);
             return obj;
         });
     }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/819

### Proposed Changes

Convert the value field of the menu items in the music extension to strings.

### Reason for Changes

Menus on blocks optionally consist of an array of objects with text and value fields. It turns out that for scratch-blocks to behave correctly, the values cannot be numbers- they must be strings. 