### PR TITLE
Add back missing Scratch3VideoSensingBlocks.INTERVAL

### DIFF
--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -93,6 +93,15 @@ class Scratch3VideoSensingBlocks {
     }
 
     /**
+     * After analyzing a frame the amount of milliseconds until another frame
+     * is analyzed.
+     * @type {number}
+     */
+    static get INTERVAL () {
+        return 33;
+    }
+
+    /**
      * Dimensions the video stream is analyzed at after its rendered to the
      * sample canvas.
      * @type {Array.<number>}


### PR DESCRIPTION
The INTERVAL time defines how often to analyze a frame. Without the value the
test whether a frame should be analyzed will always be false.

### Resolves

A small error in #1007 removed this member.

### Reason for Changes

The INTERVAL is used in one of the methods for VideoSensingBlocks. Without it a test to see if the newest frame should be analyzed is always false. Effectively keeping the VideoSensing extension from executing its intended purpose.

### Test Coverage

I'm trying to think about how to test this for regression, but its tricky. Need to separate some part of `_loop` but that could in theory cause a different regression.