### PR TITLE
Broadcast Inputs and Implicit Message Deletion

### DIFF
--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -55,9 +55,27 @@ class Scratch3EventBlocks {
         return false;
     }
 
+    /**
+     * Helper function to process broadcast block input (whether it's
+     * input from the dropdown menu or from a plugged in input block)
+     * @param {object} args The given arguments for the broadcast blocks
+     * @param {object} util The utility associated with this block.
+     * @return {?Variable} The broadcast message variable that matches
+     *  the provided input.
+     */
+    processBroadcastInput_ (args, util) {
+        let broadcastInput;
+        if (args.BROADCAST_OPTION) {
+            broadcastInput = util.runtime.getTargetForStage().lookupBroadcastMsg(
+                args.BROADCAST_OPTION.id, args.BROADCAST_OPTION.name);
+        } else {
+            broadcastInput = util.runtime.getTargetForStage().lookupBroadcastByInputValue(args.BROADCAST_INPUT.name);
+        }
+        return broadcastInput;
+    }
+
     broadcast (args, util) {
-        const broadcastVar = util.runtime.getTargetForStage().lookupBroadcastMsg(
-            args.BROADCAST_OPTION.id, args.BROADCAST_OPTION.name);
+        const broadcastVar = this.processBroadcastInput_(args, util);
         if (broadcastVar) {
             const broadcastOption = broadcastVar.name;
             util.startHats('event_whenbroadcastreceived', {
@@ -67,8 +85,7 @@ class Scratch3EventBlocks {
     }
 
     broadcastAndWait (args, util) {
-        const broadcastVar = util.runtime.getTargetForStage().lookupBroadcastMsg(
-            args.BROADCAST_OPTION.id, args.BROADCAST_OPTION.name);
+        const broadcastVar = this.processBroadcastInput_(args, util);
         if (broadcastVar) {
             const broadcastOption = broadcastVar.name;
             // Have we run before, starting threads?

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -55,27 +55,9 @@ class Scratch3EventBlocks {
         return false;
     }
 
-    /**
-     * Helper function to process broadcast block input (whether it's
-     * input from the dropdown menu or from a plugged in input block)
-     * @param {object} args The given arguments for the broadcast blocks
-     * @param {object} util The utility associated with this block.
-     * @return {?Variable} The broadcast message variable that matches
-     *  the provided input.
-     */
-    processBroadcastInput_ (args, util) {
-        let broadcastInput;
-        if (args.BROADCAST_OPTION) {
-            broadcastInput = util.runtime.getTargetForStage().lookupBroadcastMsg(
-                args.BROADCAST_OPTION.id, args.BROADCAST_OPTION.name);
-        } else {
-            broadcastInput = util.runtime.getTargetForStage().lookupBroadcastByInputValue(args.BROADCAST_INPUT.name);
-        }
-        return broadcastInput;
-    }
-
     broadcast (args, util) {
-        const broadcastVar = this.processBroadcastInput_(args, util);
+        const broadcastVar = util.runtime.getTargetForStage().lookupBroadcastMsg(
+            args.BROADCAST_OPTION.id, args.BROADCAST_OPTION.name);
         if (broadcastVar) {
             const broadcastOption = broadcastVar.name;
             util.startHats('event_whenbroadcastreceived', {
@@ -85,7 +67,8 @@ class Scratch3EventBlocks {
     }
 
     broadcastAndWait (args, util) {
-        const broadcastVar = this.processBroadcastInput_(args, util);
+        const broadcastVar = util.runtime.getTargetForStage().lookupBroadcastMsg(
+            args.BROADCAST_OPTION.id, args.BROADCAST_OPTION.name);
         if (broadcastVar) {
             const broadcastOption = broadcastVar.name;
             // Have we run before, starting threads?

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -217,9 +217,6 @@ const execute = function (sequencer, thread) {
             const broadcastInput = inputs[inputName];
             // Check if something is plugged into the broadcast block, or
             // if the shadow dropdown menu is being used.
-            // Differentiate between these two cases by giving argValues
-            // a 'BROADCAST_INPUT' field or a 'BROADCAST_OPTION' field
-            // respectively.
             if (broadcastInput.block === broadcastInput.shadow) {
                 // Shadow dropdown menu is being used.
                 // Get the appropriate information out of it.
@@ -232,7 +229,7 @@ const execute = function (sequencer, thread) {
             } else {
                 // Something is plugged into the broadcast input.
                 // Cast it to a string. We don't need an id here.
-                argValues.BROADCAST_INPUT = {
+                argValues.BROADCAST_OPTION = {
                     name: cast.toString(inputValue)
                 };
             }

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -2,6 +2,7 @@ const BlockUtility = require('./block-utility');
 const log = require('../util/log');
 const Thread = require('./thread');
 const {Map} = require('immutable');
+const cast = require('../util/cast');
 
 /**
  * Single BlockUtility instance reused by execute for every pritimive ran.
@@ -211,7 +212,33 @@ const execute = function (sequencer, thread) {
             currentStackFrame.waitingReporter = null;
             thread.popStack();
         }
-        argValues[inputName] = currentStackFrame.reported[inputName];
+        const inputValue = currentStackFrame.reported[inputName];
+        if (inputName === 'BROADCAST_INPUT') {
+            const broadcastInput = inputs[inputName];
+            // Check if something is plugged into the broadcast block, or
+            // if the shadow dropdown menu is being used.
+            // Differentiate between these two cases by giving argValues
+            // a 'BROADCAST_INPUT' field or a 'BROADCAST_OPTION' field
+            // respectively.
+            if (broadcastInput.block === broadcastInput.shadow) {
+                // Shadow dropdown menu is being used.
+                // Get the appropriate information out of it.
+                const shadow = blockContainer.getBlock(broadcastInput.shadow);
+                const broadcastField = shadow.fields.BROADCAST_OPTION;
+                argValues.BROADCAST_OPTION = {
+                    id: broadcastField.id,
+                    name: broadcastField.value
+                };
+            } else {
+                // Something is plugged into the broadcast input.
+                // Cast it to a string. We don't need an id here.
+                argValues.BROADCAST_INPUT = {
+                    name: cast.toString(inputValue)
+                };
+            }
+        } else {
+            argValues[inputName] = inputValue;
+        }
     }
 
     // Add any mutation to args (e.g., for procedures).

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -116,6 +116,23 @@ class Target extends EventEmitter {
     }
 
     /**
+     * Look up a broadcast message with the given name and return the variable
+     * if it exists. Does not create a new broadcast message variable if
+     * it doesn't exist.
+     * @param {string} name Name of the variable.
+     * @return {?Variable} Variable object.
+     */
+    lookupBroadcastByInputValue (name) {
+        const vars = this.variables;
+        for (const propName in vars) {
+            if ((vars[propName].type === Variable.BROADCAST_MESSAGE_TYPE) &&
+                (vars[propName].name.toLowerCase() === name.toLowerCase())) {
+                return vars[propName];
+            }
+        }
+    }
+
+    /**
      * Look up a variable object.
      * Search begins for local variables; then look for globals.
      * @param {string} id Id of the variable.
@@ -141,7 +158,7 @@ class Target extends EventEmitter {
     * Search begins for local lists; then look for globals.
     * @param {!string} id Id of the list.
     * @param {!string} name Name of the list.
-    * @return {!List} List object.
+    * @return {!Varible} Variable object representing the found/created list.
      */
     lookupOrCreateList (id, name) {
         const list = this.lookupVariableById(id);

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -98,12 +98,19 @@ class Target extends EventEmitter {
      * if it exists.
      * @param {string} id Id of the variable.
      * @param {string} name Name of the variable.
-     * @return {!Variable} Variable object.
+     * @return {?Variable} Variable object.
      */
     lookupBroadcastMsg (id, name) {
-        const broadcastMsg = this.lookupVariableById(id);
+        let broadcastMsg;
+        if (id) {
+            broadcastMsg = this.lookupVariableById(id);
+        } else if (name) {
+            broadcastMsg = this.lookupBroadcastByInputValue(name);
+        } else {
+            log.error('Cannot find broadcast message if neither id nor name are provided.');
+        }
         if (broadcastMsg) {
-            if (broadcastMsg.name !== name) {
+            if (name && (broadcastMsg.name.toLowerCase() !== name.toLowerCase())) {
                 log.error(`Found broadcast message with id: ${id}, but` +
                     `its name, ${broadcastMsg.name} did not match expected name ${name}.`);
             }

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -665,8 +665,9 @@ const specMap = {
         opcode: 'event_broadcast',
         argMap: [
             {
-                type: 'field',
-                fieldName: 'BROADCAST_OPTION',
+                type: 'input',
+                inputOp: 'event_broadcast_menu',
+                inputName: 'BROADCAST_INPUT',
                 variableType: Variable.BROADCAST_MESSAGE_TYPE
             }
         ]
@@ -675,8 +676,9 @@ const specMap = {
         opcode: 'event_broadcastandwait',
         argMap: [
             {
-                type: 'field',
-                fieldName: 'BROADCAST_OPTION',
+                type: 'input',
+                inputOp: 'event_broadcast_menu',
+                inputName: 'BROADCAST_INPUT',
                 variableType: Variable.BROADCAST_MESSAGE_TYPE
             }
         ]

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -8,6 +8,7 @@ const sb2 = require('./serialization/sb2');
 const sb3 = require('./serialization/sb3');
 const StringUtil = require('./util/string-util');
 const formatMessage = require('format-message');
+const Variable = require('./engine/variable');
 
 const {loadCostume} = require('./import/load-costume.js');
 const {loadSound} = require('./import/load-sound.js');
@@ -677,6 +678,35 @@ class VirtualMachine extends EventEmitter {
      * of the current editing target's blocks.
      */
     emitWorkspaceUpdate () {
+        // Create a list of broadcast message Ids according to the stage variables
+        const stageVariables = this.runtime.getTargetForStage().variables;
+        let messageIds = [];
+        for (const varId in stageVariables) {
+            if (stageVariables[varId].type === Variable.BROADCAST_MESSAGE_TYPE) {
+                messageIds.push(varId);
+            }
+        }
+        // Go through all blocks on all targets, removing referenced
+        // broadcast ids from the list.
+        for (let i = 0; i < this.runtime.targets.length; i++) {
+            const currTarget = this.runtime.targets[i];
+            const currBlocks = currTarget.blocks._blocks;
+            for (const blockId in currBlocks) {
+                if (currBlocks[blockId].fields.BROADCAST_OPTION) {
+                    const id = currBlocks[blockId].fields.BROADCAST_OPTION.id;
+                    const index = messageIds.indexOf(id);
+                    if (index !== -1) {
+                        messageIds = messageIds.slice(0, index)
+                            .concat(messageIds.slice(index + 1));
+                    }
+                }
+            }
+        }
+        // Anything left in messageIds is not referenced by a block, so delete it.
+        for (let i = 0; i < messageIds.length; i++) {
+            const id = messageIds[i];
+            delete this.runtime.getTargetForStage().variables[id];
+        }
         const variableMap = Object.assign({},
             this.runtime.getTargetForStage().variables,
             this.editingTarget.variables

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -287,12 +287,18 @@ test('emitWorkspaceUpdate', t => {
                 global: {
                     toXML: () => 'global'
                 }
+            },
+            blocks: {
+                toXML: () => 'blocks'
             }
         }, {
             variables: {
                 unused: {
                     toXML: () => 'unused'
                 }
+            },
+            blocks: {
+                toXML: () => 'blocks'
             }
         }, {
             variables: {


### PR DESCRIPTION
### Resolves

Resolves [LLK/scratch-blocks#1304](https://github.com/LLK/scratch-blocks/issues/1304), [LLK/scratch-blocks#1290](https://github.com/LLK/scratch-blocks/issues/1290), [LLK/scratch-blocks#1268](1268), and [LLK/scratch-blocks#1270](https://github.com/LLK/scratch-blocks/issues/1270).


### Proposed Changes

- Allow pluggable inputs for `broadcast`/`broadcast and wait` blocks.

- Allow importing SB2 projects that have blocks plugged into `broadcast`/`broadcast and wait` blocks. -- This also entails importing SB2 projects that have empty string messages (caused by plugging in an input into a broadcast block and then taking it back out). These empty string messages will be translated into a fresh name `messageN`, where N is an integer such that the name `messageN` does not exist as a message already being used in the project.

- This PR also implements the implicit message deletion behavior seen in Scratch 2.0 where messages that are not being referenced in the project disappear from the broadcast message dropdowns. In Scratch 3.0, this behavior will occur whenever the workspace is refreshed (e.g. when the user switches sprites or switches between the blocks tab and the costumes/sounds tabs.

### Reason for Changes

SB2 compatibility/missing feature.

### Test Coverage

Existing tests pass.

### Additional Notes

Depends on (and should be merged simultaneously with) PRs:
[LLK/scratch-gui#1033](https://github.com/LLK/scratch-gui/pull/1033)
[LLK/scratch-blocks#1302](https://github.com/LLK/scratch-blocks/pull/1302)