### PR TITLE
Make "key pressed?" sensing block import correctly

### DIFF
--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -861,8 +861,9 @@ const specMap = {
         opcode: 'sensing_keypressed',
         argMap: [
             {
-                type: 'field',
-                fieldName: 'KEY_OPTION'
+                type: 'input',
+                inputOp: 'sensing_keyoptions',
+                inputName: 'KEY_OPTION'
             }
         ]
     },


### PR DESCRIPTION
### Resolves

Fixes LLK/scratch-gui#1627.

### Proposed Changes

Fixes the way "key pressed?" blocks import. Before this PR (and after my other PR LLK/scratch-blocks#1370):

![](https://user-images.githubusercontent.com/9948030/37527747-86a641e0-2911-11e8-9f0e-0c32c128e253.png)

Now:

![](https://user-images.githubusercontent.com/9948030/37527761-8ba4c374-2911-11e8-8767-90b4a26f2702.png)

### Reason for Changes

Fixing my mistakes :sparkles:

I forgot to make this change when I made the "key pressed?" block input droppable - I wasn't thinking about imported projects then. Oops!

### Test Coverage

Manually tested locally on [this project](https://scratch.mit.edu/projects/210376086/). Local automatic tests pass.