### PR TITLE
Only measure loudness once per step

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -236,7 +236,7 @@ class Scratch3SensingBlocks {
 
     getLoudness () {
         if (typeof this.runtime.audioEngine === 'undefined') return -1;
-        if (typeof this.runtime.currentStepTime === 'undefined') return -1;
+        if (this.runtime.currentStepTime === null) return -1;
 
         // Only measure loudness once per step
         const timeSinceLoudness = this._timer.time() - this._cachedLoudnessTimestamp;

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -16,6 +16,24 @@ class Scratch3SensingBlocks {
         this._answer = '';
 
         /**
+         * The timer utility.
+         * @type {Timer}
+         */
+        this._timer = new Timer();
+
+        /**
+         * The stored microphone loudness measurement.
+         * @type {number}
+         */
+        this._cachedLoudness = -1;
+
+        /**
+         * The time of the most recent microphone loudness measurement.
+         * @type {number}
+         */
+        this._cachedLoudnessTimestamp = 0;
+
+        /**
          * The list of queued questions and respective `resolve` callbacks.
          * @type {!Array}
          */
@@ -24,8 +42,6 @@ class Scratch3SensingBlocks {
         this.runtime.on('ANSWER', this._onAnswer.bind(this));
         this.runtime.on('PROJECT_START', this._resetAnswer.bind(this));
         this.runtime.on('PROJECT_STOP_ALL', this._clearAllQuestions.bind(this));
-
-        this.timer = new Timer();
     }
 
     /**
@@ -223,16 +239,14 @@ class Scratch3SensingBlocks {
         if (typeof this.runtime.currentStepTime === 'undefined') return -1;
 
         // Only measure loudness once per step
-        if (this.loudnessTime) {
-            const timeSinceLoudness = this.timer.time() - this.loudnessTime;
-            if (timeSinceLoudness < this.runtime.currentStepTime) {
-                return this.loudness;
-            }
+        const timeSinceLoudness = this._timer.time() - this._cachedLoudnessTimestamp;
+        if (timeSinceLoudness < this.runtime.currentStepTime) {
+            return this._cachedLoudness;
         }
 
-        this.loudnessTime = this.timer.time();
-        this.loudness = this.runtime.audioEngine.getLoudness();
-        return this.loudness;
+        this._cachedLoudnessTimestamp = this._timer.time();
+        this._cachedLoudness = this.runtime.audioEngine.getLoudness();
+        return this._cachedLoudness;
     }
 
     getAttributeOf (args) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-audio/issues/72

### Proposed Changes

This change stores the calculated loudness value and the time. When loudness is requested again, it uses the stored value unless more than a frame's duration has passed. 

### Reason for Changes

Calculating the loudness in the audio engine is fairly expensive, and the audio buffers update at a rate close to the frame rate, so we should calculate the loudness value ideally at most once per frame.