### PR TITLE
Optimize stepThread by reducing the number of calls to peekStack

### DIFF
--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -174,7 +174,8 @@ class Sequencer {
             // A "null block" - empty branch.
             thread.popStack();
         }
-        while (thread.peekStack()) {
+        // Save the current block ID to notice if we did control flow.
+        while ((currentBlockId = thread.peekStack()) !== 0) {
             let isWarpMode = thread.peekStackFrame().warpMode;
             if (isWarpMode && !thread.warpTimer) {
                 // Initialize warp-mode timer if it hasn't been already.
@@ -183,8 +184,6 @@ class Sequencer {
                 thread.warpTimer.start();
             }
             // Execute the current block.
-            // Save the current block ID to notice if we did control flow.
-            currentBlockId = thread.peekStack();
             if (this.runtime.profiler !== null) {
                 if (executeProfilerId === -1) {
                     executeProfilerId = this.runtime.profiler.idByName(executeProfilerFrame);


### PR DESCRIPTION
### Resolves

Make stepThread faster by reducing the number of times it calls peekStack.

### Proposed Changes

Instead of calling `thread.peekStack()` two times, once for the condition in the while loop and once to save the current block ID, call it one time to do both.

### Reason for Changes

Assuming that it didn't break anything (see below), performance is improved.

### Test Coverage

Unfortunately, whenever I run the tests, I get `No storage/audio/rendering module present, cannot load costume/asset`, so I wasn't able to even run them.