### PR TITLE
Renaming sprite/costume/sound/backdrop updates corresponding blocks.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -584,7 +584,8 @@ class Blocks {
      * @param {string} oldName The old name of the asset that was renamed.
      * @param {string} newName The new name of the asset that was renamed.
      * @param {string} assetType String representation of the kind of asset
-     * that was renamed. This can be one of 'costume', 'sound', or 'backdrop'.
+     * that was renamed. This can be one of 'sprite','costume', 'sound', or
+     * 'backdrop'.
      */
     updateAssetName (oldName, newName, assetType) {
         let getAssetField;
@@ -594,6 +595,8 @@ class Blocks {
             getAssetField = this._getSoundField.bind(this);
         } else if (assetType === 'backdrop') {
             getAssetField = this._getBackdropField.bind(this);
+        } else if (assetType === 'sprite') {
+            getAssetField = this._getSpriteField.bind(this);
         } else {
             return;
         }
@@ -647,6 +650,29 @@ class Blocks {
         const block = this.getBlock(blockId);
         if (block && block.fields.hasOwnProperty('BACKDROP')) {
             return block.fields.BACKDROP;
+        }
+        return null;
+    }
+
+    /**
+     * Helper function to retrieve a sprite menu field from a block given its id.
+     * @param {string} blockId A unique identifier for a block
+     * @return {?object} The sprite menu field of the block with the given block id.
+     * Null, if either a block with the given id doesn't exist or if a sprite menu field
+     * does not exist on the block with the given id.
+     */
+    _getSpriteField (blockId) {
+        const block = this.getBlock(blockId);
+        if (!block) {
+            return null;
+        }
+        const spriteMenuNames = ['TOWARDS', 'TO', 'OBJECT', 'VIDEOONMENU2',
+            'DISTANCETOMENU', 'TOUCHINGOBJECTMENU', 'CLONE_OPTION'];
+        for (let i = 0; i < spriteMenuNames.length; i++) {
+            const menuName = spriteMenuNames[i];
+            if (block.fields.hasOwnProperty(menuName)) {
+                return block.fields[menuName];
+            }
         }
         return null;
     }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -577,6 +577,80 @@ class Blocks {
         }
     }
 
+    /**
+     * Update blocks after a sound, costume, or backdrop gets renamed.
+     * Any block referring to the old name of the asset should get updated
+     * to refer to the new name.
+     * @param {string} oldName The old name of the asset that was renamed.
+     * @param {string} newName The new name of the asset that was renamed.
+     * @param {string} assetType String representation of the kind of asset
+     * that was renamed. This can be one of 'costume', 'sound', or 'backdrop'.
+     */
+    updateAssetName (oldName, newName, assetType) {
+        let getAssetField;
+        if (assetType === 'costume') {
+            getAssetField = this._getCostumeField.bind(this);
+        } else if (assetType === 'sound') {
+            getAssetField = this._getSoundField.bind(this);
+        } else if (assetType === 'backdrop') {
+            getAssetField = this._getBackdropField.bind(this);
+        } else {
+            return;
+        }
+        const blocks = this._blocks;
+        for (const blockId in blocks) {
+            const assetField = getAssetField(blockId);
+            if (assetField && assetField.value === oldName) {
+                assetField.value = newName;
+            }
+        }
+    }
+
+    /**
+     * Helper function to retrieve a costume menu field from a block given its id.
+     * @param {string} blockId A unique identifier for a block
+     * @return {?object} The costume menu field of the block with the given block id.
+     * Null if either a block with the given id doesn't exist or if a costume menu field
+     * does not exist on the block with the given id.
+     */
+    _getCostumeField (blockId) {
+        const block = this.getBlock(blockId);
+        if (block && block.fields.hasOwnProperty('COSTUME')) {
+            return block.fields.COSTUME;
+        }
+        return null;
+    }
+
+    /**
+     * Helper function to retrieve a sound menu field from a block given its id.
+     * @param {string} blockId A unique identifier for a block
+     * @return {?object} The sound menu field of the block with the given block id.
+     * Null, if either a block with the given id doesn't exist or if a sound menu field
+     * does not exist on the block with the given id.
+     */
+    _getSoundField (blockId) {
+        const block = this.getBlock(blockId);
+        if (block && block.fields.hasOwnProperty('SOUND_MENU')) {
+            return block.fields.SOUND_MENU;
+        }
+        return null;
+    }
+
+    /**
+     * Helper function to retrieve a backdrop menu field from a block given its id.
+     * @param {string} blockId A unique identifier for a block
+     * @return {?object} The backdrop menu field of the block with the given block id.
+     * Null, if either a block with the given id doesn't exist or if a backdrop menu field
+     * does not exist on the block with the given id.
+     */
+    _getBackdropField (blockId) {
+        const block = this.getBlock(blockId);
+        if (block && block.fields.hasOwnProperty('BACKDROP')) {
+            return block.fields.BACKDROP;
+        }
+        return null;
+    }
+
     // ---------------------------------------------------------------------
 
     /**

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -422,15 +422,11 @@ class RenderedTarget extends Target {
         this.sprite.costumes[costumeIndex].name = newUnusedName;
 
         if (this.isStage) {
-            this.blocks.updateAssetName(oldName, newUnusedName, 'backdrop');
-            // Since this is a backdrop, run through the blocks of the other targets
-            // and update the backdrop name there as well
+            // Since this is a backdrop, go through all targets and
+            // update any blocks referencing the old backdrop name
             const targets = this.runtime.targets;
             for (let i = 0; i < targets.length; i++) {
                 const currTarget = targets[i];
-                if (currTarget.id === this.id) {
-                    continue;
-                }
                 currTarget.blocks.updateAssetName(oldName, newUnusedName, 'backdrop');
             }
         } else {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -417,7 +417,26 @@ class RenderedTarget extends Target {
         const usedNames = this.sprite.costumes
             .filter((costume, index) => costumeIndex !== index)
             .map(costume => costume.name);
-        this.sprite.costumes[costumeIndex].name = StringUtil.unusedName(newName, usedNames);
+        const oldName = this.sprite.costumes[costumeIndex].name;
+        const newUnusedName = StringUtil.unusedName(newName, usedNames);
+        this.sprite.costumes[costumeIndex].name = newUnusedName;
+
+        if (this.isStage) {
+            this.blocks.updateAssetName(oldName, newUnusedName, 'backdrop');
+            // Since this is a backdrop, run through the blocks of the other targets
+            // and update the backdrop name there as well
+            const targets = this.runtime.targets;
+            for (let i = 0; i < targets.length; i++) {
+                const currTarget = targets[i];
+                if (currTarget.id === this.id) {
+                    continue;
+                }
+                currTarget.blocks.updateAssetName(oldName, newUnusedName, 'backdrop');
+            }
+        } else {
+            this.blocks.updateAssetName(oldName, newUnusedName, 'costume');
+        }
+
     }
 
     /**
@@ -462,7 +481,10 @@ class RenderedTarget extends Target {
         const usedNames = this.sprite.sounds
             .filter((sound, index) => soundIndex !== index)
             .map(sound => sound.name);
-        this.sprite.sounds[soundIndex].name = StringUtil.unusedName(newName, usedNames);
+        const oldName = this.sprite.sounds[soundIndex].name;
+        const newUnusedName = StringUtil.unusedName(newName, usedNames);
+        this.sprite.sounds[soundIndex].name = newUnusedName;
+        this.blocks.updateAssetName(oldName, newUnusedName, 'sound');
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -475,7 +475,14 @@ class VirtualMachine extends EventEmitter {
                 const names = this.runtime.targets
                     .filter(runtimeTarget => runtimeTarget.isSprite() && runtimeTarget.id !== target.id)
                     .map(runtimeTarget => runtimeTarget.sprite.name);
-                sprite.name = StringUtil.unusedName(newName, names);
+                const oldName = sprite.name;
+                const newUnusedName = StringUtil.unusedName(newName, names);
+                sprite.name = newUnusedName;
+                const allTargets = this.runtime.targets;
+                for (let i = 0; i < allTargets.length; i++) {
+                    const currTarget = allTargets[i];
+                    currTarget.blocks.updateAssetName(oldName, newName, 'sprite');
+                }
             }
             this.emitTargetsUpdate();
         } else {

--- a/test/unit/engine_blocks.js
+++ b/test/unit/engine_blocks.js
@@ -538,3 +538,211 @@ test('delete inputs', t => {
     t.equal(b._scripts.length, 0);
     t.end();
 });
+
+test('updateAssetName function updates name in sound field', t => {
+    const b = new Blocks();
+    b.createBlock({
+        id: 'foo',
+        fields: {
+            SOUND_MENU: {
+                name: 'SOUND_MENU',
+                value: 'name1'
+            }
+        }
+    });
+    t.equals(b.getBlock('foo').fields.SOUND_MENU.value, 'name1');
+    b.updateAssetName('name1', 'name2', 'sound');
+    t.equals(b.getBlock('foo').fields.SOUND_MENU.value, 'name2');
+    t.end();
+});
+
+test('updateAssetName function updates name in costume field', t => {
+    const b = new Blocks();
+    b.createBlock({
+        id: 'foo',
+        fields: {
+            COSTUME: {
+                name: 'COSTUME',
+                value: 'name1'
+            }
+        }
+    });
+    t.equals(b.getBlock('foo').fields.COSTUME.value, 'name1');
+    b.updateAssetName('name1', 'name2', 'costume');
+    t.equals(b.getBlock('foo').fields.COSTUME.value, 'name2');
+    t.end();
+});
+
+test('updateAssetName function updates name in backdrop field', t => {
+    const b = new Blocks();
+    b.createBlock({
+        id: 'foo',
+        fields: {
+            BACKDROP: {
+                name: 'BACKDROP',
+                value: 'name1'
+            }
+        }
+    });
+    t.equals(b.getBlock('foo').fields.BACKDROP.value, 'name1');
+    b.updateAssetName('name1', 'name2', 'backdrop');
+    t.equals(b.getBlock('foo').fields.BACKDROP.value, 'name2');
+    t.end();
+});
+
+test('updateAssetName function updates name in all sprite fields', t => {
+    const b = new Blocks();
+    b.createBlock({
+        id: 'id1',
+        fields: {
+            TOWARDS: {
+                name: 'TOWARDS',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id2',
+        fields: {
+            TO: {
+                name: 'TO',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id3',
+        fields: {
+            OBJECT: {
+                name: 'OBJECT',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id4',
+        fields: {
+            VIDEOONMENU2: {
+                name: 'VIDEOONMENU2',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id5',
+        fields: {
+            DISTANCETOMENU: {
+                name: 'DISTANCETOMENU',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id6',
+        fields: {
+            TOUCHINGOBJECTMENU: {
+                name: 'TOUCHINGOBJECTMENU',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id7',
+        fields: {
+            CLONE_OPTION: {
+                name: 'CLONE_OPTION',
+                value: 'name1'
+            }
+        }
+    });
+    t.equals(b.getBlock('id1').fields.TOWARDS.value, 'name1');
+    t.equals(b.getBlock('id2').fields.TO.value, 'name1');
+    t.equals(b.getBlock('id3').fields.OBJECT.value, 'name1');
+    t.equals(b.getBlock('id4').fields.VIDEOONMENU2.value, 'name1');
+    t.equals(b.getBlock('id5').fields.DISTANCETOMENU.value, 'name1');
+    t.equals(b.getBlock('id6').fields.TOUCHINGOBJECTMENU.value, 'name1');
+    t.equals(b.getBlock('id7').fields.CLONE_OPTION.value, 'name1');
+    b.updateAssetName('name1', 'name2', 'sprite');
+    t.equals(b.getBlock('id1').fields.TOWARDS.value, 'name2');
+    t.equals(b.getBlock('id2').fields.TO.value, 'name2');
+    t.equals(b.getBlock('id3').fields.OBJECT.value, 'name2');
+    t.equals(b.getBlock('id4').fields.VIDEOONMENU2.value, 'name2');
+    t.equals(b.getBlock('id5').fields.DISTANCETOMENU.value, 'name2');
+    t.equals(b.getBlock('id6').fields.TOUCHINGOBJECTMENU.value, 'name2');
+    t.equals(b.getBlock('id7').fields.CLONE_OPTION.value, 'name2');
+    t.end();
+});
+
+test('updateAssetName function updates name according to asset type', t => {
+    const b = new Blocks();
+    b.createBlock({
+        id: 'id1',
+        fields: {
+            SOUND_MENU: {
+                name: 'SOUND_MENU',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id2',
+        fields: {
+            COSTUME: {
+                name: 'COSTUME',
+                value: 'name1'
+            }
+        }
+    });
+    t.equals(b.getBlock('id1').fields.SOUND_MENU.value, 'name1');
+    t.equals(b.getBlock('id2').fields.COSTUME.value, 'name1');
+    b.updateAssetName('name1', 'name2', 'sound');
+    // only sound should get renamed
+    t.equals(b.getBlock('id1').fields.SOUND_MENU.value, 'name2');
+    t.equals(b.getBlock('id2').fields.COSTUME.value, 'name1');
+    t.end();
+});
+
+test('updateAssetName only updates given name', t => {
+    const b = new Blocks();
+    b.createBlock({
+        id: 'id1',
+        fields: {
+            COSTUME: {
+                name: 'COSTUME',
+                value: 'name1'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id2',
+        fields: {
+            COSTUME: {
+                name: 'COSTUME',
+                value: 'foo'
+            }
+        }
+    });
+    t.equals(b.getBlock('id1').fields.COSTUME.value, 'name1');
+    t.equals(b.getBlock('id2').fields.COSTUME.value, 'foo');
+    b.updateAssetName('name1', 'name2', 'costume');
+    t.equals(b.getBlock('id1').fields.COSTUME.value, 'name2');
+    t.equals(b.getBlock('id2').fields.COSTUME.value, 'foo');
+    t.end();
+});
+
+test('updateAssetName doesn\'t update name if name isn\'t being used', t => {
+    const b = new Blocks();
+    b.createBlock({
+        id: 'id1',
+        fields: {
+            BACKDROP: {
+                name: 'BACKDROP',
+                value: 'foo'
+            }
+        }
+    });
+    t.equals(b.getBlock('id1').fields.BACKDROP.value, 'foo');
+    b.updateAssetName('name1', 'name2', 'backdrop');
+    t.equals(b.getBlock('id1').fields.BACKDROP.value, 'foo');
+    t.end();
+});

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -78,36 +78,34 @@ test('renameSprite does not set sprite names to reserved names', t => {
 test('renameSprite increments from existing sprite names', t => {
     const vm = new VirtualMachine();
     vm.emitTargetsUpdate = () => {};
-    vm.runtime.targets = [{
-        id: 'id1',
-        isSprite: () => true,
-        sprite: {
-            name: 'this name'
-        }
-    }, {
-        id: 'id2',
-        isSprite: () => true,
-        sprite: {
-            name: 'that name'
-        }
-    }];
-    vm.renameSprite('id1', 'that name');
-    t.equal(vm.runtime.targets[0].sprite.name, 'that name2');
+
+    const spr1 = new Sprite(null, vm.runtime);
+    const target1 = spr1.createClone();
+    const spr2 = new Sprite(null, vm.runtime);
+    const target2 = spr2.createClone();
+
+    vm.runtime.targets = [target1, target2];
+    vm.renameSprite(target1.id, 'foo');
+    t.equal(vm.runtime.targets[0].sprite.name, 'foo');
+    vm.renameSprite(target2.id, 'foo');
+    t.equal(vm.runtime.targets[1].sprite.name, 'foo2');
     t.end();
 });
 
 test('renameSprite does not increment when renaming to the same name', t => {
     const vm = new VirtualMachine();
     vm.emitTargetsUpdate = () => {};
-    vm.runtime.targets = [{
-        id: 'id1',
-        isSprite: () => true,
-        sprite: {
-            name: 'this name'
-        }
-    }];
-    vm.renameSprite('id1', 'this name');
-    t.equal(vm.runtime.targets[0].sprite.name, 'this name');
+
+    const spr = new Sprite(null, vm.runtime);
+    spr.name = 'foo';
+    const target = spr.createClone();
+
+    vm.runtime.targets = [target];
+
+    t.equal(vm.runtime.targets[0].sprite.name, 'foo');
+    vm.renameSprite(target.id, 'foo');
+    t.equal(vm.runtime.targets[0].sprite.name, 'foo');
+    
     t.end();
 });
 


### PR DESCRIPTION
### Resolves

Resolves #912

### Proposed Changes

Updates blocks after a sprite, sound, costume, or backdrop has been renamed.

### Reason for Changes

#912

### Test Coverage

Fixed existing renameSprite tests so that the new update function can get called correctly.
Added tests for new public updateAssetName function.