### PR TITLE
Keep block xml up-to-date after renaming a variable.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -319,6 +319,10 @@ class Blocks {
             break;
         case 'var_rename':
             stage.renameVariable(e.varId, e.newName);
+            // Update all the blocks that use the renamed variable.
+            if (optRuntime) {
+                optRuntime.updateBlocksAfterVarRename(e.varId, e.newName);
+            }
             break;
         case 'var_delete':
             stage.deleteVariable(e.varId);

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -321,7 +321,11 @@ class Blocks {
             stage.renameVariable(e.varId, e.newName);
             // Update all the blocks that use the renamed variable.
             if (optRuntime) {
-                optRuntime.updateBlocksAfterVarRename(e.varId, e.newName);
+                const targets = optRuntime.targets;
+                for (let i = 0; i < targets.length; i++) {
+                    const currTarget = targets[i];
+                    currTarget.blocks.updateBlocksAfterVarRename(e.varId, e.newName);
+                }
             }
             break;
         case 'var_delete':
@@ -415,7 +419,7 @@ class Blocks {
             const isSpriteSpecific = optRuntime.monitorBlockInfo.hasOwnProperty(block.opcode) &&
                 optRuntime.monitorBlockInfo[block.opcode].isSpriteSpecific;
             block.targetId = isSpriteSpecific ? optRuntime.getEditingTarget().id : null;
-            
+
             if (wasMonitored && !block.isMonitored) {
                 optRuntime.requestRemoveMonitor(block.id);
             } else if (!wasMonitored && block.isMonitored) {
@@ -548,6 +552,29 @@ class Blocks {
         delete this._blocks[blockId];
 
         this.resetCache();
+    }
+
+    /**
+     * Keep blocks up to date after a variable gets renamed.
+     * @param {string} varId The id of the variable that was renamed
+     * @param {string} newName The new name of the variable that was renamed
+     */
+    updateBlocksAfterVarRename (varId, newName) {
+        const blocks = this._blocks;
+        for (const blockId in blocks) {
+            let varOrListField = null;
+            if (blocks[blockId].fields.VARIABLE) {
+                varOrListField = blocks[blockId].fields.VARIABLE;
+            } else if (blocks[blockId].fields.LIST) {
+                varOrListField = blocks[blockId].fields.LIST;
+            }
+            if (varOrListField) {
+                const currFieldId = varOrListField.id;
+                if (varId === currFieldId) {
+                    varOrListField.value = newName;
+                }
+            }
+        }
     }
 
     // ---------------------------------------------------------------------

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1581,6 +1581,33 @@ class Runtime extends EventEmitter {
     disableProfiling () {
         this.profiler = null;
     }
+
+    /**
+     * Keep blocks up to date after a variable gets renamed.
+     * @param {string} varId The id of the variable that was renamed
+     * @param {string} newName The new name of the variable that was renamed
+     */
+    updateBlocksAfterVarRename (varId, newName) {
+        const allTargets = this.targets;
+        for (let i = 0; i < allTargets.length; i++) {
+            const currTarget = allTargets[i];
+            const currBlocks = currTarget.blocks._blocks;
+            for (const blockId in currBlocks) {
+                let varOrListField = null;
+                if (currBlocks[blockId].fields.VARIABLE) {
+                    varOrListField = currBlocks[blockId].fields.VARIABLE;
+                } else if (currBlocks[blockId].fields.LIST) {
+                    varOrListField = currBlocks[blockId].fields.LIST;
+                }
+                if (varOrListField) {
+                    const currFieldId = varOrListField.id;
+                    if (varId === currFieldId) {
+                        varOrListField.value = newName;
+                    }
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1581,33 +1581,6 @@ class Runtime extends EventEmitter {
     disableProfiling () {
         this.profiler = null;
     }
-
-    /**
-     * Keep blocks up to date after a variable gets renamed.
-     * @param {string} varId The id of the variable that was renamed
-     * @param {string} newName The new name of the variable that was renamed
-     */
-    updateBlocksAfterVarRename (varId, newName) {
-        const allTargets = this.targets;
-        for (let i = 0; i < allTargets.length; i++) {
-            const currTarget = allTargets[i];
-            const currBlocks = currTarget.blocks._blocks;
-            for (const blockId in currBlocks) {
-                let varOrListField = null;
-                if (currBlocks[blockId].fields.VARIABLE) {
-                    varOrListField = currBlocks[blockId].fields.VARIABLE;
-                } else if (currBlocks[blockId].fields.LIST) {
-                    varOrListField = currBlocks[blockId].fields.LIST;
-                }
-                if (varOrListField) {
-                    const currFieldId = varOrListField.id;
-                    if (varId === currFieldId) {
-                        varOrListField.value = newName;
-                    }
-                }
-            }
-        }
-    }
 }
 
 /**


### PR DESCRIPTION
### Resolves

Resolves #909 
Resolves #723

### Proposed Changes

Keep scratch-vm up-to-date after being notified that a variable has been renamed. Go through all of the blocks on all of the runtime targets and change the value of the field of the blocks that refer to the renamed variable. Update the value of these fields with the name of the new variable.

### Reason for Changes

As of [the variables_by_id work in scratch-blocks](https://github.com/LLK/scratch-blocks/pull/1350), scratch-blocks no longer emits individual block change events when a variable is renamed. This is because the block field values now refer to the id of the variable, and the id of the variable does not change if a variable is renamed. Thus, the vm emits outdated xml and JSON for the blocks that refer to any variable that has been renamed.


### Test Coverage

Existing tests pass.