### PR TITLE
Clones inherit music custom state

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -76,7 +76,7 @@ class Scratch3MusicBlocks {
         this._loadAllSounds();
 
         this._onTargetCreated = this._onTargetCreated.bind(this);
-        runtime.on('targetWasCreated', this._onTargetCreated);
+        this.runtime.on('targetWasCreated', this._onTargetCreated);
     }
 
     /**

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -74,6 +74,9 @@ class Scratch3MusicBlocks {
         this._bufferSources = [];
 
         this._loadAllSounds();
+
+        this._onTargetCreated = this._onTargetCreated.bind(this);
+        runtime.on('targetWasCreated', this._onTargetCreated);
     }
 
     /**
@@ -439,6 +442,22 @@ class Scratch3MusicBlocks {
             target.setCustomState(Scratch3MusicBlocks.STATE_KEY, musicState);
         }
         return musicState;
+    }
+
+    /**
+     * When a music-playing Target is cloned, clone the music state.
+     * @param {Target} newTarget - the newly created target.
+     * @param {Target} [sourceTarget] - the target used as a source for the new clone, if any.
+     * @listens Runtime#event:targetWasCreated
+     * @private
+     */
+    _onTargetCreated (newTarget, sourceTarget) {
+        if (sourceTarget) {
+            const musicState = sourceTarget.getCustomState(Scratch3MusicBlocks.STATE_KEY);
+            if (musicState) {
+                newTarget.setCustomState(Scratch3MusicBlocks.STATE_KEY, Clone.simple(musicState));
+            }
+        }
     }
 
     /**

--- a/test/unit/extension_music.js
+++ b/test/unit/extension_music.js
@@ -2,7 +2,8 @@ const test = require('tap').test;
 const Music = require('../../src/extensions/scratch3_music/index.js');
 
 const fakeRuntime = {
-    getTargetForStage: () => ({tempo: 60})
+    getTargetForStage: () => ({tempo: 60}),
+    on: () => {} // Stub out listener methods used in constructor.
 };
 
 const blocks = new Music(fakeRuntime);


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/987

### Proposed Changes

Listen for the targetWasCreated event, and copy any custom state for the music extension (just the instrument setting) into the new clone.

### Reason for Changes

Compatibility with Scratch 2.0, in which clones inherit the instrument set by the parent.
