### PR TITLE
Update sb2 specmap for sensing blocks that are now fixed menus.

### DIFF
--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -861,9 +861,8 @@ const specMap = {
         opcode: 'sensing_keypressed',
         argMap: [
             {
-                type: 'input',
-                inputOp: 'sensing_keyoptions',
-                inputName: 'KEY_OPTION'
+                type: 'field',
+                fieldName: 'KEY_OPTION'
             }
         ]
     },
@@ -936,9 +935,8 @@ const specMap = {
         opcode: 'sensing_of',
         argMap: [
             {
-                type: 'input',
-                inputOp: 'sensing_of_property_menu',
-                inputName: 'PROPERTY'
+                type: 'field',
+                fieldName: 'PROPERTY'
             },
             {
                 type: 'input',


### PR DESCRIPTION
The updates in https://github.com/LLK/scratch-gui/pull/1223 forgot to include an update to the specmap to make sure that sb2 blocks get imported with fields instead of inputs on `sensing_of` and `sensing_keypressed` blocks. 

You can test this by creating a project like this in scratch 2 
![image](https://user-images.githubusercontent.com/654102/34908868-39ae4dec-f865-11e7-9355-9f863f04eb8c.png)

And importing it. On develop it gives warnings about "ignoring non existent input", a sure-fire sign that something is wrong. It then just uses the default menu item instead of the one in the file. This change corrects that behavior. 
