### PR TITLE
Clones get a reference to parent’s audioPlayer

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -137,7 +137,11 @@ class RenderedTarget extends Target {
         */
         this.audioPlayer = null;
         if (this.runtime && this.runtime.audioEngine) {
-            this.audioPlayer = this.runtime.audioEngine.createPlayer();
+            if (this.isOriginal) {
+                this.audioPlayer = this.runtime.audioEngine.createPlayer();
+            } else {
+                this.audioPlayer = this.sprite.clones[0].audioPlayer;
+            }
         }
     }
 


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-audio/issues/51

### Proposed Changes

Clones no longer get their own audioPlayer instance. Instead, each clone gets a reference to its parent sprite's audioPlayer.

Note that I'm not certain that I'm accessing the parent in a 'good' way, though it works (`this.sprite.clones[0]`).

### Reason for Changes

In projects that created lots of clones, the audio was dropping out completely. This change prevents that problem. 

For example, this project plays an audio loop continuously while creating clones. On develop currently, the audio crackles and then drops out after 15 or 20 seconds:

https://llk.github.io/scratch-gui/develop/#189096081

After this change, the audio loop can play indefinitely.   

### Test Coverage

We don't currently have a way to test audio performance.