### PR TITLE
Stop all sounds for all targets

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -167,9 +167,17 @@ class Scratch3SoundBlocks {
         return -1;
     }
 
-    stopAllSounds (args, util) {
-        if (util.target.audioPlayer === null) return;
-        util.target.audioPlayer.stopAllSounds();
+    stopAllSounds () {
+        if (this.runtime.targets === null) return;
+        const allTargets = this.runtime.targets;
+        for (let i = 0; i < allTargets.length; i++) {
+            this._stopAllSoundsForTarget(allTargets[i]);
+        }
+    }
+
+    _stopAllSoundsForTarget (target) {
+        if (target.audioPlayer === null) return;
+        target.audioPlayer.stopAllSounds();
     }
 
     setEffect (args, util) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/862

### Proposed Changes

The "stop all sounds" block now iterates over all targets and stops all sounds for each.

### Reason for Changes

This makes the behavior consistent with Scratch 2.0 (good catch @paulkaplan!)