### PR TITLE
Implement counter blocks

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -7,6 +7,12 @@ class Scratch3ControlBlocks {
          * @type {Runtime}
          */
         this.runtime = runtime;
+
+        /**
+         * The "counter" block value. For compatibility with 2.0.
+         * @type {number}
+         */
+        this._counter = 0;
     }
 
     /**
@@ -25,7 +31,10 @@ class Scratch3ControlBlocks {
             control_if_else: this.ifElse,
             control_stop: this.stop,
             control_create_clone_of: this.createClone,
-            control_delete_this_clone: this.deleteClone
+            control_delete_this_clone: this.deleteClone,
+            control_get_counter: this.getCounter,
+            control_incr_counter: this.incrCounter,
+            control_clear_counter: this.clearCounter
         };
     }
 
@@ -145,6 +154,18 @@ class Scratch3ControlBlocks {
         if (util.target.isOriginal) return;
         this.runtime.disposeTarget(util.target);
         this.runtime.stopForTarget(util.target);
+    }
+
+    getCounter () {
+        return this._counter;
+    }
+
+    clearCounter () {
+        this._counter = 0;
+    }
+
+    incrCounter () {
+        this._counter++;
     }
 }
 

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -815,6 +815,21 @@ const specMap = {
         argMap: [
         ]
     },
+    'COUNT': {
+        opcode: 'control_get_counter',
+        argMap: [
+        ]
+    },
+    'INCR_COUNT': {
+        opcode: 'control_incr_counter',
+        argMap: [
+        ]
+    },
+    'CLR_COUNT': {
+        opcode: 'control_clear_counter',
+        argMap: [
+        ]
+    },
     'touching:': {
         opcode: 'sensing_touchingobject',
         argMap: [

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -169,3 +169,20 @@ test('stop', t => {
     t.strictEqual(state.stopThisScript, 1);
     t.end();
 });
+
+test('counter, incrCounter, clearCounter', t => {
+    const rt = new Runtime();
+    const c = new Control(rt);
+
+    // Default value
+    t.strictEqual(c.getCounter(), 0);
+
+    c.incrCounter();
+    c.incrCounter();
+    t.strictEqual(c.getCounter(), 2);
+
+    c.clearCounter();
+    t.strictEqual(c.getCounter(), 0);
+
+    t.end();
+});


### PR DESCRIPTION
### Resolves

Towards #355 (implements counter blocks). Should be merged alongside LLK/scratch-blocks#1431.

### Proposed Changes

Adds spec mappings from `COUNT`, `INCR_COUNT`, and `CLR_COUNT` to `control_get_counter`, `control_incr_counter`, and `control_clear_counter`, respectively.

Adds implementations for those blocks:

* `control_get_counter`: Return the counter value.
* `control_incr_counter`: Add one to the counter value.
* `control_clear_counter`: Set the counter value to zero.

### Reason for Changes

Compatibility with Scratch 2.0 projects. These are hacked blocks; in total, [around 1000 projects use the counter blocks](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752).

### Test Coverage

A new unit test for the blocks. Tested manually with [this project](https://scratch.mit.edu/projects/25344202/). (That project also uses the "while" block, which might cause issues opening it in this PR; I had my changes from #1032 active while working on this.)