### PR TITLE
Fix tertiary color of extension blocks

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -602,7 +602,7 @@ class Runtime extends EventEmitter {
             category: categoryInfo.name,
             colour: categoryInfo.color1,
             colourSecondary: categoryInfo.color2,
-            colorTertiary: categoryInfo.color3,
+            colourTertiary: categoryInfo.color3,
             args0: []
         };
 


### PR DESCRIPTION
### Proposed Changes

Fix a typo (colorTertiary should be colourTertiary) that was preventing the correct loading of the tertiary color for extension blocks.

### Reason for Changes

Matching the color spec from https://github.com/LLK/scratch-blocks/issues/523