### PR TITLE
Fix mouse positions for different stage zoom levels

### DIFF
--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -64,8 +64,8 @@ class Scratch3MotionBlocks {
         let targetX = 0;
         let targetY = 0;
         if (targetName === '_mouse_') {
-            targetX = util.ioQuery('mouse', 'getX');
-            targetY = util.ioQuery('mouse', 'getY');
+            targetX = util.ioQuery('mouse', 'getClampedX');
+            targetY = util.ioQuery('mouse', 'getClampedY');
         } else if (targetName === '_random_') {
             const stageWidth = this.runtime.constructor.STAGE_WIDTH;
             const stageHeight = this.runtime.constructor.STAGE_HEIGHT;
@@ -106,8 +106,8 @@ class Scratch3MotionBlocks {
         let targetX = 0;
         let targetY = 0;
         if (args.TOWARDS === '_mouse_') {
-            targetX = util.ioQuery('mouse', 'getX');
-            targetY = util.ioQuery('mouse', 'getY');
+            targetX = util.ioQuery('mouse', 'getClampedX');
+            targetY = util.ioQuery('mouse', 'getClampedY');
         } else {
             const pointTarget = this.runtime.getSpriteTargetByName(args.TOWARDS);
             if (!pointTarget) return;
@@ -155,7 +155,7 @@ class Scratch3MotionBlocks {
             util.yield();
         }
     }
-    
+
     glideTo (args, util) {
         const targetXY = this.getTargetXY(args.TO, util);
         if (targetXY) {

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -64,8 +64,8 @@ class Scratch3MotionBlocks {
         let targetX = 0;
         let targetY = 0;
         if (targetName === '_mouse_') {
-            targetX = util.ioQuery('mouse', 'getClampedX');
-            targetY = util.ioQuery('mouse', 'getClampedY');
+            targetX = util.ioQuery('mouse', 'getScratchX');
+            targetY = util.ioQuery('mouse', 'getScratchY');
         } else if (targetName === '_random_') {
             const stageWidth = this.runtime.constructor.STAGE_WIDTH;
             const stageHeight = this.runtime.constructor.STAGE_HEIGHT;
@@ -106,8 +106,8 @@ class Scratch3MotionBlocks {
         let targetX = 0;
         let targetY = 0;
         if (args.TOWARDS === '_mouse_') {
-            targetX = util.ioQuery('mouse', 'getClampedX');
-            targetY = util.ioQuery('mouse', 'getClampedY');
+            targetX = util.ioQuery('mouse', 'getScratchX');
+            targetY = util.ioQuery('mouse', 'getScratchY');
         } else {
             const pointTarget = this.runtime.getSpriteTargetByName(args.TOWARDS);
             if (!pointTarget) return;

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -120,8 +120,8 @@ class Scratch3SensingBlocks {
     touchingObject (args, util) {
         const requestedObject = args.TOUCHINGOBJECTMENU;
         if (requestedObject === '_mouse_') {
-            const mouseX = util.ioQuery('mouse', 'getX');
-            const mouseY = util.ioQuery('mouse', 'getY');
+            const mouseX = util.ioQuery('mouse', 'getClientX');
+            const mouseY = util.ioQuery('mouse', 'getClientY');
             return util.target.isTouchingPoint(mouseX, mouseY);
         } else if (requestedObject === '_edge_') {
             return util.target.isTouchingEdge();
@@ -147,8 +147,8 @@ class Scratch3SensingBlocks {
         let targetX = 0;
         let targetY = 0;
         if (args.DISTANCETOMENU === '_mouse_') {
-            targetX = util.ioQuery('mouse', 'getClampedX');
-            targetY = util.ioQuery('mouse', 'getClampedY');
+            targetX = util.ioQuery('mouse', 'getScratchX');
+            targetY = util.ioQuery('mouse', 'getScratchY');
         } else {
             const distTarget = this.runtime.getSpriteTargetByName(
                 args.DISTANCETOMENU
@@ -176,11 +176,11 @@ class Scratch3SensingBlocks {
     }
 
     getMouseX (args, util) {
-        return util.ioQuery('mouse', 'getClampedX');
+        return util.ioQuery('mouse', 'getScratchX');
     }
 
     getMouseY (args, util) {
-        return util.ioQuery('mouse', 'getClampedY');
+        return util.ioQuery('mouse', 'getScratchY');
     }
 
     getMouseDown (args, util) {

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -147,8 +147,8 @@ class Scratch3SensingBlocks {
         let targetX = 0;
         let targetY = 0;
         if (args.DISTANCETOMENU === '_mouse_') {
-            targetX = util.ioQuery('mouse', 'getX');
-            targetY = util.ioQuery('mouse', 'getY');
+            targetX = util.ioQuery('mouse', 'getClampedX');
+            targetY = util.ioQuery('mouse', 'getClampedY');
         } else {
             const distTarget = this.runtime.getSpriteTargetByName(
                 args.DISTANCETOMENU
@@ -176,11 +176,11 @@ class Scratch3SensingBlocks {
     }
 
     getMouseX (args, util) {
-        return util.ioQuery('mouse', 'getX');
+        return util.ioQuery('mouse', 'getClampedX');
     }
 
     getMouseY (args, util) {
-        return util.ioQuery('mouse', 'getY');
+        return util.ioQuery('mouse', 'getClampedY');
     }
 
     getMouseDown (args, util) {

--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -55,17 +55,33 @@ class Mouse {
 
     /**
      * Get the X position of the mouse.
-     * @return {number} Clamped X position of the mouse cursor.
+     * @return {number} Non-clamped X position of the mouse cursor.
      */
     getX () {
-        return MathUtil.clamp(this._x, -240, 240);
+        return this._x;
     }
 
     /**
      * Get the Y position of the mouse.
-     * @return {number} Clamped Y position of the mouse cursor.
+     * @return {number} Non-clamped Y position of the mouse cursor.
      */
     getY () {
+        return -this._y;
+    }
+
+    /**
+     * Get the stage-clamped X position of the mouse.
+     * @return {number} Clamped X position of the mouse cursor.
+     */
+    getClampedX () {
+        return MathUtil.clamp(this._x, -240, 240);
+    }
+
+    /**
+     * Get the stage-clamped Y position of the mouse.
+     * @return {number} Clamped Y position of the mouse cursor.
+     */
+    getClampedY () {
         return MathUtil.clamp(-this._y, -180, 180);
     }
 

--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -40,10 +40,20 @@ class Mouse {
      */
     postData (data) {
         if (data.x) {
-            this._x = data.x - (data.canvasWidth / 2);
+            this._clientX = data.x;
+            this._scratchX = MathUtil.clamp(
+                480 * ((data.x / data.canvasWidth) - 0.5),
+                -240,
+                240
+            );
         }
         if (data.y) {
-            this._y = data.y - (data.canvasHeight / 2);
+            this._clientY = data.y;
+            this._scratchY = MathUtil.clamp(
+                -360 * ((data.y / data.canvasHeight) - 0.5),
+                -180,
+                180
+            );
         }
         if (typeof data.isDown !== 'undefined') {
             this._isDown = data.isDown;
@@ -54,35 +64,35 @@ class Mouse {
     }
 
     /**
-     * Get the X position of the mouse.
+     * Get the X position of the mouse in client coordinates.
      * @return {number} Non-clamped X position of the mouse cursor.
      */
-    getX () {
-        return this._x;
+    getClientX () {
+        return this._clientX;
     }
 
     /**
-     * Get the Y position of the mouse.
+     * Get the Y position of the mouse in client coordinates.
      * @return {number} Non-clamped Y position of the mouse cursor.
      */
-    getY () {
-        return -this._y;
+    getClientY () {
+        return this._clientY;
     }
 
     /**
-     * Get the stage-clamped X position of the mouse.
+     * Get the X position of the mouse in scratch coordinates.
      * @return {number} Clamped X position of the mouse cursor.
      */
-    getClampedX () {
-        return MathUtil.clamp(this._x, -240, 240);
+    getScratchX () {
+        return this._scratchX;
     }
 
     /**
-     * Get the stage-clamped Y position of the mouse.
+     * Get the Y position of the mouse in scratch coordinates.
      * @return {number} Clamped Y position of the mouse cursor.
      */
-    getClampedY () {
-        return MathUtil.clamp(-this._y, -180, 180);
+    getScratchY () {
+        return this._scratchY;
     }
 
     /**

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -616,8 +616,7 @@ class RenderedTarget extends Target {
             // Limits test to this Drawable, so this will return true
             // even if the clone is obscured by another Drawable.
             const pickResult = this.runtime.renderer.pick(
-                x + (this.runtime.constructor.STAGE_WIDTH / 2),
-                -y + (this.runtime.constructor.STAGE_HEIGHT / 2),
+                x, y,
                 null, null,
                 [this.drawableID]
             );

--- a/test/unit/io_mouse.js
+++ b/test/unit/io_mouse.js
@@ -8,10 +8,10 @@ test('spec', t => {
 
     t.type(m, 'object');
     t.type(m.postData, 'function');
-    t.type(m.getX, 'function');
-    t.type(m.getY, 'function');
-    t.type(m.getClampedX, 'function');
-    t.type(m.getClampedY, 'function');
+    t.type(m.getClientX, 'function');
+    t.type(m.getClientY, 'function');
+    t.type(m.getScratchX, 'function');
+    t.type(m.getScratchY, 'function');
     t.type(m.getIsDown, 'function');
     t.end();
 });
@@ -27,10 +27,10 @@ test('mouseUp', t => {
         canvasWidth: 480,
         canvasHeight: 360
     });
-    t.strictEquals(m.getX(), -260);
-    t.strictEquals(m.getY(), 170);
-    t.strictEquals(m.getClampedX(), -240);
-    t.strictEquals(m.getClampedY(), 170);
+    t.strictEquals(m.getClientX(), -20);
+    t.strictEquals(m.getClientY(), 10);
+    t.strictEquals(m.getScratchX(), -240);
+    t.strictEquals(m.getScratchY(), 170);
     t.strictEquals(m.getIsDown(), false);
     t.end();
 });
@@ -46,10 +46,27 @@ test('mouseDown', t => {
         canvasWidth: 480,
         canvasHeight: 360
     });
-    t.strictEquals(m.getX(), -230);
-    t.strictEquals(m.getY(), -220);
-    t.strictEquals(m.getClampedX(), -230);
-    t.strictEquals(m.getClampedY(), -180);
+    t.strictEquals(m.getClientX(), 10);
+    t.strictEquals(m.getClientY(), 400);
+    t.strictEquals(m.getScratchX(), -230);
+    t.strictEquals(m.getScratchY(), -180);
     t.strictEquals(m.getIsDown(), true);
+    t.end();
+});
+
+test('at zoomed scale', t => {
+    const rt = new Runtime();
+    const m = new Mouse(rt);
+
+    m.postData({
+        x: 240,
+        y: 540,
+        canvasWidth: 960,
+        canvasHeight: 720
+    });
+    t.strictEquals(m.getClientX(), 240);
+    t.strictEquals(m.getClientY(), 540);
+    t.strictEquals(m.getScratchX(), -120);
+    t.strictEquals(m.getScratchY(), -90);
     t.end();
 });

--- a/test/unit/io_mouse.js
+++ b/test/unit/io_mouse.js
@@ -10,6 +10,8 @@ test('spec', t => {
     t.type(m.postData, 'function');
     t.type(m.getX, 'function');
     t.type(m.getY, 'function');
+    t.type(m.getClampedX, 'function');
+    t.type(m.getClampedY, 'function');
     t.type(m.getIsDown, 'function');
     t.end();
 });
@@ -19,14 +21,16 @@ test('mouseUp', t => {
     const m = new Mouse(rt);
 
     m.postData({
-        x: 1,
+        x: -20,
         y: 10,
         isDown: false,
         canvasWidth: 480,
         canvasHeight: 360
     });
-    t.strictEquals(m.getX(), -239);
+    t.strictEquals(m.getX(), -260);
     t.strictEquals(m.getY(), 170);
+    t.strictEquals(m.getClampedX(), -240);
+    t.strictEquals(m.getClampedY(), 170);
     t.strictEquals(m.getIsDown(), false);
     t.end();
 });
@@ -37,13 +41,15 @@ test('mouseDown', t => {
 
     m.postData({
         x: 10,
-        y: 100,
+        y: 400,
         isDown: true,
         canvasWidth: 480,
         canvasHeight: 360
     });
     t.strictEquals(m.getX(), -230);
-    t.strictEquals(m.getY(), 80);
+    t.strictEquals(m.getY(), -220);
+    t.strictEquals(m.getClampedX(), -230);
+    t.strictEquals(m.getClampedY(), -180);
     t.strictEquals(m.getIsDown(), true);
     t.end();
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/179
Fixes https://github.com/LLK/scratch-gui/issues/642
And an unreported issue with the mousex/y reporters giving the wrong values in fullscreen mode.

### Proposed Changes

_Describe what this Pull Request does_

Augment the mouse io to report both "scratch coordinates" (clamped, centered and scaled to the logical stage size), used for the reporters and motion blocks, as well as the "client coordinates" (top left, y down, at client stage size) which is used when interacting with the renderer.

I think doing it this way will make it easier in the future to chop off the client coordinates if we move the renderer to picking in scratch coordinates. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Updated the tests and added new tests to test the different between client coords and scratch coords.

I also used this [test project](https://llk.github.io/scratch-gui/develop/#196664014), which was useful.
On develop:

|                                                  | default size | fullscreen |
|--------------------------------------------------|--------------|------------|
| touching mouse shows "touching" bubble           | ✅            | 🚫         |
| click sprite shows "click" bubble                | ✅            | ✅          |
| hold space bar creates pen lines following mouse | ✅            | 🚫         |

![mouse-position-develop](https://user-images.githubusercontent.com/654102/34729704-709c701e-f52b-11e7-9ffc-3e31b9e489cf.gif)

After change

|                                                  | default size | fullscreen |
|--------------------------------------------------|--------------|------------|
| touching mouse shows "touching" bubble           | ✅            | ✅         |
| click sprite shows "click" bubble                | ✅            | ✅          |
| hold space bar creates pen lines following mouse | ✅            | ✅         |

![mouse-position-fixed](https://user-images.githubusercontent.com/654102/34729780-9d1db382-f52b-11e7-954c-5870cef57eea.gif)

  @cwillisf I also checked for smooth dragging, seemed smooth as ever!