### PR TITLE
No pen trails when dragging

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -181,14 +181,18 @@ class Scratch3PenBlocks {
      * @param {RenderedTarget} target - the target which has moved.
      * @param {number} oldX - the previous X position.
      * @param {number} oldY - the previous Y position.
+     * @param {boolean} isForce - whether the movement was forced.
      * @private
      */
-    _onTargetMoved (target, oldX, oldY) {
-        const penSkinId = this._getPenLayerID();
-        if (penSkinId >= 0) {
-            const penState = this._getPenState(target);
-            this.runtime.renderer.penLine(penSkinId, penState.penAttributes, oldX, oldY, target.x, target.y);
-            this.runtime.requestRedraw();
+    _onTargetMoved (target, oldX, oldY, isForce) {
+        // Only move the pen if the movement isn't forced (ie. dragged).
+        if (!isForce) {
+            const penSkinId = this._getPenLayerID();
+            if (penSkinId >= 0) {
+                const penState = this._getPenState(target);
+                this.runtime.renderer.penLine(penSkinId, penState.penAttributes, oldX, oldY, target.x, target.y);
+                this.runtime.requestRedraw();
+            }
         }
     }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -845,8 +845,8 @@ class RenderedTarget extends Target {
      */
     postSpriteInfo (data) {
         const force = data.hasOwnProperty('force') ? data.force : null;
-        let isXChanged = data.hasOwnProperty('x');
-        let isYChanged = data.hasOwnProperty('y');
+        const isXChanged = data.hasOwnProperty('x');
+        const isYChanged = data.hasOwnProperty('y');
         if (isXChanged || isYChanged) {
             this.setXY(isXChanged ? data.x : this.x, isYChanged ? data.y : this.y, force);
         }

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -845,11 +845,10 @@ class RenderedTarget extends Target {
      */
     postSpriteInfo (data) {
         const force = data.hasOwnProperty('force') ? data.force : null;
-        if (data.hasOwnProperty('x')) {
-            this.setXY(data.x, this.y, force);
-        }
-        if (data.hasOwnProperty('y')) {
-            this.setXY(this.x, data.y, force);
+        let isXChanged = data.hasOwnProperty('x');
+        let isYChanged = data.hasOwnProperty('y');
+        if (isXChanged || isYChanged) {
+            this.setXY(isXChanged ? data.x : this.x, isYChanged ? data.y : this.y, force);
         }
         if (data.hasOwnProperty('direction')) {
             this.setDirection(data.direction);

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -203,7 +203,7 @@ class RenderedTarget extends Target {
             this.x = x;
             this.y = y;
         }
-        this.emit(RenderedTarget.EVENT_TARGET_MOVED, this, oldX, oldY);
+        this.emit(RenderedTarget.EVENT_TARGET_MOVED, this, oldX, oldY, force);
         this.runtime.requestTargetsUpdate(this);
     }
 


### PR DESCRIPTION
### Resolves

[Render issue #144](https://github.com/LLK/scratch-render/issues/144)

### Proposed Changes

When a sprite is dragged while its pen is down, no pen trails are made.
In addition, only one setXY() call is made when dragging changes the X and Y positions at the same time, so even if pen trails were made while dragging, the pen trail would be smooth, not jagged and right-angle-like.

### Reason for Changes

Consistency with Scratch 2.

### Test Coverage

None.
