### PR TITLE
Allow specmap to have methods to branch into multiple sb3 opcodes

### DIFF
--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -652,19 +652,35 @@ const specMap = {
             }
         ]
     },
-    'whenSensorGreaterThan': {
-        opcode: 'event_whengreaterthan',
-        argMap: [
-            {
-                type: 'field',
-                fieldName: 'WHENGREATERTHANMENU'
-            },
-            {
-                type: 'input',
-                inputOp: 'math_number',
-                inputName: 'VALUE'
-            }
-        ]
+    'whenSensorGreaterThan': ([, sensor]) => {
+        if (sensor === 'video motion') {
+            return {
+                opcode: 'videoSensing.whenMotionGreaterThan',
+                argMap: [
+                    // skip the first arg, since we converted to a video specific sensing block
+                    {},
+                    {
+                        type: 'input',
+                        inputOp: 'math_number',
+                        inputName: 'REFERENCE'
+                    }
+                ]
+            };
+        }
+        return {
+            opcode: 'event_whengreaterthan',
+            argMap: [
+                {
+                    type: 'field',
+                    fieldName: 'WHENGREATERTHANMENU'
+                },
+                {
+                    type: 'input',
+                    inputOp: 'math_number',
+                    inputName: 'VALUE'
+                }
+            ]
+        };
     },
     'whenIReceive': {
         opcode: 'event_whenbroadcastreceived',


### PR DESCRIPTION
### Resolves

Incremental part of #304

### Proposed Changes

* allow sb2 "whenSensorGreaterThan" to have multiple output opcodes 
* sb2_specmap now can have functions that take the block and return multiple different specmaps

### Reason for Changes

* Something needs to happen to allow this old opcode to get converted to a videoSensing opcode, but only when "video motion" is the used sensor.

You can test this on 213408319 with a locally running gui 