### PR TITLE
Clear answer on green flag

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -21,6 +21,7 @@ class Scratch3SensingBlocks {
         this._questionList = [];
 
         this.runtime.on('ANSWER', this._onAnswer.bind(this));
+        this.runtime.on('PROJECT_START', this._resetAnswer.bind(this));
         this.runtime.on('PROJECT_STOP_ALL', this._clearAllQuestions.bind(this));
     }
 
@@ -71,6 +72,10 @@ class Scratch3SensingBlocks {
             resolve();
             this._askNextQuestion();
         }
+    }
+
+    _resetAnswer () {
+        this._answer = '';
     }
 
     _enqueueAsk (question, resolve, target, wasVisible, wasStage) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -318,6 +318,15 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name when the project is started (threads may not necessarily be
+     * running).
+     * @const {string}
+     */
+    static get PROJECT_START () {
+        return 'PROJECT_START';
+    }
+
+    /**
      * Event name when threads start running.
      * Used by the UI to indicate running status.
      * @const {string}
@@ -1057,6 +1066,7 @@ class Runtime extends EventEmitter {
      */
     greenFlag () {
         this.stopAll();
+        this.emit(Runtime.PROJECT_START);
         this.ioDevices.clock.resetProjectTimer();
         this.clearEdgeActivatedValues();
         // Inform all targets of the green flag.


### PR DESCRIPTION
### Resolves

[Issue #795](https://github.com/LLK/scratch-vm/issues/795)

### Proposed Changes

The contents of the "answer" block are cleared when the green flag is clicked.

### Reason for Changes

Consistency with Scratch 2.

### Test Coverage

None.
