### PR TITLE
Do not return "null" when cannot find argument param.

### DIFF
--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -15,8 +15,8 @@ class Scratch3ProcedureBlocks {
         return {
             procedures_definition: this.definition,
             procedures_call: this.call,
-            argument_reporter_string_number: this.param,
-            argument_reporter_boolean: this.param
+            argument_reporter_string_number: this.argumentReporterStringNumber,
+            argument_reporter_boolean: this.argumentReporterBoolean
         };
     }
 
@@ -47,8 +47,19 @@ class Scratch3ProcedureBlocks {
         }
     }
 
-    param (args, util) {
+    argumentReporterStringNumber (args, util) {
         const value = util.getParam(args.VALUE);
+        if (value === null) {
+            return '';
+        }
+        return value;
+    }
+
+    argumentReporterBoolean (args, util) {
+        const value = util.getParam(args.VALUE);
+        if (value === null) {
+            return false;
+        }
         return value;
     }
 }

--- a/test/unit/engine_thread.js
+++ b/test/unit/engine_thread.js
@@ -110,7 +110,9 @@ test('PushGetParam', t => {
     th.pushParam('testParam', 'testValue');
     t.strictEquals(th.peekStackFrame().params.testParam, 'testValue');
     t.strictEquals(th.getParam('testParam'), 'testValue');
-    
+    // Params outside of define stack always evaluate to null
+    t.strictEquals(th.getParam('nonExistentParam'), null);
+
     t.end();
 });
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/699

### Proposed Changes

_Describe what this Pull Request does_

Returns default falsey values for argument reporters that are either unused (like empty boolean slot) or used outside of the define context. 

### Reason for Changes

_Explain why these changes should be made_

I changed my mind on whether these should all return 0, because i realized it was very simple, makes the behavior more clear and seems to have an extremely low chance of impacting scratch 2 projects (it would require a project that depends on a boolean/string argument reporter reporting exactly "0" outside of a define stack...)

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a test to execute_thread
