### PR TITLE
Implement opcodes for new costume/backdrop reporters

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -236,9 +236,8 @@ class Scratch3LooksBlocks {
             looks_gotofrontback: this.goToFrontBack,
             looks_goforwardbackwardlayers: this.goForwardBackwardLayers,
             looks_size: this.getSize,
-            looks_costumeorder: this.getCostumeIndex,
-            looks_backdroporder: this.getBackdropIndex,
-            looks_backdropname: this.getBackdropName
+            looks_costumenumbername: this.getCostumeNumberName,
+            looks_backdropnumbername: this.getBackdropNumberName
         };
     }
 
@@ -433,18 +432,21 @@ class Scratch3LooksBlocks {
         return Math.round(util.target.size);
     }
 
-    getBackdropIndex () {
+    getBackdropNumberName (args) {
         const stage = this.runtime.getTargetForStage();
-        return stage.currentCostume + 1;
-    }
-
-    getBackdropName () {
-        const stage = this.runtime.getTargetForStage();
+        if (args.NUMBER_NAME === 'number') {
+            return stage.currentCostume + 1;
+        }
+        // Else return name
         return stage.sprite.costumes[stage.currentCostume].name;
     }
 
-    getCostumeIndex (args, util) {
-        return util.target.currentCostume + 1;
+    getCostumeNumberName (args, util) {
+        if (args.NUMBER_NAME === 'number') {
+            return util.target.currentCostume + 1;
+        }
+        // Else return name
+        return util.target.sprite.costumes[util.target.currentCostume].name;
     }
 }
 

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -602,17 +602,38 @@ const parseBlock = function (sb2block, addBroadcastMsg, getVariableId, extension
         }
     }
 
-    // Updated layering blocks
-    if (oldOpcode === 'comeToFront') {
+    // Updates for blocks that have new menus (e.g. in Looks)
+    switch (oldOpcode) {
+    case 'comeToFront':
         activeBlock.fields.FRONT_BACK = {
             name: 'FRONT_BACK',
             value: 'front'
         };
-    } else if (oldOpcode === 'goBackByLayers:') {
+        break;
+    case 'goBackByLayers:':
         activeBlock.fields.FORWARD_BACKWARD = {
             name: 'FORWARD_BACKWARD',
             value: 'backward'
         };
+        break;
+    case 'backgroundIndex':
+        activeBlock.fields.NUMBER_NAME = {
+            name: 'NUMBER_NAME',
+            value: 'number'
+        };
+        break;
+    case 'sceneName':
+        activeBlock.fields.NUMBER_NAME = {
+            name: 'NUMBER_NAME',
+            value: 'name'
+        };
+        break;
+    case 'costumeIndex':
+        activeBlock.fields.NUMBER_NAME = {
+            name: 'NUMBER_NAME',
+            value: 'number'
+        };
+        break;
     }
 
     // Special cases to generate mutations.

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -360,12 +360,12 @@ const specMap = {
         ]
     },
     'costumeIndex': {
-        opcode: 'looks_costumeorder',
+        opcode: 'looks_costumenumbername',
         argMap: [
         ]
     },
     'sceneName': {
-        opcode: 'looks_backdropname',
+        opcode: 'looks_backdropnumbername',
         argMap: [
         ]
     },
@@ -390,7 +390,7 @@ const specMap = {
         ]
     },
     'backgroundIndex': {
-        opcode: 'looks_backdroporder',
+        opcode: 'looks_backdropnumbername',
         argMap: [
         ]
     },

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -1,0 +1,52 @@
+const test = require('tap').test;
+const Looks = require('../../src/blocks/scratch3_looks');
+const util = {
+    target: {
+        currentCostume: 0, // Internally, current costume is 0 indexed
+        sprite: {
+            costumes: [
+                {name: 'first name'},
+                {name: 'second name'},
+                {name: 'third name'}
+            ]
+        }
+    }
+};
+
+const fakeRuntime = {
+    getTargetForStage: () => util.target, // Just return the dummy target above.
+    on: () => {} // Stub out listener methods used in constructor.
+};
+const blocks = new Looks(fakeRuntime);
+
+test('getCostumeNumberName returns 1-indexed costume number', t => {
+    util.target.currentCostume = 0; // This is 0-indexed.
+    const args = {NUMBER_NAME: 'number'};
+    const number = blocks.getCostumeNumberName(args, util);
+    t.strictEqual(number, 1);
+    t.end();
+});
+
+test('getCostumeNumberName can return costume name', t => {
+    util.target.currentCostume = 0; // This is 0-indexed.
+    const args = {NUMBER_NAME: 'name'};
+    const number = blocks.getCostumeNumberName(args, util);
+    t.strictEqual(number, 'first name');
+    t.end();
+});
+
+test('getBackdropNumberName returns 1-indexed costume number', t => {
+    util.target.currentCostume = 2; // This is 0-indexed.
+    const args = {NUMBER_NAME: 'number'};
+    const number = blocks.getBackdropNumberName(args, util);
+    t.strictEqual(number, 3);
+    t.end();
+});
+
+test('getBackdropNumberName can return costume name', t => {
+    util.target.currentCostume = 2; // This is 0-indexed.
+    const args = {NUMBER_NAME: 'name'};
+    const number = blocks.getBackdropNumberName(args, util);
+    t.strictEqual(number, 'third name');
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

VM part of https://github.com/LLK/scratch-blocks/issues/1318
Blocks were implemented in https://github.com/LLK/scratch-blocks/pull/1332

### Proposed Changes

_Describe what this Pull Request does_

Implement the menu-switchable costume and backdrop number/name reporters.

Also modify the SB2 import to transform the old blocks into these new blocks and set the menu items appropriately. 


![image](https://user-images.githubusercontent.com/654102/34570621-54d741a0-f13a-11e7-926a-5fea1b9b2d85.png)


### Test Coverage

_Please show how you have added tests to cover your changes_

Added a new unit test file for the looks blocks and added tests covering the new reporter opcode functions.
