### PR TITLE
Add browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "git+ssh://git@github.com/LLK/scratch-vm.git"
   },
   "main": "./dist/node/scratch-vm.js",
+  "browser": "./dist/web/scratch-vm.js",
   "scripts": {
     "build": "webpack --progress --colors --bail",
     "coverage": "tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,10 @@ const base = {
         port: process.env.PORT || 8073
     },
     devtool: 'cheap-module-source-map',
+    output: {
+        library: 'VirtualMachine',
+        filename: '[name].js'
+    },
     module: {
         rules: [{
             test: /\.js$/,
@@ -37,8 +41,8 @@ module.exports = [
             'scratch-vm.min': './src/index.js'
         },
         output: {
-            path: path.resolve(__dirname, 'dist/web'),
-            filename: '[name].js'
+            libraryTarget: 'umd',
+            path: path.resolve('dist', 'web')
         },
         module: {
             rules: base.module.rules.concat([
@@ -56,10 +60,8 @@ module.exports = [
             'scratch-vm': './src/index.js'
         },
         output: {
-            library: 'VirtualMachine',
             libraryTarget: 'commonjs2',
-            path: path.resolve(__dirname, 'dist/node'),
-            filename: '[name].js'
+            path: path.resolve('dist', 'node')
         },
         plugins: base.plugins.concat([
             new CopyWebpackPlugin([{
@@ -87,8 +89,8 @@ module.exports = [
             ]
         },
         output: {
-            path: path.resolve(__dirname, 'playground'),
-            filename: '[name].js'
+            libraryTarget: 'umd',
+            path: path.resolve('playground')
         },
         module: {
             rules: base.module.rules.concat([


### PR DESCRIPTION
### Resolves

This change resolves build errors exposed by #805.

Thanks, @ericrosenbaum, for bringing the issue to my attention!

### Proposed Changes

This PR contains two functional changes:
- Add a `"browser"` field to `package.json`, pointing to the web build output, and
- Use UMD for the web and playground build outputs.

This is similar to LLK/scratch-storage#20 which has been working well in that repository.

### Reason for Changes

The `"browser"` field fixes the build issues affecting both Travis and local builds since #805 was merged. The UMD change is just a matter of flexibility for other developers and a step toward converging on a standard build config for our webpack-built repositories.

### Test Coverage

On my local machine I tested the playground and building `scratch-gui` against this. We don't currently have a way to automatically test a `scratch-vm` change in the context of a `scratch-gui` build.