### PR TITLE
Validate sb2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "promise": "8.0.1",
     "scratch-audio": "latest",
     "scratch-blocks": "latest",
+    "scratch-parser": "latest",
     "scratch-render": "latest",
     "scratch-storage": "^0.4.0",
     "script-loader": "0.7.2",

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -228,9 +228,7 @@ class VirtualMachine extends EventEmitter {
 
         // Validate & parse
         if (typeof json !== 'string' && typeof json !== 'object') {
-            const invalidTypeError = 'Failed to parse project. Invalid type supplied to fromJSON.';
-            log.error(invalidTypeError);
-            throw new Error(invalidTypeError);
+            throw new Error('Failed to parse project. Invalid type supplied to fromJSON.');
         }
 
         // Establish version, deserialize, and load into runtime
@@ -249,10 +247,8 @@ class VirtualMachine extends EventEmitter {
             const possibleSb2 = typeof json === 'object' ? JSON.stringify(json) : json;
             validate(possibleSb2, (err, project) => {
                 if (err) {
-                    const errorMessage =
-                        `The given project could not be validated, parsing failed with error: ${JSON.stringify(err)}`;
-                    log.error(errorMessage);
-                    throw new Error(errorMessage);
+                    throw new Error(
+                        `The given project could not be validated, parsing failed with error: ${JSON.stringify(err)}`);
 
                 } else {
                     deserializer = sb2;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -228,8 +228,9 @@ class VirtualMachine extends EventEmitter {
 
         // Validate & parse
         if (typeof json !== 'string' && typeof json !== 'object') {
-            log.error('Failed to parse project. Invalid type supplied to fromJSON.');
-            return;
+            const invalidTypeError = 'Failed to parse project. Invalid type supplied to fromJSON.';
+            log.error(invalidTypeError);
+            throw new Error(invalidTypeError);
         }
 
         // Establish version, deserialize, and load into runtime
@@ -244,19 +245,17 @@ class VirtualMachine extends EventEmitter {
             deserializer = sb3;
             validatedProject = possibleSb3;
         } else {
-            // @todo need to handle default project
             validate(json, (err, project) => {
                 if (err) {
-                    // @todo Making this a warning for now. Should be updated with error handling
-                    log.warn(
-                        `There was an error in validating the project: ${JSON.stringify(err)}`);
-                    deserializer = sb2;
-                    validatedProject = possibleSb3;
+                    const errorMessage =
+                        `The given project could not be validated, parsing failed with error: ${JSON.stringify(err)}`;
+                    log.error(errorMessage);
+                    throw new Error(errorMessage);
+
                 } else {
                     deserializer = sb2;
                     validatedProject = project;
                 }
-                // handle the error
             });
         }
 
@@ -264,42 +263,6 @@ class VirtualMachine extends EventEmitter {
             .then(({targets, extensions}) =>
                 this.installTargets(targets, extensions, true));
     }
-
-
-    // /**
-    //  * Load a project from a Scratch JSON representation.
-    //  * @param {string} json JSON string representing a project.
-    //  * @returns {Promise} Promise that resolves after the project has loaded
-    //  */
-    // fromJSON (json) {
-    //     // Clear the current runtime
-    //     this.clear();
-    //
-    //     // Validate & parse
-    //     if (typeof json !== 'string' && typeof json !== 'object') {
-    //         log.error('Failed to parse project. Invalid type supplied to fromJSON.');
-    //         return;
-    //     }
-    //
-    //     // Attempt to parse JSON if string is supplied
-    //     if (typeof json === 'string') json = JSON.parse(json);
-    //
-    //     // Establish version, deserialize, and load into runtime
-    //     // @todo Support Scratch 1.4
-    //     // @todo This is an extremely naïve / dangerous way of determining version.
-    //     //       See `scratch-parser` for a more sophisticated validation
-    //     //       methodology that should be adapted for use here
-    //     let deserializer;
-    //     if ((typeof json.meta !== 'undefined') && (typeof json.meta.semver !== 'undefined')) {
-    //         deserializer = sb3;
-    //     } else {
-    //         deserializer = sb2;
-    //     }
-    //
-    //     return deserializer.deserialize(json, this.runtime)
-    //         .then(({targets, extensions}) =>
-    //             this.installTargets(targets, extensions, true));
-    // }
 
     /**
      * Install `deserialize` results: zero or more targets after the extensions (if any) used by those targets.

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -245,7 +245,9 @@ class VirtualMachine extends EventEmitter {
             deserializer = sb3;
             validatedProject = possibleSb3;
         } else {
-            validate(json, (err, project) => {
+            // scratch-parser expects a json string or a buffer
+            const possibleSb2 = typeof json === 'object' ? JSON.stringify(json) : json;
+            validate(possibleSb2, (err, project) => {
                 if (err) {
                     const errorMessage =
                         `The given project could not be validated, parsing failed with error: ${JSON.stringify(err)}`;


### PR DESCRIPTION
### Proposed Changes

Uses scratch-parser to validate a given scratch 2.0 project. Throws an error if project cannot be validated, so that something else, e.g. scratch-gui, can handle the error.

### Reason for Changes

Currently, some projects fail to load, silently, and the scratch-gui gets stuck in the loading state forever.
Here is an example project with this problem: 10003280

With these changes, scratch-vm attempts to validate the project and throws errors, the failed state gets caught by the error boundary in scratch-gui.

This is a step towards detecting invalid Scratch 2.0 projects.

Eventually, scratch-parser will be able to validate any given project as one of Legacy, Scratch 2.0, or Scratch 3.0.

### Test Coverage

Existing tests pass.

#### Additional Notes

LLK/scratch-gui#1528 should be merged before this PR.