### PR TITLE
Check for instrument sample before playing

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -602,6 +602,10 @@ class Scratch3MusicBlocks {
         const sampleArray = instrumentInfo.samples;
         const sampleIndex = this._selectSampleIndexForNote(note, sampleArray);
 
+        // If the audio sample has not loaded yet, bail out
+        if (typeof this._instrumentBufferArrays[inst] === 'undefined') return;
+        if (typeof this._instrumentBufferArrays[inst][sampleIndex] === 'undefined') return;
+
         // Create the audio buffer to play the note, and set its pitch
         const context = util.runtime.audioEngine.audioContext;
         const bufferSource = context.createBufferSource();


### PR DESCRIPTION
### Proposed Changes

In the music extension, check for the presence of an audio sample before trying to use it to play a note.

### Reason for Changes

Because the samples load asynchronously, it's possible to load a project with the music extension and try to play a note before the samples have finished downloading and decoding. This change prevents an error in that case. 