### PR TITLE
Audio effects state for clones

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -18,7 +18,9 @@ class Scratch3SoundBlocks {
         }
 
         this._onTargetCreated = this._onTargetCreated.bind(this);
-        runtime.on('targetWasCreated', this._onTargetCreated);
+        if (this.runtime) {
+            runtime.on('targetWasCreated', this._onTargetCreated);
+        }
     }
 
     /**

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -102,7 +102,7 @@ class Scratch3SoundBlocks {
      */
     _onTargetCreated (newTarget, sourceTarget) {
         if (sourceTarget) {
-            const soundState = this._getSoundState(sourceTarget);
+            const soundState = sourceTarget.getCustomState(Scratch3SoundBlocks.STATE_KEY);
             if (soundState && newTarget) {
                 newTarget.setCustomState(Scratch3SoundBlocks.STATE_KEY, Clone.simple(soundState));
                 this._syncEffectsForTarget(newTarget);

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -16,6 +16,9 @@ class Scratch3SoundBlocks {
             this.runtime.on('PROJECT_STOP_ALL', this._clearEffectsForAllTargets);
             this.runtime.on('PROJECT_START', this._clearEffectsForAllTargets);
         }
+
+        this._onTargetCreated = this._onTargetCreated.bind(this);
+        runtime.on('targetWasCreated', this._onTargetCreated);
     }
 
     /**
@@ -86,6 +89,23 @@ class Scratch3SoundBlocks {
             target.setCustomState(Scratch3SoundBlocks.STATE_KEY, soundState);
         }
         return soundState;
+    }
+
+    /**
+     * When a Target is cloned, clone the sound state.
+     * @param {Target} newTarget - the newly created target.
+     * @param {Target} [sourceTarget] - the target used as a source for the new clone, if any.
+     * @listens Runtime#event:targetWasCreated
+     * @private
+     */
+    _onTargetCreated (newTarget, sourceTarget) {
+        if (sourceTarget) {
+            const soundState = this._getSoundState(sourceTarget);
+            if (soundState && newTarget) {
+                newTarget.setCustomState(Scratch3SoundBlocks.STATE_KEY, Clone.simple(soundState));
+                this._syncEffectsForTarget(newTarget);
+            }
+        }
     }
 
     /**
@@ -206,6 +226,15 @@ class Scratch3SoundBlocks {
 
         if (util.target.audioPlayer === null) return;
         util.target.audioPlayer.setEffect(effect, soundState.effects[effect]);
+    }
+
+    _syncEffectsForTarget (target) {
+        if (!target || !target.audioPlayer) return;
+        const soundState = this._getSoundState(target);
+        for (const effect in soundState.effects) {
+            if (!soundState.effects.hasOwnProperty(effect)) continue;
+            target.audioPlayer.setEffect(effect, soundState.effects[effect]);
+        }
     }
 
     clearEffects (args, util) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -131,17 +131,15 @@ class RenderedTarget extends Target {
                 'control_start_as_clone', null, this
             );
         }
+    }
 
-        /**
-        * Audio player
-        */
+    /**
+     * Initialize the audio player for this sprite or clone.
+     */
+    initAudio () {
         this.audioPlayer = null;
         if (this.runtime && this.runtime.audioEngine) {
-            if (this.isOriginal) {
-                this.audioPlayer = this.runtime.audioEngine.createPlayer();
-            } else {
-                this.audioPlayer = this.sprite.clones[0].audioPlayer;
-            }
+            this.audioPlayer = this.runtime.audioEngine.createPlayer();
         }
     }
 
@@ -941,6 +939,10 @@ class RenderedTarget extends Target {
             if (this.visible) {
                 this.runtime.requestRedraw();
             }
+        }
+        if (this.audioPlayer) {
+            this.audioPlayer.stopAllSounds();
+            this.audioPlayer.dispose();
         }
     }
 }

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -56,6 +56,7 @@ class Sprite {
         const newClone = new RenderedTarget(this, this.runtime);
         newClone.isOriginal = this.clones.length === 0;
         this.clones.push(newClone);
+        newClone.initAudio();
         if (newClone.isOriginal) {
             newClone.initDrawable();
             this.runtime.fireTargetWasCreated(newClone);


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-audio/issues/50

Depends on https://github.com/LLK/scratch-audio/pull/71

### Proposed Changes

- Each clone has its own AudioPlayer (reverting the change [here](https://github.com/LLK/scratch-vm/pull/825/)), so that they can apply audio effects (volume, pitch and pan) independently. 
- When a sprite or clone is deleted, its AudioPlayer is disposed, disconnecting its webaudio nodes. This prevents the bug where audio drops out after too many AudioPlayers have been created (https://github.com/LLK/scratch-audio/issues/27).
- Clones get a copy of the audio effects state from their parent sprite, and sync their own AudioPlayer to it.

### Reason for Changes

If clones didn't have their own AudioPlayers, they couldn't have independent audio effects settings. 

### Test Coverage

Let me know if you have suggestions for tests.
  