### PR TITLE
Playground: load renderer as UMD

### DIFF
--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -476,7 +476,7 @@ const runBenchmark = function () {
 
     // Instantiate the renderer and connect it to the VM.
     const canvas = document.getElementById('scratch-stage');
-    const renderer = new window.RenderWebGL(canvas);
+    const renderer = new window.ScratchRender(canvas);
     Scratch.renderer = renderer;
     vm.attachRenderer(renderer);
     const audioEngine = new window.AudioEngine();

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -83,6 +83,8 @@
   <script src="./vendor.js"></script>
   <!-- Storage module -->
   <script src="./scratch-storage.js"></script>
+  <!-- Stage rendering -->
+  <script src="./scratch-render.js"></script>
   <!-- VM -->
   <script src="./scratch-vm.js"></script>
   <!-- Playground -->

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,7 +122,7 @@ module.exports = [
                 },
                 {
                     test: require.resolve('scratch-render'),
-                    loader: 'expose-loader?RenderWebGL'
+                    loader: 'expose-loader?ScratchRender'
                 }
             ])
         },
@@ -134,6 +134,8 @@ module.exports = [
                 from: 'node_modules/highlightjs/styles/zenburn.css'
             }, {
                 from: 'node_modules/scratch-storage/dist/web'
+            }, {
+                from: 'node_modules/scratch-render/dist/web'
             }, {
                 from: 'src/playground'
             }])


### PR DESCRIPTION
### Resolves

The recent changes to the renderer's build output packaging broke this repository's playground / benchmark suite. These changes aren't the only way to fix the issue, but this is consistent with the way that the storage module was already being loaded.

### Proposed Changes

Load `ScratchRender` as a separate `<script>` tag in the playground's `index.html` file. This exposes the renderer constructor as `ScratchRender` on the global object, instead of `RenderWebGL` as before.

### Reason for Changes

See LLK/scratch-render#227

### Test Coverage

I tested both the benchmark playground (`index.html`) and the full benchmarking suite (`suite.html`) locally.
