### PR TITLE
Clones share their parent’s activeSoundPlayers object

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -146,6 +146,13 @@ class RenderedTarget extends Target {
         this.audioPlayer = null;
         if (this.runtime && this.runtime.audioEngine) {
             this.audioPlayer = this.runtime.audioEngine.createPlayer();
+            // If this is a clone, it gets a reference to its parent's activeSoundPlayers object.
+            if (!this.isOriginal) {
+                const parent = this.sprite.clones[0];
+                if (parent && parent.audioPlayer) {
+                    this.audioPlayer.activeSoundPlayers = parent.audioPlayer.activeSoundPlayers;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/919

### Proposed Changes

When a clone is created, it gets a reference to the parent sprite's activeSoundPlayers object, which keeps track of which sounds are currently playing. 

### Reason for Changes

This change allows clones to have their own audio effects state, but brings back the 2.0 behavior where a sprite and its clones cannot play multiple copies of the same sound at the same time. Instead, if one of them starts playing a sound, and then another starts the same sound, it will stop and restart.