### PR TITLE
Updates for editable custom procedures

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
     "copy-webpack-plugin": "4.2.1",
+    "decode-html": "2.0.0",
     "escape-html": "1.0.3",
     "eslint": "^4.5.0",
     "eslint-config-scratch": "^5.0.0",

--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -27,7 +27,7 @@ class Scratch3ProcedureBlocks {
     call (args, util) {
         if (!util.stackFrame.executed) {
             const procedureCode = args.mutation.proccode;
-            const paramNames = util.getProcedureParamNames(procedureCode);
+            const [paramNames, paramIds] = util.getProcedureParamNamesAndIds(procedureCode);
 
             // If null, procedure could not be found, which can happen if custom
             // block is dragged between sprites without the definition.
@@ -36,9 +36,9 @@ class Scratch3ProcedureBlocks {
                 return;
             }
 
-            for (let i = 0; i < paramNames.length; i++) {
-                if (args.hasOwnProperty(`input${i}`)) {
-                    util.pushParam(paramNames[i], args[`input${i}`]);
+            for (let i = 0; i < paramIds.length; i++) {
+                if (args.hasOwnProperty(paramIds[i])) {
+                    util.pushParam(paramNames[i], args[paramIds[i]]);
                 }
             }
 

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -97,8 +97,8 @@ class BlockUtility {
      * @param {string} procedureCode Procedure code for procedure to query.
      * @return {Array.<string>} List of param names for a procedure.
      */
-    getProcedureParamNames (procedureCode) {
-        return this.thread.target.blocks.getProcedureParamNames(procedureCode);
+    getProcedureParamNamesAndIds (procedureCode) {
+        return this.thread.target.blocks.getProcedureParamNamesAndIds(procedureCode);
     }
 
     /**

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -206,7 +206,7 @@ class Blocks {
      * @param {?string} name Name of procedure to query.
      * @return {?Array.<string>} List of param names for a procedure.
      */
-    getProcedureParamNames (name) {
+    getProcedureParamNamesAndIds (name) {
         const cachedNames = this._cache.procedureParamNames[name];
         if (typeof cachedNames !== 'undefined') {
             return cachedNames;
@@ -217,9 +217,10 @@ class Blocks {
             const block = this._blocks[id];
             if (block.opcode === 'procedures_prototype' &&
                 block.mutation.proccode === name) {
-                const paramNames = JSON.parse(block.mutation.argumentnames);
-                this._cache.procedureParamNames[name] = paramNames;
-                return paramNames;
+                const names = JSON.parse(block.mutation.argumentnames);
+                const ids = JSON.parse(block.mutation.argumentids);
+                this._cache.procedureParamNames[name] = [names, ids];
+                return this._cache.procedureParamNames[name];
             }
         }
 

--- a/src/engine/mutation-adapter.js
+++ b/src/engine/mutation-adapter.js
@@ -1,4 +1,5 @@
 const html = require('htmlparser2');
+const decodeHtml = require('decode-html');
 
 /**
  * Convert a part of a mutation DOM to a mutation VM object, recursively.
@@ -11,7 +12,7 @@ const mutatorTagToObject = function (dom) {
     obj.children = [];
     for (const prop in dom.attribs) {
         if (prop === 'xmlns') continue;
-        obj[prop] = dom.attribs[prop];
+        obj[prop] = decodeHtml(dom.attribs[prop]);
     }
     for (let i = 0; i < dom.children.length; i++) {
         obj.children.push(

--- a/test/unit/blocks_procedures.js
+++ b/test/unit/blocks_procedures.js
@@ -16,7 +16,7 @@ test('calling a custom block with no definition does not throw', t => {
         }
     };
     const util = {
-        getProcedureParamNames: () => null,
+        getProcedureParamNamesAndIds: () => null,
         stackFrame: {
             executed: false
         }

--- a/test/unit/blocks_procedures.js
+++ b/test/unit/blocks_procedures.js
@@ -16,7 +16,7 @@ test('calling a custom block with no definition does not throw', t => {
         }
     };
     const util = {
-        getProcedureParamNamesAndIds: () => null,
+        getProcedureParamNamesAndIds: () => [null, null],
         stackFrame: {
             executed: false
         }


### PR DESCRIPTION
Fixes a few minor issues that came up once custom procedures became editable.

- need to unescape the mutations which hold JSON, because they are getting escaped when the mutations are updated in scratch-blocks.
- need to use the `argumentids` feature introduced into scratch-blocks to connect the name of the input field with the value of the input. These used to be static and positional, now they have real unique ids.

Updated the test that failed after implementing these minor fixes.