### PR TITLE
Fix music extension asset loading on safari

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -97,10 +97,23 @@ class Scratch3MusicBlocks {
     _loadSound (fileName, index, bufferArray) {
         if (!this.runtime.storage) return;
         if (!this.runtime.audioEngine) return;
+        if (!this.runtime.audioEngine.audioContext) return;
         return this.runtime.storage.load(this.runtime.storage.AssetType.Sound, fileName, 'mp3')
-            .then(soundAsset =>
-                this.runtime.audioEngine.audioContext.decodeAudioData(soundAsset.data.buffer)
-            )
+            .then(soundAsset => {
+                const context = this.runtime.audioEngine.audioContext;
+                // Check for newer promise-based API
+                if (context.decodeAudioData.length === 1) {
+                    return context.decodeAudioData(soundAsset.data.buffer);
+                } else { // eslint-disable no-else-return
+                    // Fall back to callback API
+                    return new Promise((resolve, reject) =>
+                        context.decodeAudioData(soundAsset.data.buffer,
+                            buffer => resolve(buffer),
+                            error => reject(error)
+                        )
+                    );
+                }
+            })
             .then(buffer => {
                 bufferArray[index] = buffer;
             });

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -104,7 +104,7 @@ class Scratch3MusicBlocks {
                 // Check for newer promise-based API
                 if (context.decodeAudioData.length === 1) {
                     return context.decodeAudioData(soundAsset.data.buffer);
-                } else { // eslint-disable no-else-return
+                } else { // eslint-disable-line no-else-return
                     // Fall back to callback API
                     return new Promise((resolve, reject) =>
                         context.decodeAudioData(soundAsset.data.buffer,


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/902

### Proposed Changes

When loading music extension sound assets, include a fallback from the promise-based API for audio decoding to the callback API. 

Note that this reveals another safari bug where the bufferSource onended function doesn't fire... I'll file another issue for that.

### Reason for Changes

This change is required to support both Safari (callback only) and Firefox (promise only).

This code is unfortunately partially redundant with code in the audio engine [here](https://github.com/LLK/scratch-audio/blob/84fdf5c76a41a4960e34282ea96687d9ef19d6aa/src/index.js#L204), but that doesn't seem important enough to refactor it.