### PR TITLE
Temporarily return real costumes array. GUI currently relies on this behavior somewhere

### DIFF
--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -66,7 +66,7 @@ class Sprite {
      *     addCostumeAt, deleteCostumeAt, or setting costumes.
      */
     get costumes () {
-        return this.costumes_.slice(0);
+        return this.costumes_;
     }
 
     /**


### PR DESCRIPTION
Fixes: Adding a costume currently fails

Eventually we should fix GUI to not access the costumes array directly and revert this change.