### PR TITLE
Implement "while" block

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -17,6 +17,7 @@ class Scratch3ControlBlocks {
         return {
             control_repeat: this.repeat,
             control_repeat_until: this.repeatUntil,
+            control_while: this.repeatWhile,
             control_for_each: this.forEach,
             control_forever: this.forever,
             control_wait: this.wait,
@@ -56,8 +57,16 @@ class Scratch3ControlBlocks {
 
     repeatUntil (args, util) {
         const condition = Cast.toBoolean(args.CONDITION);
-        // If the condition is true, start the branch.
+        // If the condition is false (repeat UNTIL), start the branch.
         if (!condition) {
+            util.startBranch(1, true);
+        }
+    }
+
+    repeatWhile (args, util) {
+        const condition = Cast.toBoolean(args.CONDITION);
+        // If the condition is true (repeat WHILE), start the branch.
+        if (condition) {
             util.startBranch(1, true);
         }
     }

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -768,6 +768,19 @@ const specMap = {
             }
         ]
     },
+    'doWhile': {
+        opcode: 'control_while',
+        argMap: [
+            {
+                type: 'input',
+                inputName: 'CONDITION'
+            },
+            {
+                type: 'input',
+                inputName: 'SUBSTACK'
+            }
+        ]
+    },
     'doForLoop': {
         opcode: 'control_for_each',
         argMap: [

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -52,6 +52,28 @@ test('repeatUntil', t => {
     t.end();
 });
 
+test('repeatWhile', t => {
+    const rt = new Runtime();
+    const c = new Control(rt);
+
+    // Test harness (mocks `util`)
+    let i = 0;
+    const repeat = 10;
+    const util = {
+        stackFrame: Object.create(null),
+        startBranch: function () {
+            i++;
+            // Note !== instead of ===
+            c.repeatWhile({CONDITION: (i !== repeat)}, util);
+        }
+    };
+
+    // Execute test
+    c.repeatWhile({CONDITION: (i !== repeat)}, util);
+    t.strictEqual(i, repeat);
+    t.end();
+});
+
 test('forEach', t => {
     const rt = new Runtime();
     const c = new Control(rt);


### PR DESCRIPTION
### Resolves

Towards #355 (implements "doWhile"). Should be merged alongside LLK/scratch-blocks#1430.

### Proposed Changes

Adds a spec mapping from `doWhile` (2.0) to `control_while` (3.0) and implements the while block.

The `while` block behaves exactly opposite of `repeat until`: instead of looping *until* a condition is true, it loops *while* a condition is true, or, instead of looping while a condition is *false*, it loops while a condition is *true*.

(There was an incorrect comment in `repeatUntil` which I fixed in this PR.)

### Reason for Changes

Compatibility with Scratch 2.0 projects. This is a hacked block; in total, [1505 projects use the `while` loop](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752).

### Test Coverage

A new unit test (the same test as "repeat until" but checking that it repeats until a condition is false instead of true).

Also manually tested with this script (I got the "while" block from importing [this project](https://scratch.mit.edu/projects/49037046)):

![Start a sound; while the timer is less than one, set the audio pitch proportional to the timer value](https://user-images.githubusercontent.com/9948030/38457927-45b56392-3a6d-11e8-9341-402cf639187b.png)