### PR TITLE
Fix music extension menu import 

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -464,7 +464,7 @@ class Scratch3MusicBlocks {
                     arguments: {
                         DRUM: {
                             type: ArgumentType.NUMBER,
-                            menu: 'drums',
+                            menu: 'DRUM',
                             defaultValue: 1
                         },
                         BEATS: {
@@ -506,7 +506,7 @@ class Scratch3MusicBlocks {
                     arguments: {
                         INSTRUMENT: {
                             type: ArgumentType.NUMBER,
-                            menu: 'instruments',
+                            menu: 'INSTRUMENT',
                             defaultValue: 1
                         }
                     }
@@ -540,8 +540,8 @@ class Scratch3MusicBlocks {
                 }
             ],
             menus: {
-                drums: this._buildMenu(this.DRUM_INFO),
-                instruments: this._buildMenu(this.INSTRUMENT_INFO)
+                DRUM: this._buildMenu(this.DRUM_INFO),
+                INSTRUMENT: this._buildMenu(this.INSTRUMENT_INFO)
             }
         };
     }

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -533,6 +533,14 @@ const parseBlock = function (sb2block, addBroadcastMsg, getVariableId, extension
                 if (shadowObscured) {
                     fieldValue = '';
                 }
+            } else if (expectedArg.inputOp === 'music.menu.DRUM') {
+                if (shadowObscured) {
+                    fieldValue = 1;
+                }
+            } else if (expectedArg.inputOp === 'music.menu.INSTRUMENT') {
+                if (shadowObscured) {
+                    fieldValue = 1;
+                }
             } else if (shadowObscured) {
                 // Filled drop-down menu.
                 fieldValue = '';

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -424,7 +424,7 @@ const specMap = {
         argMap: [
             {
                 type: 'input',
-                inputOp: 'math_number',
+                inputOp: 'music.menu.DRUM',
                 inputName: 'DRUM'
             },
             {
@@ -464,7 +464,7 @@ const specMap = {
         argMap: [
             {
                 type: 'input',
-                inputOp: 'math_number',
+                inputOp: 'music.menu.INSTRUMENT',
                 inputName: 'INSTRUMENT'
             }
         ]


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/835

### Proposed Changes

In order for the menus on the music blocks to import and function correctly, make all of the following strings match: menu name (DRUM or INSTRUMENT), arg name (DRUM or INSTRUMENT), and inputOp name (music.menu.DRUM or music.menu.INSTRUMENT).  

Also, make sure the default values for these menus are set when they are imported with shadows obscured.

### Reason for Changes

If these strings do not match, the menus do not import correctly- the menu does not display the saved value. Making them match lets them import correctly.

Ideally, the menu could be named something different from the arg in the extension definition. So this may be a temporary fix. 

I believe there is an underlying bug in the system that generates the menus.  @cwillisf may be able to investigate further when we encounter this issue again as we implement more blocks.