### PR TITLE
Go to front in stage does nothing

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -410,7 +410,9 @@ class Scratch3LooksBlocks {
     }
 
     goToFront (args, util) {
-        util.target.goToFront();
+        if (!util.target.isStage) {
+            util.target.goToFront();
+        }
     }
 
     goBackLayers (args, util) {


### PR DESCRIPTION
### Resolves

[Issue #839](https://github.com/LLK/scratch-vm/issues/839)

### Proposed Changes

Go-to-front blocks do nothing if they are executed on the stage.

### Reason for Changes

The current behavior (the stage goes to the front, covering all the sprites) is confusing to beginners. In addition, this change is consistent with Scratch 2.

### Test Coverage

None.