### PR TITLE
Fix dragging duplicated sprites

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -831,7 +831,6 @@ class RenderedTarget extends Target {
             newTarget.effects = JSON.parse(JSON.stringify(this.effects));
             newTarget.variables = JSON.parse(JSON.stringify(this.variables));
             newTarget.lists = JSON.parse(JSON.stringify(this.lists));
-            newTarget.initDrawable();
             newTarget.updateAllDrawableProperties();
             newTarget.goBehindOther(this);
             return newTarget;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-render/issues/224

### Proposed Changes

_Describe what this Pull Request does_

Although the problem occurs in the renderer, it is because we are loading the duplicate in a way that erases the linked skins. Specifically, `initDrawable` is called in `createClone` previously, where the new costumes
are installed. Calling this again here erases those loaded skins and
causes an error when trying to calculate the uniforms when a drag
starts.

This was a bug with the original implementation, but it was hidden until a change to the renderer caused a uniform access (and convex hull calculation) to occur on new drawables on drag start.

Test manually by trying to duplicate and then drag a sprite in the stage