### PR TITLE
SB3 Serialization & Load Project

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -224,9 +224,16 @@ const parseScratchObject = function (object, runtime, extensions, topLevel) {
                 bitmapResolution: costumeSource.bitmapResolution || 1,
                 rotationCenterX: costumeSource.rotationCenterX,
                 rotationCenterY: costumeSource.rotationCenterY,
+                // TODO we eventually want this next property to be called
+                // md5ext to reflect what it actually contains, however this
+                // will be a very extensive change across many repositories
+                // and should be done carefully and altogether
+                md5: costumeSource.baseLayerMD5,
                 skinId: null
             };
-            costumePromises.push(loadCostume(costumeSource.baseLayerMD5, costume, runtime));
+            // TODO need to add deserializeCostume here so that assets from
+            // actual .sb2s get loaded in
+            costumePromises.push(loadCostume(costume.md5, costume, runtime));
         }
     }
     // Sounds from JSON
@@ -240,9 +247,17 @@ const parseScratchObject = function (object, runtime, extensions, topLevel) {
                 rate: soundSource.rate,
                 sampleCount: soundSource.sampleCount,
                 soundID: soundSource.soundID,
+                // TODO we eventually want this next property to be called
+                // md5ext to reflect what it actually contains, however this
+                // will be a very extensive change across many repositories
+                // and should be done carefully and altogether
+                // (for example, the audio engine currently relies on this
+                // property to be named 'md5')
                 md5: soundSource.md5,
                 data: null
             };
+            // TODO need to add deserializeSound here so that assets from
+            // actual .sb2s get loaded in
             soundPromises.push(loadSound(sound, runtime));
         }
     }

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -29,12 +29,8 @@ const serializeBlock = function (block) {
     const obj = Object.create(null);
     obj.id = block.id;
     obj.opcode = block.opcode;
-    if (block.next) {
-        obj.next = block.next;
-    }
-    if (block.parent) {
-        obj.parent = block.parent;
-    }
+    obj.next = block.next;
+    obj.parent = block.parent;
     obj.inputs = block.inputs;
     obj.fields = block.fields;
     obj.topLevel = block.topLevel;

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -33,7 +33,7 @@ const serializeBlock = function (block) {
     obj.parent = block.parent;
     obj.inputs = block.inputs;
     obj.fields = block.fields;
-    obj.topLevel = block.topLevel;
+    obj.topLevel = block.topLevel ? block.topLevel : false;
     obj.shadow = block.shadow;
     if (block.topLevel) {
         if (block.x) {

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -85,9 +85,9 @@ const serializeSound = function (sound) {
     return obj;
 };
 
-const serializeTarget = function (target/* , runtime*/) {
+const serializeTarget = function (target) {
     const obj = Object.create(null);
-    obj.isStage = target.isStage; // target.id === runtime.getTargetForStage().id;
+    obj.isStage = target.isStage;
     obj.name = target.name;
     obj.variables = target.variables; // This means that uids for variables will persist across saves/loads
     obj.blocks = serializeBlocks(target.blocks);

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -52,6 +52,7 @@ const serializeBlock = function (block) {
 const serializeBlocks = function (blocks) {
     const obj = Object.create(null);
     for (const blockID in blocks) {
+        if (!blocks.hasOwnProperty(blockID)) continue;
         obj[blockID] = serializeBlock(blocks[blockID]);
     }
     return obj;
@@ -88,9 +89,6 @@ const serializeSound = function (sound) {
     // but that change should be made carefully since it is very
     // pervasive
     obj.md5ext = sound.md5;
-    // TODO do we need this soundID
-    // (not to be confused with soundId which is a uid for sounds)
-    // obj.soundID = sound.soundID;
     return obj;
 };
 
@@ -127,7 +125,6 @@ const serialize = function (runtime) {
     const flattenedOriginalTargets = JSON.parse(JSON.stringify(
         runtime.targets.filter(target => target.isOriginal)));
     obj.targets = flattenedOriginalTargets.map(t => serializeTarget(t, runtime));
-    // runtime.targets.filter(target => target.isOriginal);
 
     // TODO Serialize monitors
 
@@ -171,6 +168,7 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     }
     if (object.hasOwnProperty('blocks')) {
         for (const blockId in object.blocks) {
+            if (!object.blocks.hasOwnProperty(blockId)) continue;
             const blockJSON = object.blocks[blockId];
             blocks.createBlock(blockJSON);
 

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -50,7 +50,6 @@ const serializeBlock = function (block) {
 };
 
 const serializeBlocks = function (blocks) {
-    // TODO Array or object?
     const obj = Object.create(null);
     for (const blockID in blocks) {
         obj[blockID] = serializeBlock(blocks[blockID]);

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -197,10 +197,8 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     const soundPromises = (object.sounds || []).map(soundSource => {
         const sound = {
             format: soundSource.format,
-            // fileUrl: soundSource.fileUrl,
             rate: soundSource.rate,
             sampleCount: soundSource.sampleCount,
-            // soundID: soundSource.soundID,
             name: soundSource.name,
             md5: soundSource.md5,
             data: null

--- a/src/serialization/serialize-assets.js
+++ b/src/serialization/serialize-assets.js
@@ -19,8 +19,7 @@ const serializeAssets = function (runtime, assetType) {
             const storage = runtime.storage;
             const storedAsset = storage.get(assetId);
             assetDescs.push({
-                fileName: currAsset.md5 ?
-                    currAsset.md5 : `${assetId}.${storedAsset.dataFormat}`,
+                fileName: `${assetId}.${storedAsset.dataFormat}`,
                 fileContent: storedAsset.data});
         }
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -182,8 +182,13 @@ class VirtualMachine extends EventEmitter {
      * @return {!Promise} Promise that resolves after targets are installed.
      */
     loadProject (input) {
-        if (typeof input === 'object' && !(input instanceof ArrayBuffer)) {
+        if (typeof input === 'object' && !ArrayBuffer.isView(input)) {
+            // If the input is an object and not any ArrayBuffer view
+            // (this includes all typed arrays and DataViews)
+            // turn the object into a JSON string, because we suspect
+            // this is a project.json as an object
             // validate expects a string or buffer as input
+            // TODO not sure if we need to check that it also isn't a data view
             input = JSON.stringify(input);
         }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -177,34 +177,22 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
-     * Load a project from a Scratch 2.0 JSON representation.
-     * @param {?string} json JSON string representing the project.
+     * Load a Scratch project from a .sb, .sb2, .sb3 or json string.
+     * @param {Buffer} input A buffe or json string representing the project to load.
      * @return {!Promise} Promise that resolves after targets are installed.
      */
-    loadProject (json) {
-        // @todo: Handle other formats, e.g., Scratch 1.4, Scratch 3.0.
-        return this.fromJSON(json);
-    }
+    loadProject (input) {
+        // Clear the current runtime
+        this.clear();
 
-    /**
-     * Load a project from a Scratch 3.0 sb3 file containing a project json
-     * and all of the sound and costume files.
-     * @param {Buffer} inputBuffer A buffer representing the project to load.
-     * @return {!Promise} Promise that resolves after targets are installed.
-     */
-    loadProjectLocal (inputBuffer) {
-        // TODO need to handle sb2 files as well, and will possibly merge w/
-        // above function
-        return JSZip.loadAsync(inputBuffer)
-            .then(sb3File => {
-                sb3File.file('project.json').async('string')
-                    .then(json => {
-                        // TODO error handling for unpacking zip/not finding project.json
-                        json = JSON.parse(json); // TODO catch errors here (validation)
-                        return sb3.deserialize(json, this.runtime, sb3File)
-                            .then(({targets, extensions}) =>
-                                this.installTargets(targets, extensions, true));
-                    });
+        return validate(input)
+            .then(validatedInput => this.deserializeProject(validatedInput[0], validatedInput[1]))
+            .catch(error => {
+                // Intentionally rejecting here (want errors to be handled by caller)
+                if (error.hasOwnProperty('validationError')) {
+                    return Promise.reject(JSON.stringify(error));
+                }
+                return Promise.reject(error);
             });
     }
 
@@ -233,6 +221,8 @@ class VirtualMachine extends EventEmitter {
         const costumeDescs = serializeCostumes(this.runtime);
         const projectJson = this.toJSON();
 
+        // TODO want to eventually move zip creation out of here, and perhaps
+        // into scratch-storage
         const zip = new JSZip();
 
         // Put everything in a zip file
@@ -260,45 +250,23 @@ class VirtualMachine extends EventEmitter {
 
     /**
      * Load a project from a Scratch JSON representation.
-     * @param {string} json JSON string representing a project.
+     * @param {string} projectJSON JSON string representing a project.
+     * @param {?JSZip} zip Optional zipped project containing assets to be loaded.
      * @returns {Promise} Promise that resolves after the project has loaded
      */
-    fromJSON (json) {
-        // Clear the current runtime
-        this.clear();
-
-        // Validate & parse
-        if (typeof json !== 'string' && typeof json !== 'object') {
-            throw new Error('Failed to parse project. Invalid type supplied to fromJSON.');
-        }
-
-        // Establish version, deserialize, and load into runtime
-        // @todo Support Scratch 1.4
-        // @todo This is an extremely naïve / dangerous way of determining version.
-        //       See `scratch-parser` for a more sophisticated validation
-        //       methodology that should be adapted for use here
-        let deserializer;
-        let validatedProject;
-        const possibleSb3 = typeof json === 'string' ? JSON.parse(json) : json;
-        if ((typeof possibleSb3.meta !== 'undefined') && (typeof possibleSb3.meta.semver !== 'undefined')) {
-            deserializer = sb3;
-            validatedProject = possibleSb3;
-        } else {
-            // scratch-parser expects a json string or a buffer
-            const possibleSb2 = typeof json === 'object' ? JSON.stringify(json) : json;
-            validate(possibleSb2, (err, project) => {
-                if (err) {
-                    throw new Error(
-                        `The given project could not be validated, parsing failed with error: ${JSON.stringify(err)}`);
-
-                } else {
-                    deserializer = sb2;
-                    validatedProject = project;
-                }
-            });
-        }
-
-        return deserializer.deserialize(validatedProject, this.runtime)
+    deserializeProject (projectJSON, zip) {
+        const runtime = this.runtime;
+        const deserializePromise = function () {
+            const projectVersion = projectJSON.projectVersion;
+            if (projectVersion === 2) {
+                return sb2.deserialize(projectJSON, runtime);
+            }
+            if (projectVersion === 3) {
+                return sb3.deserialize(projectJSON, runtime, zip);
+            }
+            return Promise.reject('Unable to verify Scratch Project version.');
+        };
+        return deserializePromise()
             .then(({targets, extensions}) =>
                 this.installTargets(targets, extensions, true));
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -178,10 +178,15 @@ class VirtualMachine extends EventEmitter {
 
     /**
      * Load a Scratch project from a .sb, .sb2, .sb3 or json string.
-     * @param {Buffer} input A buffe or json string representing the project to load.
+     * @param {string | object} input A json string, object, or ArrayBuffer representing the project to load.
      * @return {!Promise} Promise that resolves after targets are installed.
      */
     loadProject (input) {
+        if (typeof input === 'object' && !(input instanceof ArrayBuffer)) {
+            // validate expects a string or buffer as input
+            input = JSON.stringify(input);
+        }
+
         // Clear the current runtime
         this.clear();
 
@@ -246,6 +251,17 @@ class VirtualMachine extends EventEmitter {
      */
     toJSON () {
         return JSON.stringify(sb3.serialize(this.runtime));
+    }
+
+    // TODO do we still need this function? Keeping it here so as not to introduce
+    // a breaking change.
+    /**
+     * Load a project from a Scratch JSON representation.
+     * @param {string} json JSON string representing a project.
+     * @returns {Promise} Promise that resolves after the project has loaded
+     */
+    fromJSON (json) {
+        return this.loadProject(json);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -190,7 +190,18 @@ class VirtualMachine extends EventEmitter {
         // Clear the current runtime
         this.clear();
 
-        return validate(input)
+        const validationPromise = new Promise((resolve, reject) => {
+            validate(input, (error, res) => {
+                if (error) {
+                    reject(error);
+                }
+                if (res) {
+                    resolve(res);
+                }
+            });
+        });
+
+        return validationPromise
             .then(validatedInput => this.deserializeProject(validatedInput[0], validatedInput[1]))
             .catch(error => {
                 // Intentionally rejecting here (want errors to be handled by caller)

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -269,6 +269,7 @@ class VirtualMachine extends EventEmitter {
      * @returns {Promise} Promise that resolves after the project has loaded
      */
     fromJSON (json) {
+        log.warning('fromJSON is now just a wrapper around loadProject, please use that function instead.');
         return this.loadProject(json);
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -182,9 +182,10 @@ class VirtualMachine extends EventEmitter {
      * @return {!Promise} Promise that resolves after targets are installed.
      */
     loadProject (input) {
-        if (typeof input === 'object' && !ArrayBuffer.isView(input)) {
-            // If the input is an object and not any ArrayBuffer view
-            // (this includes all typed arrays and DataViews)
+        if (typeof input === 'object' && !(input instanceof ArrayBuffer) &&
+          !ArrayBuffer.isView(input)) {
+            // If the input is an object and not any ArrayBuffer
+            // or an ArrayBuffer view (this includes all typed arrays and DataViews)
             // turn the object into a JSON string, because we suspect
             // this is a project.json as an object
             // validate expects a string or buffer as input

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -187,9 +187,6 @@ class VirtualMachine extends EventEmitter {
             input = JSON.stringify(input);
         }
 
-        // Clear the current runtime
-        this.clear();
-
         const validationPromise = new Promise((resolve, reject) => {
             validate(input, (error, res) => {
                 if (error) {
@@ -282,6 +279,9 @@ class VirtualMachine extends EventEmitter {
      * @returns {Promise} Promise that resolves after the project has loaded
      */
     deserializeProject (projectJSON, zip) {
+        // Clear the current runtime
+        this.clear();
+
         const runtime = this.runtime;
         const deserializePromise = function () {
             const projectVersion = projectJSON.projectVersion;

--- a/test/unit/serialization_sb3.js
+++ b/test/unit/serialization_sb3.js
@@ -5,11 +5,13 @@ const demoSb3 = require('../fixtures/demo.json');
 
 test('serialize', t => {
     const vm = new VirtualMachine();
-    vm.fromJSON(JSON.stringify(demoSb3));
-    const result = sb3.serialize(vm.runtime);
-    // @todo Analyze
-    t.type(JSON.stringify(result), 'string');
-    t.end();
+    vm.fromJSON(JSON.stringify(demoSb3))
+        .then(() => {
+            const result = sb3.serialize(vm.runtime);
+            // @todo Analyze
+            t.type(JSON.stringify(result), 'string');
+            t.end();
+        });
 });
 
 test('deserialize', t => {

--- a/test/unit/serialization_sb3.js
+++ b/test/unit/serialization_sb3.js
@@ -5,7 +5,7 @@ const demoSb3 = require('../fixtures/demo.json');
 
 test('serialize', t => {
     const vm = new VirtualMachine();
-    vm.fromJSON(JSON.stringify(demoSb3))
+    vm.loadProject(JSON.stringify(demoSb3))
         .then(() => {
             const result = sb3.serialize(vm.runtime);
             // @todo Analyze


### PR DESCRIPTION
a.k.a Save/Load pt.2
### Resolves
Towards resolving #194.

### Proposed Changes
- SB3 Serialization cleanup (be explicit about what we're serializing, attempting to serialize only the minimum information necessary to load a project)
- Leverage changes in LLK/scratch-parser#21 to validate sb3 files
- Load .sb, .sb2, and .sb3 files (.sb files are still not supported, but they are at least passed through to scratch-parser)

#### Additional changes to come:
- More serialization work (serialize monitors, extension custom state)
- Support for sb1 import

#### Eventually (these are changes we want for the ideal world of save/load, but should not block release of this feature):
- Reducing unnecessary processes surrounding saving projects (only encode sounds/costumes when necessary instead of every time an edit is made -- even more eventually, move this to scratch-storage)
- Cleanup of unnecessary/duplicate information tracked in VM (e.g. assetId vs. md5 for sounds and costumes)
- Cleanup of relationship between scratch-vm, scratch-storage, and scratch-parser (this PR makes some progress towards this goal)

### Reason for Changes

Continuation Save/Load work.

### Test Coverage

Existing tests pass. Additional tests need to be added for sb3 round-trip testing.
(Travis build will fail until LLK/scratch-parser#21 gets merged)

### Additional Notes
This PR depends on LLK/scratch-parser#21, and is a dependency of LLK/scratch-gui#1621
