### PR TITLE
Unique sprite and backdrop names

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -268,6 +268,8 @@ class VirtualMachine extends EventEmitter {
             targets.forEach(target => {
                 this.runtime.targets.push(target);
                 (/** @type RenderedTarget */ target).updateAllDrawableProperties();
+                // Ensure unique sprite name
+                if (target.isSprite()) this.renameSprite(target.id, target.getName());
             });
             // Select the first target for editing, e.g., the first sprite.
             if (wholeProject && (targets.length > 1)) {
@@ -448,7 +450,7 @@ class VirtualMachine extends EventEmitter {
     addBackdrop (md5ext, backdropObject) {
         return loadCostume(md5ext, backdropObject, this.runtime).then(() => {
             const stage = this.runtime.getTargetForStage();
-            stage.sprite.costumes.push(backdropObject);
+            stage.addCostume(backdropObject);
             stage.setCostume(stage.sprite.costumes.length - 1);
         });
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -631,7 +631,7 @@ class VirtualMachine extends EventEmitter {
      */
     setEditingTarget (targetId) {
         // Has the target id changed? If not, exit.
-        if (targetId === this.editingTarget.id) {
+        if (this.editingTarget && targetId === this.editingTarget.id) {
             return;
         }
         const target = this.runtime.getTargetById(targetId);


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-gui/issues/1209

### Proposed Changes
Do duplicate name checking when adding sprites or backdrops from the library

### Reason for Changes
Before, you could do this to make sprites/backdrops with identical names, which is confusing and doesn't happen in Scratch 2.0.
