### PR TITLE
Block serialization compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "promise": "8.0.1",
     "scratch-audio": "latest",
     "scratch-blocks": "latest",
-    "scratch-parser": "latest",
+    "scratch-parser": "^3.0.0",
     "scratch-render": "latest",
     "scratch-storage": "^0.4.0",
     "script-loader": "0.7.2",

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -98,7 +98,14 @@ class Scratch3DataBlocks {
         if (index === Cast.LIST_INVALID) {
             return;
         }
+        const listLimit = Scratch3DataBlocks.LIST_ITEM_LIMIT;
+        if (index > listLimit) return;
         list.value.splice(index - 1, 0, item);
+        if (list.value.length > listLimit) {
+            // If inserting caused the list to grow larger than the limit,
+            // remove the last element in the list
+            list.value.pop();
+        }
     }
 
     replaceItemOfList (args, util) {

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -74,7 +74,7 @@ class Scratch3DataBlocks {
     addToList (args, util) {
         const list = util.target.lookupOrCreateList(
             args.LIST.id, args.LIST.name);
-        list.value.push(args.ITEM);
+        if (list.value.length < Scratch3DataBlocks.LIST_ITEM_LIMIT) list.value.push(args.ITEM);
     }
 
     deleteOfList (args, util) {
@@ -143,6 +143,14 @@ class Scratch3DataBlocks {
             }
         }
         return false;
+    }
+
+    /**
+     * Type representation for list variables.
+     * @const {string}
+     */
+    static get LIST_ITEM_LIMIT () {
+        return 200000;
     }
 }
 

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -12,6 +12,10 @@ const log = require('../util/log');
  */
 const loadSoundFromAsset = function (sound, soundAsset, runtime) {
     sound.assetId = soundAsset.assetId;
+    if (!runtime.audioEngine) {
+        log.error('No audio engine present; cannot load sound asset: ', sound.md5);
+        return Promise.resolve(sound);
+    }
     return runtime.audioEngine.decodeSound(Object.assign(
         {},
         sound,
@@ -33,10 +37,6 @@ const loadSoundFromAsset = function (sound, soundAsset, runtime) {
 const loadSound = function (sound, runtime) {
     if (!runtime.storage) {
         log.error('No storage module present; cannot load sound asset: ', sound.md5);
-        return Promise.resolve(sound);
-    }
-    if (!runtime.audioEngine) {
-        log.error('No audio engine present; cannot load sound asset: ', sound.md5);
         return Promise.resolve(sound);
     }
     const idParts = StringUtil.splitFirst(sound.md5, '.');

--- a/src/serialization/deserialize-assets.js
+++ b/src/serialization/deserialize-assets.js
@@ -106,14 +106,11 @@ const deserializeCostume = function (costume, runtime, zip, assetFileName) {
         log.error(`Could not find costume file associated with the ${costume.name} costume.`);
         return Promise.resolve(null);
     }
-    let dataFormat = null;
     let assetType = null;
     const costumeFormat = costume.dataFormat.toLowerCase();
     if (costumeFormat === 'svg') {
-        dataFormat = storage.DataFormat.SVG;
         assetType = storage.AssetType.ImageVector;
-    } else if (costumeFormat === 'png') {
-        dataFormat = storage.DataFormat.PNG;
+    } else if (['png', 'bmp', 'jpeg', 'jpg', 'gif'].indexOf(costumeFormat) >= 0) {
         assetType = storage.AssetType.ImageBitmap;
     } else {
         log.error(`Unexpected file format for costume: ${costumeFormat}`);
@@ -126,7 +123,7 @@ const deserializeCostume = function (costume, runtime, zip, assetFileName) {
     return costumeFile.async('uint8array').then(data => {
         storage.builtinHelper.cache(
             assetType,
-            dataFormat,
+            costumeFormat,
             data,
             assetId
         );

--- a/src/serialization/deserialize-assets.js
+++ b/src/serialization/deserialize-assets.js
@@ -30,11 +30,7 @@ const deserializeSound = function (sound, runtime, zip, assetFileName) {
         // This sound has already been cached.
         return Promise.resolve(null);
     }
-    if (!zip) {
-        // TODO adding this case to make integration tests pass, need to rethink
-        // the entire structure of saving/loading here (w.r.t. differences between
-        // loading from local zip file or from server)
-        log.error('Zipped assets were not provided.');
+    if (!zip) { // Zip will not be provided if loading project json from server
         return Promise.resolve(null);
     }
     const soundFile = zip.file(fileName);
@@ -93,11 +89,7 @@ const deserializeCostume = function (costume, runtime, zip, assetFileName) {
         return Promise.resolve(null);
     }
 
-    if (!zip) {
-        // TODO adding this case to make integration tests pass, need to rethink
-        // the entire structure of saving/loading here (w.r.t. differences between
-        // loading from local zip file or from server)
-        log.error('Zipped assets were not provided.');
+    if (!zip) { // Zip will not be provided if loading project json from server
         return Promise.resolve(null);
     }
 

--- a/src/serialization/deserialize-assets.js
+++ b/src/serialization/deserialize-assets.js
@@ -123,6 +123,7 @@ const deserializeCostume = function (costume, runtime, zip, assetFileName) {
     return costumeFile.async('uint8array').then(data => {
         storage.builtinHelper.cache(
             assetType,
+            // TODO eventually we want to map non-png's to their actual file types?
             costumeFormat,
             data,
             assetId

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -215,7 +215,7 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip)
     const sprite = new Sprite(blocks, runtime);
     // Sprite/stage name from JSON.
     if (object.hasOwnProperty('objName')) {
-        sprite.name = object.objName;
+        sprite.name = topLevel ? 'Stage' : object.objName;
     }
     // Costumes from JSON.
     const costumePromises = [];

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -306,7 +306,7 @@ const serializeCostume = function (costume) {
     // but that change should be made carefully since it is very
     // pervasive
     obj.md5ext = costume.md5;
-    obj.dataFormat = costume.dataFormat;
+    obj.dataFormat = costume.dataFormat.toLowerCase();
     obj.rotationCenterX = costume.rotationCenterX;
     obj.rotationCenterY = costume.rotationCenterY;
     return obj;
@@ -321,7 +321,7 @@ const serializeSound = function (sound) {
     const obj = Object.create(null);
     obj.assetId = sound.assetId;
     obj.name = sound.name;
-    obj.dataFormat = sound.dataFormat;
+    obj.dataFormat = sound.dataFormat.toLowerCase();
     obj.format = sound.format;
     obj.rate = sound.rate;
     obj.sampleCount = sound.sampleCount;

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -762,24 +762,13 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     if (object.hasOwnProperty('variables')) {
         for (const varId in object.variables) {
             const variable = object.variables[varId];
-            let newVariable;
-            if (Array.isArray(variable)) {
-                newVariable = new Variable(
-                    varId, // var id is the index of the variable desc array in the variables obj
-                    variable[0], // name of the variable
-                    Variable.SCALAR_TYPE, // type of the variable
-                    (variable.length === 3) ? variable[2] : false // isPersistent/isCloud
-                );
-                newVariable.value = variable[1];
-            } else {
-                newVariable = new Variable(
-                    variable.id,
-                    variable.name,
-                    variable.type,
-                    variable.isPersistent
-                );
-                newVariable.value = variable.value;
-            }
+            const newVariable = new Variable(
+                varId, // var id is the index of the variable desc array in the variables obj
+                variable[0], // name of the variable
+                Variable.SCALAR_TYPE, // type of the variable
+                (variable.length === 3) ? variable[2] : false // isPersistent/isCloud
+            );
+            newVariable.value = variable[1];
             target.variables[newVariable.id] = newVariable;
         }
     }

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -171,7 +171,8 @@ const serializeBlock = function (block) {
     const obj = Object.create(null);
     obj.opcode = block.opcode;
     // NOTE: this is extremely important to serialize even if null;
-    // not serializing `next: null` results in strange behavior
+    // not serializing `next: null` results in strange behavior with block
+    // execution
     obj.next = block.next;
     obj.parent = block.parent;
     obj.inputs = serializeInputs(block.inputs);

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -177,7 +177,7 @@ const serializeBlock = function (block) {
     obj.inputs = serializeInputs(block.inputs);
     obj.fields = serializeFields(block.fields);
     obj.topLevel = block.topLevel ? block.topLevel : false;
-    obj.shadow = block.shadow; // I think we don't need this either..
+    obj.shadow = block.shadow;
     if (block.topLevel) {
         if (block.x) {
             obj.x = Math.round(block.x);
@@ -442,7 +442,6 @@ const deserializeInputDesc = function (inputDescOrId, parentId, isShadow, blocks
             }
         };
         primitiveObj.topLevel = false;
-        // what should we do about shadows
         break;
     }
     case POSITIVE_NUM_PRIMITIVE: {

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -345,8 +345,12 @@ const serializeTarget = function (target) {
     obj.currentCostume = target.currentCostume;
     obj.costumes = target.costumes.map(serializeCostume);
     obj.sounds = target.sounds.map(serializeSound);
-    if (!obj.isStage) {
-        // Stage does not need the following properties
+    if (target.hasOwnProperty('volume')) obj.volume = target.volume;
+    if (obj.isStage) { // Only the stage should have these properties
+        if (target.hasOwnProperty('tempo')) obj.tempo = target.tempo;
+        if (target.hasOwnProperty('videoTransparency')) obj.videoTransparency = target.videoTransparency;
+        if (target.hasOwnProperty('videoState')) obj.videoState = target.videoState;
+    } else { // The stage does not need the following properties, but sprites should
         obj.visible = target.visible;
         obj.x = target.x;
         obj.y = target.y;
@@ -700,6 +704,18 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     // Create the first clone, and load its run-state from JSON.
     const target = sprite.createClone();
     // Load target properties from JSON.
+    if (object.hasOwnProperty('tempo')) {
+        target.tempo = object.tempo;
+    }
+    if (object.hasOwnProperty('volume')) {
+        target.volume = object.volume;
+    }
+    if (object.hasOwnProperty('videoTransparency')) {
+        target.videoTransparency = object.videoTransparency;
+    }
+    if (object.hasOwnProperty('videoState')) {
+        target.videoState = object.videoState;
+    }
     if (object.hasOwnProperty('variables')) {
         for (const varId in object.variables) {
             const variable = object.variables[varId];

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -217,7 +217,7 @@ class RenderedTarget extends Target {
         return {
             'OFF': 'off',
             'ON': 'on',
-            'ON-FLIPPED': 'on-flipped'
+            'ON_FLIPPED': 'on_flipped'
         };
     }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -215,9 +215,9 @@ class RenderedTarget extends Target {
      */
     static get VIDEO_STATE () {
         return {
-            'OFF': 'off',
-            'ON': 'on',
-            'ON_FLIPPED': 'on_flipped'
+            OFF: 'off',
+            ON: 'on',
+            ON_FLIPPED: 'on_flipped'
         };
     }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -217,7 +217,7 @@ class RenderedTarget extends Target {
         return {
             OFF: 'off',
             ON: 'on',
-            ON_FLIPPED: 'on_flipped'
+            ON_FLIPPED: 'on-flipped'
         };
     }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1003,7 +1003,12 @@ class RenderedTarget extends Target {
             variables: this.variables,
             lists: this.lists,
             costumes: costumes,
-            sounds: this.getSounds()
+            sounds: this.getSounds(),
+            tempo: this.tempo,
+            volume: this.volume,
+            videoTransparency: this.videoTransparency,
+            videoState: this.videoState
+
         };
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -256,7 +256,13 @@ class VirtualMachine extends EventEmitter {
             zip.file(currCostume.fileName, currCostume.fileContent);
         }
 
-        return zip.generateAsync({type: 'blob'});
+        return zip.generateAsync({
+            type: 'blob',
+            compression: 'DEFLATE',
+            compressionOptions: {
+                level: 9 // best compression (level 1 would be best speed)
+            }
+        });
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -245,7 +245,6 @@ class VirtualMachine extends EventEmitter {
         const zip = new JSZip();
 
         // Put everything in a zip file
-        // TODO compression?
         zip.file('project.json', projectJson);
         for (let i = 0; i < soundDescs.length; i++) {
             const currSound = soundDescs[i];
@@ -260,7 +259,7 @@ class VirtualMachine extends EventEmitter {
             type: 'blob',
             compression: 'DEFLATE',
             compressionOptions: {
-                level: 9 // best compression (level 1 would be best speed)
+                level: 6 // Tradeoff between best speed (1) and best compression (9)
             }
         });
     }

--- a/test/unit/serialization_sb3.js
+++ b/test/unit/serialization_sb3.js
@@ -1,11 +1,13 @@
 const test = require('tap').test;
+const path = require('path');
 const VirtualMachine = require('../../src/index');
 const sb3 = require('../../src/serialization/sb3');
-const demoSb3 = require('../fixtures/demo.json');
+const extract = require('../fixtures/extract');
+const projectPath = path.resolve(__dirname, '../fixtures/clone-cleanup.sb2');
 
 test('serialize', t => {
     const vm = new VirtualMachine();
-    vm.loadProject(JSON.stringify(demoSb3))
+    vm.loadProject(extract(projectPath))
         .then(() => {
             const result = sb3.serialize(vm.runtime);
             // @todo Analyze

--- a/test/unit/serialization_sb3.js
+++ b/test/unit/serialization_sb3.js
@@ -2,12 +2,12 @@ const test = require('tap').test;
 const path = require('path');
 const VirtualMachine = require('../../src/index');
 const sb3 = require('../../src/serialization/sb3');
-const extract = require('../fixtures/extract');
+const readFileToBuffer = require('../fixtures/readProjectFile').readFileToBuffer;
 const projectPath = path.resolve(__dirname, '../fixtures/clone-cleanup.sb2');
 
 test('serialize', t => {
     const vm = new VirtualMachine();
-    vm.loadProject(extract(projectPath))
+    vm.loadProject(readFileToBuffer(projectPath))
         .then(() => {
             const result = sb3.serialize(vm.runtime);
             // @todo Analyze


### PR DESCRIPTION
### Resolves

#194

### Proposed Changes

This is the last of the save/load work. This pull request covers the following changes:

* New list limit of 200k items per list.
* Make sb3 format more compact. This includes: 
  * serializing the following block opcodes into a more compact form ([`number representing opcode`, `info about the opcode`, `(in one or more elements)`]:
    * `math_number`
    * `math_positive_number`
    * `math_whole_number`
    * `math_angle`
    * `math_integer`
    * `colour_picker`
    * `text`
    * `event_broadcast_menu` (this is the shadow block used in broadcast menus)
    * `data_variable`
    * `data_listcontents`
  * reducing duplication in how our data is structured, for example removing serialization of the `id`-uid pair in the  blocks, which were previously stored as:
    ```
    blocks: {
        'this is my long uid for my block' : {
             opcode: 'a cool block'
             id: 'this is my long uid for my block'
             ...  more stuff here ...
    }
    ```
* Added serialization and deserialization for custom state such as `tempo`, `volume`, and video related state

**Note:** Monitor serialization/deserialization is not covered by this work.

### Reason for Changes

Making serialized 3.0 format smaller.

### Test Coverage

Existing save/load tests pass. New test cases for the 3.0 format to be added in the near future.

#### Related PRs
LLK/scratch-parser#32
LLK/scratch-gui#1738
