### PR TITLE
Accept both objects and strings for 'loadProject'

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -217,15 +217,13 @@ class VirtualMachine extends EventEmitter {
         this.clear();
 
         // Validate & parse
-        if (typeof json !== 'string') {
-            log.error('Failed to parse project. Non-string supplied to fromJSON.');
+        if (typeof json !== 'string' && typeof json !== 'object') {
+            log.error('Failed to parse project. Invalid type supplied to fromJSON.');
             return;
         }
-        json = JSON.parse(json);
-        if (typeof json !== 'object') {
-            log.error('Failed to parse project. JSON supplied to fromJSON is not an object.');
-            return;
-        }
+
+        // Attempt to parse JSON if string is supplied
+        if (typeof json === 'string') json = JSON.parse(json);
 
         // Establish version, deserialize, and load into runtime
         // @todo Support Scratch 1.4

--- a/test/integration/import-sb2-from-object.js
+++ b/test/integration/import-sb2-from-object.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const test = require('tap').test;
+const makeTestStorage = require('../fixtures/make-test-storage');
+const extract = require('../fixtures/extract');
+const VirtualMachine = require('../../src/index');
+
+const uri = path.resolve(__dirname, '../fixtures/default.sb2');
+const project = JSON.parse(extract(uri));
+
+test('default', t => {
+    const vm = new VirtualMachine();
+    vm.attachStorage(makeTestStorage());
+
+    // Evaluate playground data and exit
+    vm.on('playgroundData', e => {
+        const threads = JSON.parse(e.threads);
+        t.ok(threads.length === 0);
+        t.end();
+        process.nextTick(process.exit);
+    });
+
+    // Start VM, load project, and run
+    t.doesNotThrow(() => {
+        vm.start();
+        vm.clear();
+        vm.setCompatibilityMode(false);
+        vm.setTurboMode(false);
+        vm.loadProject(project).then(() => {
+            vm.greenFlag();
+
+            // After two seconds, get playground data and stop
+            setTimeout(() => {
+                vm.getPlaygroundData();
+                vm.stopAll();
+            }, 2000);
+        });
+    });
+});


### PR DESCRIPTION
### Resolves

GH-733

### Proposed Changes

- Adds some handling to the `loadProject` method (in the underlying `fromJson` method) of the VM to accept both stringified JSON as well as an object when attempting to load a project.

### Reason for Changes

- Improves developer ergonomics (particularly when working in the browser console)

### Test Coverage

- See new integration test case (`test/integration/import-sb2-from-object.js`)
