### PR TITLE
midiInstrument: support

### DIFF
--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -469,7 +469,7 @@ const specMap = {
             }
         ]
     },
-    'midiInstrument:':{
+    'midiInstrument:': {
         opcode: 'music.setInstrument',
         argMap: [
             {

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -469,6 +469,16 @@ const specMap = {
             }
         ]
     },
+    'midiInstrument:':{
+        opcode: 'music.setInstrument',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'INSTRUMENT'
+            }
+        ]
+    },
     'changeVolumeBy:': {
         opcode: 'sound_changevolumeby',
         argMap: [


### PR DESCRIPTION
### Resolves
#861 
Projects with old 1.4 "midiInstrument:" block fail to open
### Proposed Changes
Supporting midiInstrument: as Scratch 2.0 supporting.
src/serialization/sb2_specmap.js added 
```
'midiInstrument:':{
+        opcode: 'music.setInstrument',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'INSTRUMENT'
+            }
+        ]
+    },
```
### Reason for Changes
Old one cannot read 1.4 projects with this block.
### Test Coverage
Read 2.0 project uses it and was uploaded by 1.4 like
https://llk.github.io/scratch-gui/develop/#138256836