### PR TITLE
Reset sound effects

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -12,8 +12,10 @@ class Scratch3SoundBlocks {
 
         // Clear sound effects on green flag and stop button events.
         this._clearEffectsForAllTargets = this._clearEffectsForAllTargets.bind(this);
-        this.runtime.on('PROJECT_STOP_ALL', this._clearEffectsForAllTargets);
-        this.runtime.on('PROJECT_START', this._clearEffectsForAllTargets);
+        if (this.runtime) {
+            this.runtime.on('PROJECT_STOP_ALL', this._clearEffectsForAllTargets);
+            this.runtime.on('PROJECT_START', this._clearEffectsForAllTargets);
+        }
     }
 
     /**
@@ -213,6 +215,7 @@ class Scratch3SoundBlocks {
     }
 
     _clearEffectsForAllTargets () {
+        if (this.runtime.targets === null) return;
         const allTargets = this.runtime.targets;
         for (let i = 0; i < allTargets.length; i++) {
             this._clearEffectsForTarget(allTargets[i]);

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -9,6 +9,11 @@ class Scratch3SoundBlocks {
          * @type {Runtime}
          */
         this.runtime = runtime;
+
+        // Clear sound effects on green flag and stop button events.
+        this._clearEffectsForAllTargets = this._clearEffectsForAllTargets.bind(this);
+        this.runtime.on('PROJECT_STOP_ALL', this._clearEffectsForAllTargets);
+        this.runtime.on('PROJECT_START', this._clearEffectsForAllTargets);
     }
 
     /**
@@ -194,13 +199,24 @@ class Scratch3SoundBlocks {
     }
 
     clearEffects (args, util) {
-        const soundState = this._getSoundState(util.target);
+        this._clearEffectsForTarget(util.target);
+    }
+
+    _clearEffectsForTarget (target) {
+        const soundState = this._getSoundState(target);
         for (const effect in soundState.effects) {
             if (!soundState.effects.hasOwnProperty(effect)) continue;
             soundState.effects[effect] = 0;
         }
-        if (util.target.audioPlayer === null) return;
-        util.target.audioPlayer.clearEffects();
+        if (target.audioPlayer === null) return;
+        target.audioPlayer.clearEffects();
+    }
+
+    _clearEffectsForAllTargets () {
+        const allTargets = this.runtime.targets;
+        for (let i = 0; i < allTargets.length; i++) {
+            this._clearEffectsForTarget(allTargets[i]);
+        }
     }
 
     setVolume (args, util) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-audio/issues/34

### Proposed Changes

Bind the green flag and stop events to a new function that clears the sound effects for all targets. This includes clearing the effects state for each target, and calling the reset function on the audio player for each target. I refactored the clearing code a bit here to make this simpler.

### Reason for Changes

This change makes sure that the state of the effects in the target and the audio player don't get out of sync.

### Test Coverage

No new tests