### PR TITLE
ensure this.workerClass exists before instanceof check

### DIFF
--- a/src/dispatch/central-dispatch.js
+++ b/src/dispatch/central-dispatch.js
@@ -83,7 +83,7 @@ class CentralDispatch extends SharedDispatch {
         const provider = this.services[service];
         return provider && {
             provider,
-            isRemote: provider instanceof this.workerClass
+            isRemote: Boolean(this.workerClass && provider instanceof this.workerClass)
         };
     }
 


### PR DESCRIPTION
This avoids an error I was running into in a node environment:

```
TypeError: Right-hand side of 'instanceof' is not an object
```
