### PR TITLE
Ensure music extension _decodeSound is promise

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -125,10 +125,11 @@ class Scratch3MusicBlocks {
      * @return {Promise} - a promise which will resolve once the sound has decoded.
      */
     _decodeSound (soundBuffer) {
-        if (!this.runtime.audioEngine) return;
-        if (!this.runtime.audioEngine.audioContext) return;
+        const context = this.runtime.audioEngine && this.runtime.audioEngine.audioContext;
 
-        const context = this.runtime.audioEngine.audioContext;
+        if (!context) {
+            return Promise.reject(new Error('No Audio Context Detected'));
+        }
 
         // Check for newer promise-based API
         if (context.decodeAudioData.length === 1) {


### PR DESCRIPTION
Currently if there is no audio engine detected this `_decodeSound` method returns undefined,
which in turn causes the line above to be a runtime error while trying to call `.then` on it.
