### PR TITLE
Use text-encoding library for text encoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "socket.io-client": "2.0.4",
     "stats.js": "^0.17.0",
     "tap": "^10.2.0",
+    "text-encoding": "0.6.4",
     "tiny-worker": "^2.1.1",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.4.1",

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1,3 +1,4 @@
+import {TextEncoder} from 'text-encoding';
 const EventEmitter = require('events');
 
 const centralDispatch = require('./dispatch/central-dispatch');

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1,4 +1,4 @@
-import {TextEncoder} from 'text-encoding';
+const TextEncoder = require('text-encoding');
 const EventEmitter = require('events');
 
 const centralDispatch = require('./dispatch/central-dispatch');


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-paint/issues/255#issuecomment-358088363

### Proposed Changes

Add polyfill for TextEncoder. Microsoft Edge doesn't support TextEncoder.
