### PR TITLE
Add blockly extension for scratch extensions

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -603,7 +603,8 @@ class Runtime extends EventEmitter {
             colour: categoryInfo.color1,
             colourSecondary: categoryInfo.color2,
             colourTertiary: categoryInfo.color3,
-            args0: []
+            args0: [],
+            extensions: ['scratch_extension']
         };
 
         const inputList = [];


### PR DESCRIPTION
### Resolves

This is needed to display the changes from https://github.com/LLK/scratch-blocks/pull/1284 in the GUI.

### Proposed Changes

When loading extension blocks, add a Blockly extension (i.e. a piece of code added to a block definition) to each block that sets a flag, isScratchExtension, to indicate that it is a Scratch extension.  

### Reason for Changes

The block rendering checks the isScratchExtension flag in order to render extension blocks correctly.