### PR TITLE
Clamp pitch effect range to -360 to 360

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -74,7 +74,7 @@ class Scratch3SoundBlocks {
      */
     static get EFFECT_RANGE () {
         return {
-            pitch: {min: -600, max: 600}, // -5 to 5 octaves
+            pitch: {min: -360, max: 360}, // -3 to 3 octaves
             pan: {min: -100, max: 100} // 100% left to 100% right
         };
     }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/899

### Proposed Changes

Reduce the range of the pitch effect so that it is clamped from -360 to 360 (from three octaves down to three octaves up).

### Reason for Changes

Previously the pitch effect was clamped from -600 to 600. It is 120 steps per octave, so that's from -5 octaves to +5 octaves of pitch shifting. Maybe that was too much. :D

The issues at extreme parts of the range include:

- At extreme low values, you can't hear anything.
- At extreme low values, the sound is too long. Pitch effect of -600 is shifted down 5 octaves, which will double the duration 5 times. So a sound that's 1 second long will last 32 seconds!
- At extreme high values, the sound can be become so short it's just a tiny click.
- At both high and low values, the sound becomes increasingly distorted (I think this is mostly interpolation and aliasing artifacts)

I did some experimenting with a variety of sounds, and I think a range of three octaves in either direction, -360 to 360, will work well. Generally, sounds are still audible at both -360 and 360, and the distortion is not terrible. At -360, the duration is doubled three times, so a 1 second sound lasts 8 seconds, which is long but not crazy.