### PR TITLE
Remove current instrument from sound state

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -26,7 +26,6 @@ class Scratch3SoundBlocks {
     static get DEFAULT_SOUND_STATE () {
         return {
             volume: 100,
-            currentInstrument: 0,
             effects: {
                 pitch: 0,
                 pan: 0


### PR DESCRIPTION
### Proposed Changes

When moving music functionality out of the sound blocks and into the music extension, I forgot to remove the custom state field for the current instrument, so this is just removing it.