### PR TITLE
Benchmark prototype

### DIFF
--- a/src/playground/benchmark.css
+++ b/src/playground/benchmark.css
@@ -11,15 +11,41 @@ p {
         left: 450px;
     }
 }
+.share {
+    display: none;
+}
+.share label {
+    cursor: pointer;
+}
+.share[href] {
+    display: inline;
+}
+
+.render .profile-tables {
+    position: static;
+    left: 0;
+}
+.render .description {
+    display: none;
+}
+.render .run-push {
+    display: none;
+}
 #scratch-stage {
     border: 5px solid black;
     display: block;
     width: 400px;
     height: 300px;
 }
+.render #scratch-stage {
+    display: none;
+}
 .loading label, .profile-count label{
     width: 15em;
     display: inline-block;
+}
+.render .loading {
+    display: none;
 }
 .profile-tables table {
     margin: 30px 0 30px 0px;

--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -348,11 +348,21 @@ class ProfilerRun {
     run () {
         loadProject();
 
+        window.parent.postMessage({
+            type: 'BENCH_MESSAGE_LOADING'
+        }, '*');
+
         this.vm.on('workspaceUpdate', () => {
             setTimeout(() => {
+                window.parent.postMessage({
+                    type: 'BENCH_MESSAGE_WARMING_UP'
+                }, '*');
                 this.vm.greenFlag();
             }, 100);
             setTimeout(() => {
+                window.parent.postMessage({
+                    type: 'BENCH_MESSAGE_ACTIVE'
+                }, '*');
                 this.vm.runtime.profiler = this.profiler;
             }, 100 + this.warmUpTime);
             setTimeout(() => {
@@ -362,6 +372,12 @@ class ProfilerRun {
 
                 this.frameTable.render();
                 this.opcodeTable.render();
+
+                window.parent.postMessage({
+                    type: 'BENCH_MESSAGE_COMPLETE',
+                    frames: this.frames.frames,
+                    opcodes: this.opcodes.opcodes
+                }, '*');
             }, 100 + this.warmUpTime + this.maxRecordedTime);
         });
     }

--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -134,10 +134,16 @@ class StatView {
         }
 
         cell = document.createElement('td');
+        // Truncate selfTime. Value past the microsecond are floating point
+        // noise.
+        this.selfTime = Math.floor(this.selfTime * 1000) / 1000;
         cell.innerText = (this.selfTime / 1000).toPrecision(3);
         row.appendChild(cell);
 
         cell = document.createElement('td');
+        // Truncate totalTime. Value past the microsecond are floating point
+        // noise.
+        this.totalTime = Math.floor(this.totalTime * 1000) / 1000;
         cell.innerText = (this.totalTime / 1000).toPrecision(3);
         row.appendChild(cell);
 

--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -14,7 +14,7 @@ document.querySelector('.run')
     }, false);
 
 const loadProject = function () {
-    let id = location.hash.substring(1);
+    let id = location.hash.substring(1).split(',')[0];
     if (id.length < 1 || !isFinite(id)) {
         id = projectInput.value;
     }
@@ -310,7 +310,7 @@ class ProfilerRun {
             dom: document.getElementsByClassName('profile-count-group')[0],
 
             runningStats,
-            maxRecordedTime: 6000
+            maxRecordedTime
         });
 
         const frames = this.frames = new Frames(profiler);
@@ -388,10 +388,21 @@ window.onload = function () {
             .innerText = progress.complete;
     }).on(storage);
 
+    let warmUpTime = 4000;
+    let maxRecordedTime = 6000;
+
+    if (location.hash) {
+        const split = location.hash.substring(1).split(',');
+        if (split[1] && split[1].length > 0) {
+            warmUpTime = Number(split[1]);
+        }
+        maxRecordedTime = Number(split[2] || '0') || 6000;
+    }
+
     new ProfilerRun({
         vm,
-        warmUpTime: 4000,
-        maxRecordedTime: 6000
+        warmUpTime,
+        maxRecordedTime
     }).run();
 
     // Instantiate the renderer and connect it to the VM.

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -8,19 +8,21 @@
 </head>
 <body>
   <h2>Scratch VM Benchmark</h2>
-  <p>
+  <p class="description">
     Welcome to the scratch-vm benchmark. This tool helps you profile a scratch
     project. When you load the page, it:
-    <ol>
+    <ol class="description">
       <li>loads the default project and enables turbo mode
       <li>runs the project for 4 seconds to warm up
       <li>profiles for 6 seconds
       <li>stops and reports
     </ol>
   </p>
-  <input type="text" value="119615668">
-  <button class="run">run</button>
-  <p>
+  <div class="run-form">
+      <input type="text" value="119615668">
+      <button class="run">run</button>
+  </div>
+  <p class="run-push">
     <i>Try a different project, like `130041250`</i>
   </p>
 
@@ -43,6 +45,14 @@
       <label>Blocks executed:</label>
       <span class="profile-count-value profile-count-blocks-executed">...</span>
     </div>
+    <a class="share"><div class="profile-count">
+      <label>Share this report</label>
+    </div></a>
+    <a class="share" target="_parent">
+        <div class="profile-count">
+            <label>Run the full suite</label>
+        </div>
+    </a>
   </div>
 
   <div class="profile-tables">

--- a/src/playground/suite.css
+++ b/src/playground/suite.css
@@ -1,0 +1,45 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+}
+
+.runner-controls {
+    position: absolute;
+    width: 30em;
+    height: 100%;
+    left: 0;
+    right: 30em;
+    top: 0;
+    bottom: 0;
+    overflow: scroll;
+    padding: 1em;
+    box-sizing: border-box;
+}
+
+.bench-frame-owner {
+    position: absolute;
+    width: calc(100% - 30em);
+    height: 100%;
+    left: 30em;
+    right: 100%;
+    top: 0;
+    bottom: 0;
+}
+
+.fixture-project {
+    display: inline-block;
+}
+
+.fixture-warm-up {
+    display: inline-block;
+}
+
+.fixture-recording {
+    display: inline-block;
+}
+
+.result-status {
+    float: right;
+}

--- a/src/playground/suite.css
+++ b/src/playground/suite.css
@@ -5,6 +5,10 @@ html, body {
     overflow: hidden;
 }
 
+iframe {
+    border: none;
+}
+
 .runner-controls {
     position: absolute;
     width: 30em;
@@ -15,6 +19,7 @@ html, body {
     bottom: 0;
     overflow: scroll;
     padding: 1em;
+    padding-top: 0;
     box-sizing: border-box;
 }
 
@@ -28,8 +33,24 @@ html, body {
     bottom: 0;
 }
 
+.controls {
+    margin-bottom: 1em;
+}
+
+.legend {
+    margin: 1em 0;
+}
+
+.result-view {
+    border-bottom: 1px solid #ccc;
+    border-spacing: 0;
+    border-collapse: collapse;
+    padding: 5px;
+}
+
 .fixture-project {
     display: inline-block;
+    clear: both;
 }
 
 .fixture-warm-up {
@@ -40,6 +61,18 @@ html, body {
     display: inline-block;
 }
 
+.result-view.resume {
+    cursor: pointer;
+}
+
 .result-status {
     float: right;
+    text-align: right;
+    margin-left: 0.3em;
+}
+
+.compare-file {
+    cursor: pointer;
+    visibility: hidden;
+    width: 0;
 }

--- a/src/playground/suite.html
+++ b/src/playground/suite.html
@@ -1,0 +1,23 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Scratch VM Benchmark Suite</title>
+    <link rel="stylesheet" href="./suite.css" type="text/css" media="screen">
+</head>
+<body>
+    <div class="runner-controls">
+        <h2>Scratch VM Benchmark Suite</h2>
+        <div class="suite-results">
+        
+        </div>
+    </div>
+    <div class="bench-frame-owner">
+        <iframe src="" class="bench-frame" width="100%" height="100%"></iframe>
+    </div>
+
+    <!-- BenchRunner -->
+    <script src="./suite.js" type="text/javascript" charset="utf-8"></script>
+</body>
+</html>

--- a/src/playground/suite.html
+++ b/src/playground/suite.html
@@ -10,11 +10,13 @@
     <div class="runner-controls">
         <h2>Scratch VM Benchmark Suite</h2>
         <div class="suite-results">
-        
+
         </div>
     </div>
+
     <div class="bench-frame-owner">
-        <iframe src="" class="bench-frame" width="100%" height="100%"></iframe>
+        <iframe id="bench_frame" name="bench_frame" src="" class="bench-frame"
+            width="100%" height="100%"></iframe>
     </div>
 
     <!-- BenchRunner -->

--- a/src/playground/suite.js
+++ b/src/playground/suite.js
@@ -1,0 +1,385 @@
+const soon = (() => {
+    let _soon;
+    return () => {
+        if (!_soon) {
+            _soon = Promise.resolve()
+                .then(() => {
+                    _soon = null;
+                });
+        }
+        return _soon;
+    };
+})();
+
+class Emitter {
+    constructor () {
+        Object.defineProperty(this, '_listeners', {
+            value: {},
+            enumerable: false
+        });
+    }
+    on (name, listener, context) {
+        if (!this._listeners[name]) {
+            this._listeners[name] = [];
+        }
+
+        this._listeners[name].push(listener, context);
+    }
+    off (name, listener, context) {
+        if (this._listeners[name]) {
+            if (listener) {
+                for (let i = 0; i < this._listeners[name].length; i += 2) {
+                    if (
+                        this._listeners[name][i] === listener &&
+                        this._listeners[name][i + 1] === context) {
+                        this._listeners[name].splice(i, 2);
+                        i -= 2;
+                    }
+                }
+            } else {
+                for (let i = 0; i < this._listeners[name].length; i += 2) {
+                    if (this._listeners[name][i + 1] === context) {
+                        this._listeners[name].splice(i, 2);
+                        i -= 2;
+                    }
+                }
+            }
+        }
+    }
+    emit (name, ...args) {
+        if (this._listeners[name]) {
+            for (let i = 0; i < this._listeners[name].length; i += 2) {
+                this._listeners[name][i].call(this._listeners[name][i + 1] || this, ...args);
+            }
+        }
+    }
+}
+
+class BenchFrameStream extends Emitter {
+    constructor (frame) {
+        super();
+
+        this.frame = frame;
+        window.addEventListener('message', message => {
+            this.emit('message', message.data);
+        });
+    }
+
+    send (message) {
+        this.frame.send(message);
+    }
+}
+
+const BENCH_MESSAGE_TYPE = {
+    LOAD: 'BENCH_MESSAGE_LOAD',
+    LOADING: 'BENCH_MESSAGE_LOADING',
+    WARMING_UP: 'BENCH_MESSAGE_WARMING_UP',
+    ACTIVE: 'BENCH_MESSAGE_ACTIVE',
+    COMPLETE: 'BENCH_MESSAGE_COMPLETE'
+};
+
+class BenchUtil {
+    constructor (frame) {
+        this.frame = frame;
+        this.benchStream = new BenchFrameStream(frame);
+    }
+
+    startBench (args) {
+        Promise.resolve()
+            .then(() => new Promise(resolve => setTimeout(resolve, 100)))
+            .then(() => {
+                this.frame.contentWindow.location.assign('about:blank');
+            })
+            .then(() => new Promise(resolve => setTimeout(resolve, 100)))
+            .then(() => {
+                this.frame.contentWindow.location.assign(
+                    `/benchmark/#${args.projectId},${args.warmUpTime},${args.recordingTime}`);
+            });
+    }
+}
+
+const BENCH_STATUS = {
+    INACTIVE: 'BENCH_STATUS_INACTIVE',
+    STARTING: 'BENCH_STATUS_STARTING',
+    LOADING: 'BENCH_STATUS_LOADING',
+    WARMING_UP: 'BENCH_STATUS_WARMING_UP',
+    ACTIVE: 'BENCH_STATUS_ACTIVE',
+    COMPLETE: 'BENCH_STATUS_COMPLETE'
+};
+
+class BenchResult {
+    constructor ({fixture, status = BENCH_STATUS.INACTIVE, frames = null, opcodes = null}) {
+        this.fixture = fixture;
+        this.status = status;
+        this.frames = frames;
+        this.opcodes = opcodes;
+    }
+}
+
+class BenchFixture extends Emitter {
+    constructor ({
+        projectId,
+        warmUpTime = 4000,
+        recordingTime = 6000
+    }) {
+        super();
+
+        this.projectId = projectId;
+        this.warmUpTime = warmUpTime;
+        this.recordingTime = recordingTime;
+    }
+
+    get id () {
+        return `${this.projectId}-${this.warmUpTime}-${this.recordingTime}`;
+    }
+
+    run (util) {
+        return new Promise(resolve => {
+            util.benchStream.on('message', message => {
+                const result = {
+                    fixture: this,
+                    status: BENCH_STATUS.STARTING,
+                    frames: null,
+                    opcodes: null
+                };
+                if (message.type === BENCH_MESSAGE_TYPE.LOADING) {
+                    result.status = BENCH_STATUS.LOADING;
+                } else if (message.type === BENCH_MESSAGE_TYPE.WARMING_UP) {
+                    result.status = BENCH_STATUS.WARMING_UP;
+                } else if (message.type === BENCH_MESSAGE_TYPE.ACTIVE) {
+                    result.status = BENCH_STATUS.ACTIVE;
+                } else if (message.type === BENCH_MESSAGE_TYPE.COMPLETE) {
+                    result.status = BENCH_STATUS.COMPLETE;
+                    result.frames = message.frames;
+                    result.opcodes = message.opcodes;
+                    resolve(new BenchResult(result));
+                    util.benchStream.off('message', null, this);
+                }
+                this.emit('result', new BenchResult(result));
+            }, this);
+            util.startBench(this);
+        });
+    }
+}
+
+class BenchSuiteResult extends Emitter {
+    constructor ({suite, results = []}) {
+        super();
+
+        this.suite = suite;
+        this.results = results;
+
+        if (suite) {
+            suite.on('result', result => {
+                if (result.status === BENCH_STATUS.COMPLETE) {
+                    this.results.push(results);
+                    this.emit('add', this);
+                }
+            });
+        }
+    }
+}
+
+class BenchSuite extends Emitter {
+    constructor (fixtures = []) {
+        super();
+
+        this.fixtures = fixtures;
+    }
+
+    add (fixture) {
+        this.fixtures.push(fixture);
+    }
+
+    run (util) {
+        return new Promise(resolve => {
+            const fixtures = this.fixtures.slice();
+            const results = [];
+            const push = result => {
+                result.fixture.off('result', null, this);
+                results.push(result);
+            };
+            const emitResult = this.emit.bind(this, 'result');
+            const pop = () => {
+                const fixture = fixtures.shift();
+                if (fixture) {
+                    fixture.on('result', emitResult, this);
+                    fixture.run(util)
+                        .then(push)
+                        .then(pop);
+                } else {
+                    resolve(new BenchSuiteResult({suite: this, results}));
+                }
+            };
+            pop();
+        });
+    }
+}
+
+class BenchRunner extends Emitter {
+    constructor ({frame, suite}) {
+        super();
+
+        this.frame = frame;
+        this.suite = suite;
+        this.util = new BenchUtil(frame);
+    }
+
+    run () {
+        return this.suite.run(this.util);
+    }
+}
+
+const viewNames = {
+    [BENCH_STATUS.INACTIVE]: 'Inactive',
+    [BENCH_STATUS.STARTING]: 'Starting',
+    [BENCH_STATUS.LOADING]: 'Loading',
+    [BENCH_STATUS.WARMING_UP]: 'Warming Up',
+    [BENCH_STATUS.ACTIVE]: 'Active',
+    [BENCH_STATUS.COMPLETE]: 'Complete'
+};
+
+class BenchResultView {
+    constructor ({result}) {
+        this.result = result;
+        this.dom = document.createElement('div');
+    }
+
+    update (result) {
+        soon().then(() => this.render(result));
+    }
+
+    render (newResult = this.result) {
+        const blockFunctionFrame = (newResult.frames ? newResult.frames : [])
+            .find(frame => frame.name === 'blockFunction');
+        const stepThreadsInnerFrame = (newResult.frames ? newResult.frames : [])
+            .find(frame => frame.name === 'Sequencer.stepThreads#inner');
+
+        const blocksPerSecond = blockFunctionFrame ?
+            (blockFunctionFrame.executions / (stepThreadsInnerFrame.totalTime / 1000)) | 0 :
+            0;
+
+        this.dom.innerHTML = `
+            <div class="fixture-project">
+                <label>Project ID</label> <a
+                    href="/playground/#${newResult.fixture.projectId}"
+                    >${newResult.fixture.projectId}</a>
+            </div>
+            (<span class="fixture-warm-up">${newResult.fixture.warmUpTime / 1000}s</span>
+            <span class="fixture-recording">${newResult.fixture.recordingTime / 1000}s</span>)
+            <div class="result-status">
+                ${blockFunctionFrame ? `${blocksPerSecond} blocks/s` : viewNames[newResult.status]}
+            </div>
+        `;
+
+        this.result = newResult;
+        return this;
+    }
+}
+
+class BenchSuiteResultView {
+    constructor ({runner}) {
+        this.runner = runner;
+        this.suite = runner.suite;
+        this.views = {};
+        this.dom = document.createElement('div');
+
+        const {suite} = runner;
+        for (const fixture of suite.fixtures) {
+            this.views[fixture.id] = new BenchResultView({result: new BenchResult({fixture})});
+            this.dom.appendChild(this.views[fixture.id].render().dom);
+        }
+
+        suite.on('result', result => {
+            this.views[result.fixture.id].update(result);
+        });
+    }
+
+    render () {
+        return this;
+    }
+}
+
+window.onload = function () {
+    const suite = new BenchSuite();
+
+    suite.add(new BenchFixture({
+        projectId: 130041250,
+        warmUpTime: 0,
+        recordingTime: 2000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 130041250,
+        warmUpTime: 4000,
+        recordingTime: 6000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 14844969,
+        warmUpTime: 0,
+        recordingTime: 2000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 14844969,
+        warmUpTime: 1000,
+        recordingTime: 6000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 173918262,
+        warmUpTime: 0,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 173918262,
+        warmUpTime: 5000,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 155128646,
+        warmUpTime: 0,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 155128646,
+        warmUpTime: 5000,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 89811578,
+        warmUpTime: 0,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 89811578,
+        warmUpTime: 5000,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 139193539,
+        warmUpTime: 0,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 139193539,
+        warmUpTime: 5000,
+        recordingTime: 5000
+    }));
+
+    const frame = document.getElementsByTagName('iframe')[0];
+    const runner = new BenchRunner({frame, suite});
+    const resultsView = new BenchSuiteResultView({runner});
+
+    document.getElementsByClassName('suite-results')[0].appendChild(resultsView.dom);
+
+    runner.run();
+};


### PR DESCRIPTION
### Resolves

Related https://github.com/LLK/scratch-vm/issues/554

### Proposed Changes

- Add benchmark suite
- The individual benchmark at `playground/index.html` displays a link to the suite page after running
- Control individual benchmark warm up and recording time as url components in the hash
- Serialize individual benchmark data into its URL
- A share link is displayed after the run with that encoded URL
- Suite reports can be opened in the running frame for easy viewing
- `Save Reports` as a JSON download and `Compare Reports` to load that JSON in a future run to compare changes made to the VM

### Reason for Changes

The individual benchmark page was a stepping stone to this to provide a more representative view of performance across varying Scratch projects. The suite executes multiple projects in order with varying warm up and recording times.

Two high level performance statistics are immediately presented, steps per second and blocks per second. The steps per second are the number of times any thread is run until it yields or completes during one second. The blocks per second are the number of VM script blocks executed in a second. VM bound projects regularly show a similar number of blocks per second with steps per second being a representation of the complexity of the threads. Lower steps per second with a VM bound number of blocks per seconds relates to a higher number of blocks per step. Blocks per second lower than the VM bound value likely indicates a currently expensive block function being executed like `pen_stamp`. Lower blocks per second may also indicate a simple project or that the project is render bound.

More details can be viewed by click the steps per second and blocks per second values. Either opening in the benchmark frame or in a new tab.

All of the benchmark suite's reports can be saved together with the `Save Reports` link. This creates a JSON download to the local system that can be loaded with `Compare Reports` in a future run, during or after the run, to see side by side steps and blocks per second values. Or the second values can be clicked to see the other recorded performance values. This is great for recording a run and comparing later against the VM with an optimization implemented. There will be some margin for error between any two runs depending on other work the testing system may be doing.

Example benchmark run:
![1-alt-suite](https://user-images.githubusercontent.com/833298/35061529-80ac1576-fb8f-11e7-85c0-8a4cbb2256cb.gif)

Example saving reports and re-running against the loaded report:
![2-alt-suite](https://user-images.githubusercontent.com/833298/35061530-80b58c3c-fb8f-11e7-834b-5e9c74c7f5e3.gif)

Example navigating detailed reports between two executions:
![3-alt-suite](https://user-images.githubusercontent.com/833298/35061531-80c151ac-fb8f-11e7-8243-9aeeefc3e9bb.gif)
