### PR TITLE
Import and store video state

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -341,6 +341,18 @@ const parseScratchObject = function (object, runtime, extensions, topLevel) {
     if (object.hasOwnProperty('tempoBPM')) {
         target.tempo = object.tempoBPM;
     }
+    if (object.hasOwnProperty('videoAlpha')) {
+        // SB2 stores alpha as opacity, where 1.0 is opaque.
+        // We convert to a percentage, and invert it so 100% is full transparency.
+        target.videoTransparency = 100 - (100 * object.videoAlpha);
+    }
+    if (object.hasOwnProperty('info')) {
+        if (object.info.hasOwnProperty('videoOn')) {
+            if (object.info.videoOn) {
+                target.videoState = RenderedTarget.VIDEO_STATE.ON;
+            }
+        }
+    }
 
     target.isStage = topLevel;
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -118,16 +118,31 @@ class RenderedTarget extends Target {
         this.rotationStyle = RenderedTarget.ROTATION_STYLE_ALL_AROUND;
 
         /**
-         * Current tempo (used by the music extension)
+         * Loudness for sound playback for this target, as a percentage.
+         * @type {number}
+         */
+        this.volume = 100;
+
+        /**
+         * Current tempo (used by the music extension).
+         * This property is global to the project and stored in the stage.
          * @type {number}
          */
         this.tempo = 60;
 
         /**
-         * Loudness for sound playback for this target, as a percentage.
+         * The transparency of the video (used by extensions with camera input).
+         * This property is global to the project and stored in the stage.
          * @type {number}
          */
-        this.volume = 100;
+        this.videoTransparency = 50;
+
+        /**
+         * The state of the video input (used by extensions with camera input).
+         * This property is global to the project and stored in the stage.
+         * @type {string}
+         */
+        this.videoState = RenderedTarget.VIDEO_STATE.OFF;
     }
 
     /**
@@ -192,6 +207,18 @@ class RenderedTarget extends Target {
      */
     static get ROTATION_STYLE_NONE () {
         return "don't rotate";
+    }
+
+    /**
+     * Available states for video input.
+     * @type {object}
+     */
+    static get VIDEO_STATE () {
+        return {
+            'OFF': 'off',
+            'ON': 'on',
+            'ON-FLIPPED': 'on-flipped'
+        };
     }
 
     /**


### PR DESCRIPTION
### Resolves

Related to https://github.com/LLK/scratch-vm/issues/954

### Proposed Changes

- Add videoState and videoTransparency properties to rendered target
- Re-arrange rendered target's properties a tiny bit, with comments clarifying which ones are global to the project, and stored in the stage
- Load videoState and videoTransparency from SB2 files

Note that SB2 files store video state as a boolean, so it does not save a difference between "on" and "on-flipped". In Scratch 3.0, we should store a string, so we can save any of the three states (and possibly others in the future, e.g. front vs rear camera).

cc @mzgoddard 