### PR TITLE
Push reported

### DIFF
--- a/src/engine/blocks-execute-cache.js
+++ b/src/engine/blocks-execute-cache.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview
+ * Access point for private method shared between blocks.js and execute.js for
+ * caching execute information.
+ */
+
+/**
+ * A private method shared with execute to build an object containing the block
+ * information execute needs and that is reset when other cached Blocks info is
+ * reset.
+ * @param {Blocks} blocks Blocks containing the expected blockId
+ * @param {string} blockId blockId for the desired execute cache
+ */
+exports.getCached = function () {
+    throw new Error('blocks.js has not initialized BlocksExecuteCache');
+};
+
+// Call after the default throwing getCached is assigned for Blocks to replace.
+require('./blocks');

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -4,6 +4,7 @@ const xmlEscape = require('../util/xml-escape');
 const MonitorRecord = require('./monitor-record');
 const Clone = require('../util/clone');
 const {Map} = require('immutable');
+const BlocksExecuteCache = require('./blocks-execute-cache');
 
 /**
  * @fileoverview
@@ -47,7 +48,14 @@ class Blocks {
              * Cache procedure definitions by block id
              * @type {object.<string, ?string>}
              */
-            procedureDefinitions: {}
+            procedureDefinitions: {},
+
+            /**
+             * A cache for execute to use and store on. Only available to
+             * execute.
+             * @type {object.<string, object>}
+             */
+            _executeCached: {}
         };
 
     }
@@ -335,6 +343,7 @@ class Blocks {
         this._cache.inputs = {};
         this._cache.procedureParamNames = {};
         this._cache.procedureDefinitions = {};
+        this._cache._executeCached = {};
     }
 
     /**
@@ -411,7 +420,7 @@ class Blocks {
             const isSpriteSpecific = optRuntime.monitorBlockInfo.hasOwnProperty(block.opcode) &&
                 optRuntime.monitorBlockInfo[block.opcode].isSpriteSpecific;
             block.targetId = isSpriteSpecific ? optRuntime.getEditingTarget().id : null;
-            
+
             if (wasMonitored && !block.isMonitored) {
                 optRuntime.requestRemoveMonitor(block.id);
             } else if (!wasMonitored && block.isMonitored) {
@@ -696,5 +705,32 @@ class Blocks {
         if (this._blocks[topBlockId]) this._blocks[topBlockId].topLevel = false;
     }
 }
+
+/**
+ * A private method shared with execute to build an object containing the block
+ * information execute needs and that is reset when other cached Blocks info is
+ * reset.
+ * @param {Blocks} blocks Blocks containing the expected blockId
+ * @param {string} blockId blockId for the desired execute cache
+ * @return {object} execute cache object
+ */
+BlocksExecuteCache.getCached = function (blocks, blockId) {
+    const block = blocks.getBlock(blockId);
+    if (typeof block === 'undefined') return null;
+    let cached = blocks._cache._executeCached[blockId];
+    if (typeof cached !== 'undefined') {
+        return cached;
+    }
+
+    cached = {
+        _initialized: false,
+        opcode: blocks.getOpcode(block),
+        fields: blocks.getFields(block),
+        inputs: blocks.getInputs(block),
+        mutation: blocks.getMutation(block)
+    };
+    blocks._cache._executeCached[blockId] = cached;
+    return cached;
+};
 
 module.exports = Blocks;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -113,14 +113,6 @@ const RECURSIVE = true;
  */
 const execute = function (sequencer, thread, recursiveCall) {
     const runtime = sequencer.runtime;
-    const target = thread.target;
-
-    // Stop if block or target no longer exists.
-    if (target === null) {
-        // No block found: stop the thread; script no longer exists.
-        sequencer.retireThread(thread);
-        return;
-    }
 
     // Current block to execute is the one on the top of the stack.
     const currentBlockId = thread.peekStack();

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -126,12 +126,7 @@ const execute = function (sequencer, thread, recursiveCall) {
     const currentBlockId = thread.peekStack();
     const currentStackFrame = thread.peekStackFrame();
 
-    let blockContainer;
-    if (thread.updateMonitor) {
-        blockContainer = runtime.monitorBlocks;
-    } else {
-        blockContainer = target.blocks;
-    }
+    let blockContainer = thread.blockContainer;
     let block = blockContainer.getBlock(currentBlockId);
     if (typeof block === 'undefined') {
         blockContainer = runtime.flyoutBlocks;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -861,6 +861,9 @@ class Runtime extends EventEmitter {
         thread.target = target;
         thread.stackClick = opts.stackClick;
         thread.updateMonitor = opts.updateMonitor;
+        thread.blockContainer = opts.updateMonitor ?
+            this.monitorBlocks :
+            target.blocks;
 
         thread.pushStack(id);
         this.threads.push(thread);
@@ -890,6 +893,7 @@ class Runtime extends EventEmitter {
         newThread.target = thread.target;
         newThread.stackClick = thread.stackClick;
         newThread.updateMonitor = thread.updateMonitor;
+        newThread.blockContainer = thread.blockContainer;
         newThread.pushStack(thread.topBlock);
         const i = this.threads.indexOf(thread);
         if (i > -1) {

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -197,7 +197,11 @@ class Sequencer {
                 this.runtime.profiler.records.push(
                     this.runtime.profiler.START, executeProfilerId, null, performance.now());
             }
-            execute(this, thread);
+            if (thread.target === null) {
+                this.retireThread(thread);
+            } else {
+                execute(this, thread);
+            }
             if (this.runtime.profiler !== null) {
                 // this.runtime.profiler.stop();
                 this.runtime.profiler.records.push(this.runtime.profiler.STOP, performance.now());

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -124,7 +124,8 @@ class Thread {
             this.stackFrames.push({
                 isLoop: false, // Whether this level of the stack is a loop.
                 warpMode: warpMode, // Whether this level is in warp mode.
-                reported: {}, // Collects reported input values.
+                justReported: null, // Reported value from just executed block.
+                reported: {}, // Persists reported inputs during async block.
                 waitingReporter: null, // Name of waiting reporter.
                 params: {}, // Procedure parameters.
                 executionContext: {} // A context passed to block implementations.
@@ -209,9 +210,8 @@ class Thread {
      */
     pushReportedValue (value) {
         const parentStackFrame = this.peekParentStackFrame();
-        if (parentStackFrame) {
-            const waitingReporter = parentStackFrame.waitingReporter;
-            parentStackFrame.reported[waitingReporter] = value;
+        if (parentStackFrame !== null) {
+            parentStackFrame.justReported = value;
         }
     }
 

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -43,6 +43,12 @@ class Thread {
         this.target = null;
 
         /**
+         * The Blocks this thread will execute.
+         * @type {Blocks}
+         */
+        this.blockContainer = null;
+
+        /**
          * Whether the thread requests its script to glow during this frame.
          * @type {boolean}
          */

--- a/test/unit/engine_sequencer.js
+++ b/test/unit/engine_sequencer.js
@@ -91,7 +91,8 @@ const generateThread = function (runtime) {
     rt.blocks.createBlock(generateBlock(next));
     th.pushStack(next);
     th.target = rt;
-    
+    th.blockContainer = rt.blocks;
+
     runtime.threads.push(th);
 
     return th;

--- a/test/unit/engine_thread.js
+++ b/test/unit/engine_thread.js
@@ -89,8 +89,8 @@ test('pushReportedValue', t => {
     th.pushStack('arbitraryString');
     th.pushStack('secondString');
     th.pushReportedValue('value');
-    t.strictEquals(th.peekParentStackFrame().reported.null, 'value');
-    
+    t.strictEquals(th.peekParentStackFrame().justReported, 'value');
+
     t.end();
 });
 


### PR DESCRIPTION
### Resolves

#781

### Proposed Changes

- Report at `parentStackFrame.justReported`
- Fill `currentStackFrame.reported` if the thread pauses.
- Test that `thread`.target is not null before calling `execute` from a Sequencer.
- Assign a thread's Blocks to `blockContainer`.
- Add a third optional argument argument that lets execute calls let executes they make know they are being recursed and let some logic shortcut faster.
- Add a Blocks cache only available to `execute`.

### Reason for Changes

#### `justReported`

Speed up block reporting by normally building one object, `argValues`, dynamically. Reporting block results to `justReported` lets `execute` read that value from a member statically. If the thread pauses values already stored on argValues can be copied to `currentStackFrame.reported`. For execute overall this makes passing a resulting value from one execute call to the parent execute call faster with less dynamic stores on and lookups in `reported`.

#### `target.thread` / `blockContainer`

Move `target.thread` null check from `execute` to Sequencer. Move `blockContainer` lookup to a new Thread member. This moves some branching out of `execute` so they happen less (`target.thread`) or not at all (`blockContainer`).

#### `BlocksExecuteCache`

A lot of the test results and lookups in `execute` relate to the executed block. `BlocksExecuteCache` presents an access point to `execute` from `Blocks` to a private cache that is reset with the other `Blocks` caches. `execute` then also initializes the per-block-cache with branch test results and lookups it would make up for every execution of that individual block, saving time reconsidering a test whose results will not change for that block or on lookups that will not change.

- Cache a reference to blockFunction and the isHat value (saves dynamic string lookups)
- Cache the shadow value if the block is a shadow value (saves calling Object.keys on fields and inputs)
- Cache local execute cache copies of block inputs and fields to know that the keys are their own properties and to remove input.custom_block if its there
- Cache fields VARIABLE, LIST, or BROADCAST_OPTION and booleans to check if that is what fields contains to assign these regular fields to argValues quickly

### Numbers

Here are some gathered metrics from the benchmark suite using blocks performed per second.

Samsung Chromebook Plus and iPhone 6S+ see big gains.

<del>Projects on a Samsung Chromebook Plus are 25% to 50% faster.</del>

<details>
<summary>Samsung Chromebook Pro</summary>

Project ID          | before |  after |    %
--------------------|--------|--------|-----
Floating Blocks     | 252539 | 278216 | 10.1
Scratch Cat         | 292586 | 319532 |  9.2
Bouncy Heros        | 146079 | 153622 |  5.1
Stacky Towers       | 258688 | 296762 | 14.7 
3D Solar System     | 245551 | 291313 | 18.6
Pixel Art Maker     | 284832 | 323312 | 13.5
Dynamic Maurer Rose |  15780 |  16842 |  6.7

</details>

<details>
<summary>Samsung Chromebook Plus</summary>

Project ID          | before |  after |    %
--------------------|--------|--------|-----
Floating Blocks     |  57723 |  65991 | 14.3
Scratch Cat         |  76960 |  81804 |  6.2
Bouncy Heros        |  38491 |  42662 | 10.8
Stacky Towers       |  71616 |  76758 |  7.1
3D Solar System     |  64093 |  79020 | 23.2
Pixel Art Maker     |  69604 |  81340 | 16.8
Dynamic Maurer Rose |  17550 |  18373 |  4.6

</details>

<details>
<summary>iPhone 6S+</summary>

Project ID          | before |  after |    %
--------------------|--------|--------|-----
Floating Blocks     | 146089 | 173187 | 18.5
Scratch Cat         | 233421 | 248157 |  6.3
Bouncy Heros        |  65755 |  65755 |  0.0
Stacky Towers       | 123809 | 191943 | 55.0
3D Solar System     | 306352 | 476707 | 55.6
Pixel Art Maker     | 211448 | 291472 | 37.8
Dynamic Maurer Rose |  28037 |  37821 | 34.8

</details>

<details>
<summary>15" 2017 MacBookPro</summary>

Project ID          | before |  after |    %
--------------------|--------|--------|-----
Floating Blocks     | 412900 | 445739 |  7.9
Scratch Cat         | 482179 | 520419 |  7.9
Bouncy Heros        | 181250 | 208117 | 14.8
Stacky Towers       | 485965 | 529686 |  8.9
3D Solar System     | 458371 | 491895 |  7.3
Pixel Art Maker     | 467683 | 501665 |  7.2
Dynamic Maurer Rose |  79143 |  81413 |  2.8

</details>

### Test Coverage

Update affected thread and sequencer tests. 
