### PR TITLE
Add separator to extension block definition

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -617,16 +617,20 @@ class Runtime extends EventEmitter {
 
         blockJSON.message0 = '';
 
-        // If an icon for the extension exists, prepend it to each block
+        // If an icon for the extension exists, prepend it to each block, with a vertical separator.
         if (categoryInfo.iconURI) {
-            blockJSON.message0 = '%1';
+            blockJSON.message0 = '%1 %2';
             const iconJSON = {
                 type: 'field_image',
                 src: categoryInfo.iconURI,
                 width: 40,
                 height: 40
             };
+            const separatorJSON = {
+                type: 'field_vertical_separator'
+            };
             blockJSON.args0.push(iconJSON);
+            blockJSON.args0.push(separatorJSON);
         }
 
         blockJSON.message0 += blockInfo.text.replace(/\[(.+?)]/g, (match, placeholder) => {


### PR DESCRIPTION
### Proposed Changes

When generating extension block definitions, include a vertical separator field after the icon. 

### Reason for Changes

Implementing that remaining parts of the design spec in https://github.com/LLK/scratch-blocks/issues/1207