### PR TITLE
Require TextEncoder correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "socket.io-client": "2.0.4",
     "stats.js": "^0.17.0",
     "tap": "^10.2.0",
+    "text-encoding": "0.6.4",
     "tiny-worker": "^2.1.1",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.4.1",

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1,3 +1,4 @@
+const TextEncoder = require('text-encoding').TextEncoder;
 const EventEmitter = require('events');
 
 const centralDispatch = require('./dispatch/central-dispatch');


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Use the text encoder polyfill correctly. By looking at the way the GUI uses it, the text encoder require doesn't bring in the constructor directly, but needs to be accessed.  

https://github.com/LLK/scratch-gui/blob/79ebea303fd693f3991578cce4a6636a82572d7c/src/lib/default-project/index.js#L1
