### PR TITLE
When getting sprite by name, skip the stage

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1458,6 +1458,9 @@ class Runtime extends EventEmitter {
     getSpriteTargetByName (spriteName) {
         for (let i = 0; i < this.targets.length; i++) {
             const target = this.targets[i];
+            if (target.isStage) {
+                continue;
+            }
             if (target.sprite && target.sprite.name === spriteName) {
                 return target;
             }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/1210

### Proposed Changes

Change the runtime's getSpriteTargetByName function so that it skips the stage.

### Reason for Changes

Sprites can have the name "Stage." Before this change, dynamic menus for selecting a sprite in which "Stage" was selected would always return the stage itself, not the sprite named Stage. As a result, none of the following blocks behaved correctly when "Stage" is selected in the menu: "go to," "glide to", "point towards," "touching", "distance to", "create clone of" and "() of ()". None of these blocks should be able to select the stage itself.

### Test Coverage

I'd appreciate any input on how we should apply tests for this situation.