### PR TITLE
Move volume to rendered target

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -238,7 +238,7 @@ class Scratch3SensingBlocks {
             case 'backdrop #': return attrTarget.currentCostume + 1;
             case 'backdrop name':
                 return attrTarget.getCostumes()[attrTarget.currentCostume].name;
-            case 'volume': return; // @todo: Keep this in mind for sound blocks!
+            case 'volume': return attrTarget.volume;
             }
         } else {
             switch (args.PROPERTY) {
@@ -249,7 +249,7 @@ class Scratch3SensingBlocks {
             case 'costume name':
                 return attrTarget.getCostumes()[attrTarget.currentCostume].name;
             case 'size': return attrTarget.size;
-            case 'volume': return; // @todo: above, keep in mind for sound blocks..
+            case 'volume': return attrTarget.volume;
             }
         }
 

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -37,7 +37,6 @@ class Scratch3SoundBlocks {
      */
     static get DEFAULT_SOUND_STATE () {
         return {
-            volume: 100,
             effects: {
                 pitch: 0,
                 pan: 0
@@ -267,22 +266,19 @@ class Scratch3SoundBlocks {
     }
 
     changeVolume (args, util) {
-        const soundState = this._getSoundState(util.target);
-        const volume = Cast.toNumber(args.VOLUME) + soundState.volume;
+        const volume = Cast.toNumber(args.VOLUME) + util.target.volume;
         this._updateVolume(volume, util);
     }
 
     _updateVolume (volume, util) {
-        const soundState = this._getSoundState(util.target);
         volume = MathUtil.clamp(volume, 0, 100);
-        soundState.volume = volume;
+        util.target.volume = volume;
         if (util.target.audioPlayer === null) return;
-        util.target.audioPlayer.setVolume(soundState.volume);
+        util.target.audioPlayer.setVolume(util.target.volume);
     }
 
     getVolume (args, util) {
-        const soundState = this._getSoundState(util.target);
-        return soundState.volume;
+        return util.target.volume;
     }
 
     soundsMenu (args) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -122,6 +122,12 @@ class RenderedTarget extends Target {
          * @type {number}
          */
         this.tempo = 60;
+
+        /**
+         * Loudness for sound playback for this target, as a percentage.
+         * @type {number}
+         */
+        this.volume = 100;
     }
 
     /**


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/892
Resolves https://github.com/LLK/scratch-vm/issues/339

### Proposed Changes

- Add a "volume" property to RenderedTarget.
- Use it in Scratch3SensingBlocks, instead of custom state.
- Use it in the "sensing of" block.

### Reason for Changes

We discussed a few options for fixing the volume option in the "sensing of" block, none of which are ideal. The underlying issue is that it's not clear exactly what custom state should and should not be used for. This is the simplest fix in my opinion. We just have to enlarge the sense of "rendered" in RenderedTarget to include "audio rendering."

### Test Coverage

Not sure if we need tests for this.