### PR TITLE
Allow size to be set through postSpriteInfo, and emit updates when it is

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -329,6 +329,7 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         }
+        this.runtime.requestTargetsUpdate(this);
     }
 
     /**
@@ -861,6 +862,9 @@ class RenderedTarget extends Target {
         }
         if (data.hasOwnProperty('visible')) {
             this.setVisible(data.visible);
+        }
+        if (data.hasOwnProperty('size')) {
+            this.setSize(data.size);
         }
     }
 


### PR DESCRIPTION
Required to allow size to be added to sprite info panel in the GUI.

### Resolves

_What Github issue does this resolve (please include link)?_

Part of implementing https://github.com/LLK/scratch-gui/issues/1064

### Proposed Changes

_Describe what this Pull Request does_

Allow `size` to be set through the `postSpriteInfo` method, and emit target update events when it is.

Both of these changes just follow the pattern of the other params that can be set through `postSpriteInfo`.

### Reason for Changes

_Explain why these changes should be made_

So that the GUI can set the target size and receive up-to-date information about it when it is changed by the blocks.
