### PR TITLE
Move pen and wedo into extensions folder

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -6,8 +6,8 @@ const BlockType = require('./block-type');
 // These extensions are currently built into the VM repository but should not be loaded at startup.
 // TODO: move these out into a separate repository?
 // TODO: change extension spec so that library info, including extension ID, can be collected through static methods
-const Scratch3PenBlocks = require('../blocks/scratch3_pen');
-const Scratch3WeDo2Blocks = require('../blocks/scratch3_wedo2');
+const Scratch3PenBlocks = require('../extensions/scratch3_pen');
+const Scratch3WeDo2Blocks = require('../extensions/scratch3_wedo2');
 const Scratch3MusicBlocks = require('../extensions/scratch3_music');
 const builtinExtensions = {
     pen: Scratch3PenBlocks,

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -1,11 +1,11 @@
-const ArgumentType = require('../extension-support/argument-type');
-const BlockType = require('../extension-support/block-type');
-const Cast = require('../util/cast');
-const Clone = require('../util/clone');
-const Color = require('../util/color');
-const MathUtil = require('../util/math-util');
-const RenderedTarget = require('../sprites/rendered-target');
-const log = require('../util/log');
+const ArgumentType = require('../../extension-support/argument-type');
+const BlockType = require('../../extension-support/block-type');
+const Cast = require('../../util/cast');
+const Clone = require('../../util/clone');
+const Color = require('../../util/color');
+const MathUtil = require('../../util/math-util');
+const RenderedTarget = require('../../sprites/rendered-target');
+const log = require('../../util/log');
 
 /**
  * Icon svg to be displayed at the left edge of each extension block, encoded as a data URI.

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1,7 +1,7 @@
-const ArgumentType = require('../extension-support/argument-type');
-const BlockType = require('../extension-support/block-type');
-const color = require('../util/color');
-const log = require('../util/log');
+const ArgumentType = require('../../extension-support/argument-type');
+const BlockType = require('../../extension-support/block-type');
+const color = require('../../util/color');
+const log = require('../../util/log');
 
 /**
  * Icon svg to be displayed at the left edge of each extension block, encoded as a data URI.

--- a/test/integration/pen.js
+++ b/test/integration/pen.js
@@ -2,7 +2,7 @@ const Worker = require('tiny-worker');
 const path = require('path');
 const test = require('tap').test;
 
-const Scratch3PenBlocks = require('../../src/blocks/scratch3_pen');
+const Scratch3PenBlocks = require('../../src/extensions/scratch3_pen/index.js');
 const VirtualMachine = require('../../src/index');
 const dispatch = require('../../src/dispatch/central-dispatch');
 


### PR DESCRIPTION
### Proposed Changes

We created an extensions folder when we set up the music extension- this is just moving the other internal extensions (currently pen and wedo) into that folder.