### PR TITLE
round numbers but break tests

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -251,6 +251,10 @@ class Scratch3LooksBlocks {
 
     say (args, util) {
         // @TODO in 2.0 calling say/think resets the right/left bias of the bubble
+        let message = args.MESSAGE;
+        if (typeof message === 'number') {
+            message = message.toFixed(2);
+        }
         this._updateBubble(util.target, 'say', String(args.MESSAGE));
     }
 

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -255,7 +255,8 @@ class Scratch3LooksBlocks {
         if (typeof message === 'number') {
             message = message.toFixed(2);
         }
-        this._updateBubble(util.target, 'say', String(args.MESSAGE));
+        message = String(message);
+        this.runtime.emit('SAY', util.target, 'say', message);
     }
 
     sayforsecs (args, util) {

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -50,3 +50,13 @@ test('getBackdropNumberName can return costume name', t => {
     t.strictEqual(number, 'third name');
     t.end();
 });
+
+test('numbers should be rounded to two decimals in say', t => {
+    const args = {MESSAGE: 3.14159};
+    const sayString = blocks.say(args, util);
+    // This breaks becuase it is not returned,
+    // instead this calls this._updateBubble(util.target, 'say', String(args.MESSAGE));
+    // I'm not familiar
+    t.strictEqual(sayString, '3.14');
+    t.end();
+});

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -1,5 +1,6 @@
 const test = require('tap').test;
 const Looks = require('../../src/blocks/scratch3_looks');
+const Runtime = require('../../src/engine/runtime');
 const util = {
     target: {
         currentCostume: 0, // Internally, current costume is 0 indexed
@@ -52,11 +53,18 @@ test('getBackdropNumberName can return costume name', t => {
 });
 
 test('numbers should be rounded to two decimals in say', t => {
+    const rt = new Runtime();
+    const looks = new Looks(rt);
+
     const args = {MESSAGE: 3.14159};
-    const sayString = blocks.say(args, util);
-    // This breaks becuase it is not returned,
-    // instead this calls this._updateBubble(util.target, 'say', String(args.MESSAGE));
-    // I'm not familiar
-    t.strictEqual(sayString, '3.14');
-    t.end();
+    const expectedSayString = '3.14';
+
+    rt.removeAllListeners('SAY'); // Prevent say blocks from executing
+
+    rt.addListener('SAY', (target, type, sayString) => {
+        t.strictEqual(sayString, expectedSayString);
+        t.end();
+    });
+
+    looks.say(args, util);
 });


### PR DESCRIPTION
### Resolves

Issue from `scratch-gui`: https://github.com/LLK/scratch-gui/issues/1372

### Proposed Changes

Rounds the number before saying it (if the data type is a number).

### Reason for Changes

To match Scratch 2.0 behavior

### Test Coverage

I have added tests, but since this function calls another instead of returning a value, the test is breaking. I'm not sure what the proper way to approach this is. If we were using `sinon` I would set up a spy, but I'm not sure how to do it with `tap`. Here is what I tried:

```JavaScript
test('numbers should be rounded to two decimals in say', t => {
    const args = {MESSAGE: 3.14159};
    const sayString = blocks.say(args, util);
    // This breaks becuase it is not returned,
    // instead this calls this._updateBubble(util.target, 'say', String(args.MESSAGE));
    // I'm not familiar
    t.strictEqual(sayString, '3.14');
    t.end();
});
```

But I am getting this error (which makes sense, I just don't know how to fix it).

```shell
./test/unit/blocks_looks.js ........................... 4/5
  numbers should be rounded to two decimals in say
  not ok target.getCustomState is not a function
    stack: |
      Scratch3LooksBlocks._getBubbleState (src/blocks/scratch3_looks.js:65:34)
      Scratch3LooksBlocks._updateBubble (src/blocks/scratch3_looks.js:208:34)
      Scratch3LooksBlocks.say (src/blocks/scratch3_looks.js:258:14)
      Test.t (test/unit/blocks_looks.js:56:30)
    at:
      line: 65
      column: 34
      file: src/blocks/scratch3_looks.js
      function: Scratch3LooksBlocks._getBubbleState
    type: TypeError
    test: numbers should be rounded to two decimals in say
    source: |
      let bubbleState = target.getCustomState(Scratch3LooksBlocks.STATE_KEY);
```
