### PR TITLE
Cast to string before asking question. Same as say blocks do.

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -105,7 +105,7 @@ class Scratch3SensingBlocks {
         const _target = util.target;
         return new Promise(resolve => {
             const isQuestionAsked = this._questionList.length > 0;
-            this._enqueueAsk(args.QUESTION, resolve, _target, _target.visible, _target.isStage);
+            this._enqueueAsk(String(args.QUESTION), resolve, _target, _target.visible, _target.isStage);
             if (!isQuestionAsked) {
                 this._askNextQuestion();
             }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/866

### Proposed Changes

_Describe what this Pull Request does_

As with the say blocks, make sure to cast inputs to string before asking questions.

### Reason for Changes

_Explain why these changes should be made_

Eric S. found a bug with plugging numbers into "ask" blocks.
