### PR TITLE
Load tempo from sb2

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -44,13 +44,6 @@ class Scratch3MusicBlocks {
         this.runtime = runtime;
 
         /**
-         * The current tempo in beats per minute. The tempo is a global property of the project,
-         * not a property of each sprite, so it is not stored in the MusicState object.
-         * @type {number}
-         */
-        this.tempo = 60;
-
-        /**
          * The number of drum and instrument sounds currently being played simultaneously.
          * @type {number}
          * @private
@@ -759,7 +752,7 @@ class Scratch3MusicBlocks {
      * @private
      */
     _beatsToSec (beats) {
-        return (60 / this.tempo) * beats;
+        return (60 / this.getTempo()) * beats;
     }
 
     /**
@@ -829,7 +822,7 @@ class Scratch3MusicBlocks {
      */
     changeTempo (args) {
         const change = Cast.toNumber(args.TEMPO);
-        const tempo = change + this.tempo;
+        const tempo = change + this.getTempo();
         this._updateTempo(tempo);
     }
 
@@ -840,7 +833,10 @@ class Scratch3MusicBlocks {
      */
     _updateTempo (tempo) {
         tempo = MathUtil.clamp(tempo, Scratch3MusicBlocks.TEMPO_RANGE.min, Scratch3MusicBlocks.TEMPO_RANGE.max);
-        this.tempo = tempo;
+        const stage = this.runtime.getTargetForStage();
+        if (stage) {
+            stage.tempo = tempo;
+        }
     }
 
     /**
@@ -848,7 +844,11 @@ class Scratch3MusicBlocks {
      * @return {number} - the current tempo, in beats per minute.
      */
     getTempo () {
-        return this.tempo;
+        const stage = this.runtime.getTargetForStage();
+        if (stage) {
+            return stage.tempo;
+        }
+        return 60;
     }
 }
 

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -320,6 +320,9 @@ const parseScratchObject = function (object, runtime, extensions, topLevel) {
             target.rotationStyle = RenderedTarget.ROTATION_STYLE_ALL_AROUND;
         }
     }
+    if (object.hasOwnProperty('tempoBPM')) {
+        target.tempo = object.tempoBPM;
+    }
 
     target.isStage = topLevel;
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -116,6 +116,12 @@ class RenderedTarget extends Target {
          * @type {!string}
          */
         this.rotationStyle = RenderedTarget.ROTATION_STYLE_ALL_AROUND;
+
+        /**
+         * Current tempo (used by the music extension)
+         * @type {number}
+         */
+        this.tempo = 60;
     }
 
     /**

--- a/test/unit/extension_music.js
+++ b/test/unit/extension_music.js
@@ -1,8 +1,11 @@
 const test = require('tap').test;
 const Music = require('../../src/extensions/scratch3_music/index.js');
-const runtime = Object.create(null);
 
-const blocks = new Music(runtime);
+const fakeRuntime = {
+    getTargetForStage: () => ({tempo: 60})
+};
+
+const blocks = new Music(fakeRuntime);
 
 const util = {
     stackFrame: Object.create(null),


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/837

### Proposed Changes

- Add a tempo property to rendered target (used only by the stage, only for the music extension)
- Load the tempo stored in an sb2, use it to set the stage's tempo
- The extension no longer has its own tempo property, and uses the stage's tempo

### Reason for Changes

This change is necessary for compatibility. Some 2.0 projects rely on a saved tempo for correct behavior.

### Test Coverage

No tests