### PR TITLE
Position the speech bubble more tightly.

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -119,7 +119,7 @@ class Scratch3LooksBlocks {
     _positionBubble (target) {
         const bubbleState = this._getBubbleState(target);
         const [bubbleWidth, bubbleHeight] = this.runtime.renderer.getSkinSize(bubbleState.drawableId);
-        const targetBounds = target.getBounds();
+        const targetBounds = target.getBoundsForBubble();
         const stageBounds = this.runtime.getTargetForStage().getBounds();
         if (bubbleState.onSpriteRight && bubbleWidth + targetBounds.right > stageBounds.right &&
             (targetBounds.left - bubbleWidth > stageBounds.left)) { // Only flip if it would fit
@@ -137,7 +137,7 @@ class Scratch3LooksBlocks {
                     ) : (
                         Math.max(stageBounds.left, targetBounds.left - bubbleWidth)
                     ),
-                    Math.min(stageBounds.top, targetBounds.top + bubbleHeight)
+                    Math.min(stageBounds.top, targetBounds.bottom + bubbleHeight)
                 ]
             });
             this.runtime.requestRedraw();

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -637,6 +637,18 @@ class RenderedTarget extends Target {
     }
 
     /**
+     * Return the bounding box around a slice of the top 8px of the rendered target.
+     * Includes top, left, bottom, right attributes in Scratch coordinates.
+     * @return {?object} Tight bounding box, or null.
+     */
+    getBoundsForBubble () {
+        if (this.renderer) {
+            return this.runtime.renderer.getBoundsForBubble(this.drawableID);
+        }
+        return null;
+    }
+
+    /**
      * Return whether touching a point.
      * @param {number} x X coordinate of test point.
      * @param {number} y Y coordinate of test point.


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes LLK/scratch-gui#1591 
Fixes LLK/scratch-gui#1568

### Proposed Changes

_Describe what this Pull Request does_

Use the new getBoundsForBubble API to position the bubble more tightly.

