### PR TITLE
Reformat string keys for costume changes

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -313,11 +313,11 @@ class Scratch3LooksBlocks {
             const costumeIndex = target.getCostumeIndexByName(requestedCostume);
             if (costumeIndex > -1) {
                 target.setCostume(costumeIndex);
-            } else if (requestedCostume === 'previous costume' ||
-                       requestedCostume === 'previous backdrop') {
+            } else if (requestedCostume === '_prevCostume_' ||
+                       requestedCostume === '_prevBackdrop_') {
                 target.setCostume(target.currentCostume - 1);
-            } else if (requestedCostume === 'next costume' ||
-                       requestedCostume === 'next backdrop') {
+            } else if (requestedCostume === '_nextCostume_' ||
+                       requestedCostume === '_nextBackdrop_') {
                 target.setCostume(target.currentCostume + 1);
             } else {
                 const forcedNumber = Number(requestedCostume);


### PR DESCRIPTION
### Resolves

This pull request is a dependency for [GUI PR #1123](https://github.com/LLK/scratch-gui/pull/1123).

### Proposed Changes

String keys that could be passed into setCostumeOrBackdrop changed from "next costume" to "\_nextCostume\_", "next backdrop" to "\_nextBackdrop\_", etc.

### Reason for Changes

The clone blocks use the same style string keys (underscores around them), so costume blocks should be like this too.

### Test Coverage

None.
