### PR TITLE
Implement for-each block

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -121,7 +121,8 @@ class Scratch3ControlBlocks {
         // is being iterated does not change the mode.
 
         if (typeof util.stackFrame.iterationMode === 'undefined') {
-            let value = args.VALUE, mode;
+            const value = args.VALUE;
+            let mode;
             if (typeof value === 'string' && !isNaN(Number(value))) {
                 mode = 'number';
             } else if (typeof value === 'number') {

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -66,92 +66,14 @@ class Scratch3ControlBlocks {
         const variable = util.target.lookupOrCreateVariable(
             args.VARIABLE.id, args.VARIABLE.name);
 
-        // The for-each block has two different but similar modes of operation,
-        // based on the value to be iterated:
-        //
-        // 1. If the value is a string, keep INTERNAL track of the index.
-        //    The value assigned to the Scratch variable will be the letter at
-        //    the current index, which will increase by 1 each tick. For example:
-        //
-        //    for each (x) in [abcdef]:
-        //      say (x)
-        //
-        //    ..is equivalent to:
-        //
-        //    set (i_) to 0
-        //    repeat until (i_) > length of [abcdef]:
-        //      change (i_) by 1
-        //      set (x) to letter (i_) of [abcdef]
-        //      say (x)
-        //
-        //    In this example, i_ is effectively invisible to the Scratch code:
-        //    There is no way to view or change it. Also, changing (x) has no
-        //    effect on the next iteration.
-        //
-        // 2. If the value is a number, DO NOT keep internal track of the index.
-        //    When for-each is passed a number, it iterates over all the numbers
-        //    from 1 to that number (inclusive). For example:
-        //
-        //    for each (x) in [10]:
-        //      say (x)
-        //
-        //    ..is equivalent to:
-        //
-        //    set (x) to 0
-        //    repeat until (x) > 10:
-        //      change (x) by 1
-        //      say (x)
-        //
-        //    The critical difference is that (x) is just a normal Scratch
-        //    variable. Changing it DOES have an effect on the next iteration.
-        //    This makes it possible to "skip" items, or to go back, et cetera.
-        //    For example:
-        //
-        //    for each (x) in [10]:
-        //      if (x) mod 4 = 0:
-        //        say [Mod 4 - Skip the next.]
-        //        change (x) by 1
-        //      else:
-        //        say x
-        //
-        //    ..would say 1, 2, 3, "Mod 4", 6, 7, "Mod 4", 10.
-        //
-        // The mode of operation above is decided at the beginning of the for-
-        // each loop, and changing the value that is being iterated *while* it
-        // is being iterated does not change the mode.
-
-        if (typeof util.stackFrame.iterationMode === 'undefined') {
-            const value = args.VALUE;
-            let mode;
-            if (typeof value === 'string' && !isNaN(Number(value))) {
-                mode = 'number';
-            } else if (typeof value === 'number') {
-                mode = 'number';
-            } else {
-                mode = 'string';
-            }
-
-            if (mode === 'number') {
-                variable.value = 0;
-            } else {
-                util.stackFrame.stringIndex = 0;
-            }
-
-            util.stackFrame.iterationMode = mode;
+        if (typeof util.stackFrame.index === 'undefined') {
+            util.stackFrame.index = 0;
         }
 
-        if (util.stackFrame.iterationMode === 'string') {
-            if (util.stackFrame.stringIndex < args.VALUE.length) {
-                variable.value = args.VALUE[util.stackFrame.stringIndex++];
-                util.startBranch(1, true);
-            }
-        }
-
-        if (util.stackFrame.iterationMode === 'number') {
-            if (variable.value < Number(args.VALUE)) {
-                variable.value++;
-                util.startBranch(1, true);
-            }
+        if (util.stackFrame.index < Number(args.VALUE)) {
+            util.stackFrame.index++;
+            variable.value = util.stackFrame.index;
+            util.startBranch(1, true);
         }
     }
 

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -17,6 +17,7 @@ class Scratch3ControlBlocks {
         return {
             control_repeat: this.repeat,
             control_repeat_until: this.repeatUntil,
+            control_for_each: this.forEach,
             control_forever: this.forever,
             control_wait: this.wait,
             control_wait_until: this.waitUntil,
@@ -58,6 +59,98 @@ class Scratch3ControlBlocks {
         // If the condition is true, start the branch.
         if (!condition) {
             util.startBranch(1, true);
+        }
+    }
+
+    forEach (args, util) {
+        const variable = util.target.lookupOrCreateVariable(
+            args.VARIABLE.id, args.VARIABLE.name);
+
+        // The for-each block has two different but similar modes of operation,
+        // based on the value to be iterated:
+        //
+        // 1. If the value is a string, keep INTERNAL track of the index.
+        //    The value assigned to the Scratch variable will be the letter at
+        //    the current index, which will increase by 1 each tick. For example:
+        //
+        //    for each (x) in [abcdef]:
+        //      say (x)
+        //
+        //    ..is equivalent to:
+        //
+        //    set (i_) to 0
+        //    repeat until (i_) > length of [abcdef]:
+        //      change (i_) by 1
+        //      set (x) to letter (i_) of [abcdef]
+        //      say (x)
+        //
+        //    In this example, i_ is effectively invisible to the Scratch code:
+        //    There is no way to view or change it. Also, changing (x) has no
+        //    effect on the next iteration.
+        //
+        // 2. If the value is a number, DO NOT keep internal track of the index.
+        //    When for-each is passed a number, it iterates over all the numbers
+        //    from 1 to that number (inclusive). For example:
+        //
+        //    for each (x) in [10]:
+        //      say (x)
+        //
+        //    ..is equivalent to:
+        //
+        //    set (x) to 0
+        //    repeat until (x) > 10:
+        //      change (x) by 1
+        //      say (x)
+        //
+        //    The critical difference is that (x) is just a normal Scratch
+        //    variable. Changing it DOES have an effect on the next iteration.
+        //    This makes it possible to "skip" items, or to go back, et cetera.
+        //    For example:
+        //
+        //    for each (x) in [10]:
+        //      if (x) mod 4 = 0:
+        //        say [Mod 4 - Skip the next.]
+        //        change (x) by 1
+        //      else:
+        //        say x
+        //
+        //    ..would say 1, 2, 3, "Mod 4", 6, 7, "Mod 4", 10.
+        //
+        // The mode of operation above is decided at the beginning of the for-
+        // each loop, and changing the value that is being iterated *while* it
+        // is being iterated does not change the mode.
+
+        if (typeof util.stackFrame.iterationMode === 'undefined') {
+            let value = args.VALUE, mode;
+            if (typeof value === 'string' && !isNaN(Number(value))) {
+                mode = 'number';
+            } else if (typeof value === 'number') {
+                mode = 'number';
+            } else {
+                mode = 'string';
+            }
+
+            if (mode === 'number') {
+                variable.value = 0;
+            } else {
+                util.stackFrame.stringIndex = 0;
+            }
+
+            util.stackFrame.iterationMode = mode;
+        }
+
+        if (util.stackFrame.iterationMode === 'string') {
+            if (util.stackFrame.stringIndex < args.VALUE.length) {
+                variable.value = args.VALUE[util.stackFrame.stringIndex++];
+                util.startBranch(1, true);
+            }
+        }
+
+        if (util.stackFrame.iterationMode === 'number') {
+            if (variable.value < Number(args.VALUE)) {
+                variable.value++;
+                util.startBranch(1, true);
+            }
         }
     }
 

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -768,6 +768,24 @@ const specMap = {
             }
         ]
     },
+    'doForLoop': {
+        opcode: 'control_for_each',
+        argMap: [
+            {
+                type: 'field',
+                fieldName: 'VARIABLE'
+            },
+            {
+                type: 'input',
+                inputOp: 'text',
+                inputName: 'VALUE'
+            },
+            {
+                type: 'input',
+                inputName: 'SUBSTACK'
+            }
+        ]
+    },
     'stopScripts': {
         opcode: 'control_stop',
         argMap: [

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -56,12 +56,9 @@ test('forEach', t => {
     const rt = new Runtime();
     const c = new Control(rt);
 
-    // for each (variable) in "abcd"
-    // ..should yield variable values "a", "b", "c", "d"
     const variableValues = [];
     const variable = {value: 0};
-    let value = 'abcd';
-
+    let value;
     const util = {
         stackFrame: Object.create(null),
         target: {
@@ -74,9 +71,6 @@ test('forEach', t => {
             c.forEach({VARIABLE: {}, VALUE: value}, util);
         }
     };
-
-    c.forEach({VARIABLE: {}, VALUE: value}, util);
-    t.deepEqual(variableValues, ['a', 'b', 'c', 'd']);
 
     // for each (variable) in "5"
     // ..should yield variable values 1, 2, 3, 4, 5
@@ -95,25 +89,6 @@ test('forEach', t => {
     value = 4;
     c.forEach({VARIABLE: {}, VALUE: value}, util);
     t.deepEqual(variableValues, [1, 2, 3, 4]);
-
-    // for each (variable) in 10:
-    //   if variable % 4 === 3:
-    //     variable++
-    // ..should yield variable values 1, 2, 3,  5, 6, 7,  9, 10
-    // (this script skips multiples of 4)
-    util.stackFrame = Object.create(null);
-    variableValues.splice(0);
-    variable.value = 0;
-    value = 10;
-    util.startBranch = function () {
-        variableValues.push(variable.value);
-        if (variable.value % 4 === 3) {
-            variable.value++;
-        }
-        c.forEach({VARIABLE: {}, VALUE: value}, util);
-    };
-    c.forEach({VARIABLE: {}, VALUE: value}, util);
-    t.deepEquals(variableValues, [1, 2, 3, 5, 6, 7, 9, 10]);
 
     t.end();
 });

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -52,6 +52,72 @@ test('repeatUntil', t => {
     t.end();
 });
 
+test('forEach', t => {
+    const rt = new Runtime();
+    const c = new Control(rt);
+
+    // for each (variable) in "abcd"
+    // ..should yield variable values "a", "b", "c", "d"
+    const variableValues = [];
+    const variable = {value: 0};
+    let value = 'abcd';
+
+    const util = {
+        stackFrame: Object.create(null),
+        target: {
+            lookupOrCreateVariable: function () {
+                return variable;
+            }
+        },
+        startBranch: function () {
+            variableValues.push(variable.value);
+            c.forEach({VARIABLE: {}, VALUE: value}, util);
+        }
+    };
+
+    c.forEach({VARIABLE: {}, VALUE: value}, util);
+    t.deepEqual(variableValues, ['a', 'b', 'c', 'd']);
+
+    // for each (variable) in "5"
+    // ..should yield variable values 1, 2, 3, 4, 5
+    util.stackFrame = Object.create(null);
+    variableValues.splice(0);
+    variable.value = 0;
+    value = '5';
+    c.forEach({VARIABLE: {}, VALUE: value}, util);
+    t.deepEqual(variableValues, [1, 2, 3, 4, 5]);
+
+    // for each (variable) in 4
+    // ..should yield variable values 1, 2, 3, 4
+    util.stackFrame = Object.create(null);
+    variableValues.splice(0);
+    variable.value = 0;
+    value = 4;
+    c.forEach({VARIABLE: {}, VALUE: value}, util);
+    t.deepEqual(variableValues, [1, 2, 3, 4]);
+
+    // for each (variable) in 10:
+    //   if variable % 4 === 3:
+    //     variable++
+    // ..should yield variable values 1, 2, 3,  5, 6, 7,  9, 10
+    // (this script skips multiples of 4)
+    util.stackFrame = Object.create(null);
+    variableValues.splice(0);
+    variable.value = 0;
+    value = 10;
+    util.startBranch = function () {
+        variableValues.push(variable.value);
+        if (variable.value % 4 === 3) {
+            variable.value++;
+        }
+        c.forEach({VARIABLE: {}, VALUE: value}, util);
+    };
+    c.forEach({VARIABLE: {}, VALUE: value}, util);
+    t.deepEquals(variableValues, [1, 2, 3, 5, 6, 7, 9, 10]);
+
+    t.end();
+});
+
 test('forever', t => {
     const rt = new Runtime();
     const c = new Control(rt);


### PR DESCRIPTION
### Resolves

Resolves #959. Should not be merged before LLK/scratch-blocks#1394.

### Proposed Changes

(Edit note: the below changes are irrelevant; the code now behaves identically to Scratch 2.0, no added features that better fit an extension.)

Adds the implementation for the "for each" block. A code comment that explains how it works is included in the implementation, and is quoted below:

>The for-each block has two different but similar modes of operation, based on the value to be iterated:
>
> 1. If the value is a string, keep INTERNAL track of the index. The value assigned to the Scratch variable will be the letter at the current index, which will increase by 1 each tick. For example:
>
>    ```
>    for each (x) in [abcdef]:
>      say (x)
>    ```
>
>    ..is equivalent to:
>
>    ```
>    set (i_) to 0
>    repeat until (i_) > length of [abcdef]:
>      change (i_) by 1
>      set (x) to letter (i_) of [abcdef]
>      say (x)
>    ```
>
>    In this example, i_ is effectively invisible to the Scratch code: there is no way to view or change it. Also, changing (x) has no effect on the next iteration.
>
> 2. If the value is a number, DO NOT keep internal track of the index. When for-each is passed a number, it iterates over all the numbers from 1 to that number (inclusive). For example:
>
>    ```
>    for each (x) in [10]:
>      say (x)
>    ```
>
>    ..is equivalent to:
>
>    ```
>    set (x) to 0
>    repeat until (x) > 10:
>      change (x) by 1
>      say (x)
>    ```
>
>    The critical difference is that (x) is just a normal Scratch variable. Changing it DOES have an effect on the next iteration. This makes it possible to "skip" items, or to go back, et cetera. For example:
>
>    ```
>    for each (x) in [10]:
>      if (x) mod 4 = 0:
>        say [Mod 4 - Skip the next.]
>        change (x) by 1
>      else:
>        say x
>    ```
>
>    ..would say 1, 2, 3, "Mod 4", 6, 7, "Mod 4", 10.
>
>The mode of operation above is decided at the beginning of the for-each loop, and changing the value that is being iterated *while* it is being iterated does not change the mode. 

### Reason for Changes

For compatibility with Scratch 2.0 projects that use the hacked "for each" block. Also, as a powerful and convenient block. What it can do is described above, but here are some examples:

Basic fizz-buzz - no special usage of "for" loop, it simply iterates a range of numbers:

![Fizz-buzz script](https://user-images.githubusercontent.com/9948030/36998316-dbf61c24-2092-11e8-9827-3ee3da9e51e5.png)

This says "1, 2, fizz, 4, buzz, fizz, 7, 8, fizz, buzz, 11, fizz, 13, 14, fizz buzz".

Changing the iterator variable while running - this skips numbers that are immediately after numbers divisible by 4:

![Skip past (divisible by 4)+1](https://user-images.githubusercontent.com/9948030/36998388-222edbe0-2093-11e8-898d-53e824629bb4.png)

This says "1, 2, 3, mod 4, 6, 7, mod 4, 10".

Manipulating a list while it is being iterated - this is a bit more complicated! When the loop reaches items equal to "baddy", those items are removed, and the loop continues from the item that appears in baddy's place. When the loop reaches items equal to "boom", the "boom" is removed, and four items ("wow!!!", "watch out for the sneaky", "baddy", and "cool!!!") are added in its place. The loop then continues from just past those items.

![baddyboom](https://user-images.githubusercontent.com/9948030/36998479-74343e80-2093-11e8-8247-3eb59df83bbd.png)

This prints:

* 1: a
* 2: b
* 3: baddy
* 3: boom
* 7: baddy
* 7: c

And the resulting modified list looks like "a, b, wow!!!, watch out for the sneaky, baddy, cool!!!, c".

All of the above changes maintain compatibility with 2.0 projects, assuming those 2.0 projects did not modify the iterator variable, since that would not have an effect in 2.0 (since the index was entirely stored and counted internally, then copied into the iterator variable). Since the "for each" block was used so rarely in 2.0, I think it's not unreasonable to break those for the sake of making the block significantly more versatile.

### Test Coverage

Besides making the examples above, I manually tested importing and running some 2.0 projects:

* https://scratch.mit.edu/projects/21950622/ - Imported. Ran correctly ("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, Look inside!").
* https://scratch.mit.edu/projects/48023824/ - Imported. Ran correctly (replacing the block with "repeat (32)" has the same effect).
* https://scratch.mit.edu/projects/92051100/ - **Does not import correctly.** This is because there's a reporter in the variable field. I think this isn't actually a problem for this PR; putting a reporter inside a "set variable" block probably has the same issue.
  ![Imports as "for each [concatenate:with:,hello ,world] in (10)"](https://user-images.githubusercontent.com/9948030/37001361-a4dee3ce-209c-11e8-8f1e-2963e44b5e3c.png)
* https://scratch.mit.edu/projects/63313634/ - Imported. Ran correctly (the sprite moves across the screen, saying the numbers 1 through 10 each time it steps). Note that this project uses nested for loops.