### PR TITLE
Preliminary Save and Load Work

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "watch": "webpack --progress --colors --watch",
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\""
   },
+  "dependencies": {
+    "scratch-parser": "LLK/scratch-parser#save-load"
+  },
   "devDependencies": {
     "adm-zip": "0.4.7",
     "babel-core": "^6.24.1",
@@ -59,7 +62,6 @@
     "scratch-parser": "latest",
     "scratch-render": "latest",
     "scratch-storage": "^0.4.0",
-    "scratch-parser": "latest",
     "script-loader": "0.7.2",
     "socket.io-client": "2.0.4",
     "stats.js": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "watch": "webpack --progress --colors --watch",
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\""
   },
-  "dependencies": {
-    "scratch-parser": "LLK/scratch-parser#save-load"
-  },
   "devDependencies": {
     "adm-zip": "0.4.7",
     "babel-core": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "scratch-parser": "latest",
     "scratch-render": "latest",
     "scratch-storage": "^0.4.0",
+    "scratch-parser": "latest",
     "script-loader": "0.7.2",
     "socket.io-client": "2.0.4",
     "stats.js": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "immutable": "3.8.1",
     "in-publish": "^2.0.0",
     "json": "^9.0.4",
+    "jszip": "^3.1.5",
     "lodash.defaultsdeep": "4.6.0",
     "minilog": "3.1.0",
     "nets": "3.2.0",

--- a/src/serialization/deserialize-assets.js
+++ b/src/serialization/deserialize-assets.js
@@ -27,7 +27,13 @@ const deserializeSound = function (sound, runtime, zip) {
         // This sound has already been cached.
         return Promise.resolve(null);
     }
-
+    if (!zip) {
+        // TODO adding this case to make integration tests pass, need to rethink
+        // the entire structure of saving/loading here (w.r.t. differences between
+        // loading from local zip file or from server)
+        log.error('Zipped assets were not provided.');
+        return Promise.resolve(null);
+    }
     const soundFile = zip.file(fileName);
     if (!soundFile) {
         log.error(`Could not find sound file associated with the ${sound.name} sound.`);
@@ -79,6 +85,14 @@ const deserializeCostume = function (costume, runtime, zip) {
     // has already been initialized?
     if (storage.get(assetId)) {
         // This costume has already been cached.
+        return Promise.resolve(null);
+    }
+
+    if (!zip) {
+        // TODO adding this case to make integration tests pass, need to rethink
+        // the entire structure of saving/loading here (w.r.t. differences between
+        // loading from local zip file or from server)
+        log.error('Zipped assets were not provided.');
         return Promise.resolve(null);
     }
 

--- a/src/serialization/deserialize-assets.js
+++ b/src/serialization/deserialize-assets.js
@@ -1,0 +1,120 @@
+const JSZip = require('jszip');
+const log = require('../util/log');
+
+/**
+ * Deserializes sound from file into storage cache so that it can
+ * be loaded into the runtime.
+ * @param {object} sound Descriptor for sound from sb3 file
+ * @param {Runtime} runtime The runtime containing the storage to cache the sounds in
+ * @param {JSZip} zip The zip containing the sound file being described by `sound`
+ * @return {Promise} Promise that resolves after the described sound has been stored
+ * into the runtime storage cache, the sound was already stored, or an error has
+ * occurred.
+ */
+const deserializeSound = function (sound, runtime, zip) {
+    const fileName = sound.md5; // The md5 property has the full file name
+    const storage = runtime.storage;
+    if (!storage) {
+        log.error('No storage module present; cannot load sound asset: ', fileName);
+        return Promise.resolve(null);
+    }
+
+    const assetId = sound.assetId;
+
+    // TODO Is there a faster way to check that this asset
+    // has already been initialized?
+    if (storage.get(assetId)) {
+        // This sound has already been cached.
+        return Promise.resolve(null);
+    }
+
+    const soundFile = zip.file(fileName);
+    if (!soundFile) {
+        log.error(`Could not find sound file associated with the ${sound.name} sound.`);
+        return Promise.resolve(null);
+    }
+    let dataFormat = null;
+    if (sound.dataFormat.toLowerCase() === 'wav') {
+        dataFormat = storage.DataFormat.WAV;
+    }
+    if (!JSZip.support.uint8array) {
+        log.error('JSZip uint8array is not supported in this browser.');
+        return Promise.resolve(null);
+    }
+
+    return soundFile.async('uint8array').then(data => {
+        storage.builtinHelper.cache(
+            storage.AssetType.Sound,
+            dataFormat,
+            data,
+            assetId
+        );
+    });
+};
+
+/**
+ * Deserializes costume from file into storage cache so that it can
+ * be loaded into the runtime.
+ * @param {object} costume Descriptor for costume from sb3 file
+ * @param {Runtime} runtime The runtime containing the storage to cache the costumes in
+ * @param {JSZip} zip The zip containing the costume file being described by `costume`
+ * @return {Promise} Promise that resolves after the described costume has been stored
+ * into the runtime storage cache, the costume was already stored, or an error has
+ * occurred.
+ */
+const deserializeCostume = function (costume, runtime, zip) {
+    const storage = runtime.storage;
+    const assetId = costume.assetId;
+    const fileName = costume.md5 ?
+        costume.md5 :
+        `${assetId}.${costume.dataFormat}`; // The md5 property has the full file name
+
+    if (!storage) {
+        log.error('No storage module present; cannot load costume asset: ', fileName);
+        return Promise.resolve(null);
+    }
+
+
+    // TODO Is there a faster way to check that this asset
+    // has already been initialized?
+    if (storage.get(assetId)) {
+        // This costume has already been cached.
+        return Promise.resolve(null);
+    }
+
+    const costumeFile = zip.file(fileName);
+    if (!costumeFile) {
+        log.error(`Could not find costume file associated with the ${costume.name} costume.`);
+        return Promise.resolve(null);
+    }
+    let dataFormat = null;
+    let assetType = null;
+    const costumeFormat = costume.dataFormat.toLowerCase();
+    if (costumeFormat === 'svg') {
+        dataFormat = storage.DataFormat.SVG;
+        assetType = storage.AssetType.ImageVector;
+    } else if (costumeFormat === 'png') {
+        dataFormat = storage.DataFormat.PNG;
+        assetType = storage.AssetType.ImageBitmap;
+    } else {
+        log.error(`Unexpected file format for costume: ${costumeFormat}`);
+    }
+    if (!JSZip.support.uint8array) {
+        log.error('JSZip uint8array is not supported in this browser.');
+        return Promise.resolve(null);
+    }
+
+    return costumeFile.async('uint8array').then(data => {
+        storage.builtinHelper.cache(
+            assetType,
+            dataFormat,
+            data,
+            assetId
+        );
+    });
+};
+
+module.exports = {
+    deserializeSound,
+    deserializeCostume
+};

--- a/src/serialization/serialize-assets.js
+++ b/src/serialization/serialize-assets.js
@@ -17,11 +17,11 @@ const serializeAssets = function (runtime, assetType) {
             const currAsset = currAssets[j];
             const assetId = currAsset.assetId;
             const storage = runtime.storage;
-            const asset = storage.get(assetId);
+            const storedAsset = storage.get(assetId);
             assetDescs.push({
                 fileName: assetType === 'sound' ?
-                    currAsset.md5 : `${assetId}.${currAsset.dataFormat}`,
-                fileContent: asset.data});
+                    currAsset.md5 : `${assetId}.${storedAsset.dataFormat}`,
+                fileContent: storedAsset.data});
         }
     }
     return assetDescs;

--- a/src/serialization/serialize-assets.js
+++ b/src/serialization/serialize-assets.js
@@ -1,0 +1,55 @@
+/**
+ * Serialize all the assets of the given type ('sounds' or 'costumes')
+ * in the provided runtime into an array of file descriptors.
+ * A file descriptor is an object containing the name of the file
+ * to be written and the contents of the file, the serialized asset.
+ * @param {Runtime} runtime The runtime with the assets to be serialized
+ * @param {string} assetType The type of assets to be serialized: 'sounds' | 'costumes'
+ * @returns {Array<object>} An array of file descriptors for each asset
+ */
+const serializeAssets = function (runtime, assetType) {
+    const targets = runtime.targets;
+    const assetDescs = [];
+    for (let i = 0; i < targets.length; i++) {
+        const currTarget = targets[i];
+        const currAssets = currTarget.sprite[assetType];
+        for (let j = 0; j < currAssets.length; j++) {
+            const currAsset = currAssets[j];
+            const assetId = currAsset.assetId;
+            const storage = runtime.storage;
+            const asset = storage.get(assetId);
+            assetDescs.push({
+                fileName: assetType === 'sound' ?
+                    currAsset.md5 : `${assetId}.${currAsset.dataFormat}`,
+                fileContent: asset.data});
+        }
+    }
+    return assetDescs;
+};
+
+/**
+ * Serialize all the sounds in the provided runtime into an array of file
+ * descriptors. A file descriptor is an object containing the name of the file
+ * to be written and the contents of the file, the serialized sound.
+ * @param {Runtime} runtime The runtime with the sounds to be serialized
+ * @returns {Array<object>} An array of file descriptors for each sound
+ */
+const serializeSounds = function (runtime) {
+    return serializeAssets(runtime, 'sounds');
+};
+
+/**
+ * Serialize all the costumes in the provided runtime into an array of file
+ * descriptors. A file descriptor is an object containing the name of the file
+ * to be written and the contents of the file, the serialized costume.
+ * @param {Runtime} runtime The runtime with the costumes to be serialized
+ * @returns {Array<object>} An array of file descriptors for each costume
+ */
+const serializeCostumes = function (runtime) {
+    return serializeAssets(runtime, 'costumes');
+};
+
+module.exports = {
+    serializeSounds,
+    serializeCostumes
+};

--- a/src/serialization/serialize-assets.js
+++ b/src/serialization/serialize-assets.js
@@ -19,7 +19,7 @@ const serializeAssets = function (runtime, assetType) {
             const storage = runtime.storage;
             const storedAsset = storage.get(assetId);
             assetDescs.push({
-                fileName: assetType === 'sound' ?
+                fileName: currAsset.md5 ?
                     currAsset.md5 : `${assetId}.${storedAsset.dataFormat}`,
                 fileContent: storedAsset.data});
         }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -513,6 +513,9 @@ class VirtualMachine extends EventEmitter {
             storage.DataFormat.SVG,
             (new TextEncoder()).encode(svg)
         );
+        // If we're in here, we've edited an svg in the vector editor,
+        // so the dataFormat should be 'svg'
+        costume.dataFormat = storage.DataFormat.SVG;
         this.emitTargetsUpdate();
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -15,6 +15,7 @@ const Variable = require('./engine/variable');
 
 const {loadCostume} = require('./import/load-costume.js');
 const {loadSound} = require('./import/load-sound.js');
+const {serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
 
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
 
@@ -206,7 +207,14 @@ class VirtualMachine extends EventEmitter {
      */
     saveProjectSb3 () {
         // @todo: Handle other formats, e.g., Scratch 1.4, Scratch 2.0.
-        return this.toJSON();
+        const soundDescs = serializeSounds(this.runtime);
+        const costumeDescs = serializeCostumes(this.runtime);
+
+        return {
+            projectJson: this.toJSON(),
+            sounds: soundDescs,
+            costumes: costumeDescs
+        };
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -186,6 +186,27 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * Load a project from a Scratch 3.0 sb3 file containing a project json
+     * and all of the sound and costume files.
+     * @param {JSZip} sb3File The sb3 file representing the project to load.
+     * @return {!Promise} Promise that resolves after targets are installed.
+     */
+    loadProjectLocal (sb3File) {
+        // TODO need to handle sb2 files as well, and will possibly merge w/
+        // above function
+        return sb3File.file('project.json').async('string')
+            .then(json => {
+                // TODO look at promise documentation to do this on success,
+                // but something else on error
+
+                json = JSON.parse(json); // TODO catch errors here (validation)
+                return sb3.deserialize(json, this.runtime, sb3File)
+                    .then(({targets, extensions}) =>
+                        this.installTargets(targets, extensions, true));
+            });
+    }
+
+    /**
      * Load a project from the Scratch web site, by ID.
      * @param {string} id - the ID of the project to download, as a string.
      */

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -537,6 +537,7 @@ class VirtualMachine extends EventEmitter {
         // If we're in here, we've edited an svg in the vector editor,
         // so the dataFormat should be 'svg'
         costume.dataFormat = storage.DataFormat.SVG;
+        costume.md5 = `${costume.assetId}.${costume.dataFormat}`;
         this.emitTargetsUpdate();
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -189,21 +189,22 @@ class VirtualMachine extends EventEmitter {
     /**
      * Load a project from a Scratch 3.0 sb3 file containing a project json
      * and all of the sound and costume files.
-     * @param {JSZip} sb3File The sb3 file representing the project to load.
+     * @param {Buffer} inputBuffer A buffer representing the project to load.
      * @return {!Promise} Promise that resolves after targets are installed.
      */
-    loadProjectLocal (sb3File) {
+    loadProjectLocal (inputBuffer) {
         // TODO need to handle sb2 files as well, and will possibly merge w/
         // above function
-        return sb3File.file('project.json').async('string')
-            .then(json => {
-                // TODO look at promise documentation to do this on success,
-                // but something else on error
-
-                json = JSON.parse(json); // TODO catch errors here (validation)
-                return sb3.deserialize(json, this.runtime, sb3File)
-                    .then(({targets, extensions}) =>
-                        this.installTargets(targets, extensions, true));
+        return JSZip.loadAsync(inputBuffer)
+            .then(sb3File => {
+                sb3File.file('project.json').async('string')
+                    .then(json => {
+                        // TODO error handling for unpacking zip/not finding project.json
+                        json = JSON.parse(json); // TODO catch errors here (validation)
+                        return sb3.deserialize(json, this.runtime, sb3File)
+                            .then(({targets, extensions}) =>
+                                this.installTargets(targets, extensions, true));
+                    });
             });
     }
 


### PR DESCRIPTION
### Proposed Changes

Preliminary work for saving and loading 3.0 projects. This includes:
- Serialization and deserialization of costumes and sounds on save and load respectively
- Updating asset metadata properly when making edits in sound and costume editors
- Making heavy use of storage caching (improvements to be made to this, see 'Changes yet to come' section)

### Reason for Changes

This is the first cut at a working implementation of save and load. Improvements need to be made (see 'Changes yet to come' section below) to optimize code to reduce duplication of metadata stored in the VM runtime, code duplication, and unnecessary calls to scratch-storage.

### Test Coverage

Existing tests pass. Need to make changes to how errors are handled (especially in serialize-assets and deserialize-assets). Need to add unit and integration tests for save/load functionality.

### Changes yet to come
In the future, this implementation should be improved by:
- removing unnecessary storage caching calls, e.g.
    - Implementing an indication of a dirty asset and only encoding assets upon 'save' instead of each time a sound or costume is updated.
- removing duplicate information from the sound/costume metadata stored in the runtime ('assetId' vs. 'md5')
- clean up top-level loadProject/loadProjectLocal api
- #194 and validating finalized spec
- see similar section in LLK/scratch-gui#1564

