### PR TITLE
Parse the `warp` property from the mutation instead of using directly.

### DIFF
--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -316,7 +316,7 @@ class Sequencer {
             const definitionBlock = thread.target.blocks.getBlock(definition);
             const innerBlock = thread.target.blocks.getBlock(
                 definitionBlock.inputs.custom_block.block);
-            const doWarp = innerBlock.mutation.warp;
+            const doWarp = JSON.parse(innerBlock.mutation.warp);
             if (doWarp) {
                 thread.peekStackFrame().warpMode = true;
             } else if (isRecursive) {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -316,7 +316,15 @@ class Sequencer {
             const definitionBlock = thread.target.blocks.getBlock(definition);
             const innerBlock = thread.target.blocks.getBlock(
                 definitionBlock.inputs.custom_block.block);
-            const doWarp = JSON.parse(innerBlock.mutation.warp);
+            let doWarp = false;
+            if (innerBlock && innerBlock.mutation) {
+                const warp = innerBlock.mutation.warp;
+                if (typeof warp === 'boolean') {
+                    doWarp = warp;
+                } else if (typeof warp === 'string') {
+                    doWarp = JSON.parse(warp);
+                }
+            }
             if (doWarp) {
                 thread.peekStackFrame().warpMode = true;
             } else if (isRecursive) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/858

### Proposed Changes

_Describe what this Pull Request does_

Parse the `warp` property from the mutation instead of using directly.

### Reason for Changes

_Explain why these changes should be made_

Note the way we are always parsing from json the things on the mutator in other places. This fixes the way it seemed like custom procedures were always created with "run without screen refresh". They were not actually just string/boolean truthiness problem.
