### PR TITLE
Attach the costume size to the costume when loaded and modified

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -118,7 +118,7 @@ class Scratch3LooksBlocks {
      */
     _positionBubble (target) {
         const bubbleState = this._getBubbleState(target);
-        const [bubbleWidth, bubbleHeight] = this.runtime.renderer.getSkinSize(bubbleState.drawableId);
+        const [bubbleWidth, bubbleHeight] = this.runtime.renderer.getCurrentSkinSize(bubbleState.drawableId);
         const targetBounds = target.getBoundsForBubble();
         const stageBounds = this.runtime.getTargetForStage().getBounds();
         if (bubbleState.onSpriteRight && bubbleWidth + targetBounds.right > stageBounds.right &&

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -26,6 +26,7 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
     ];
     if (costumeAsset.assetType === AssetType.ImageVector) {
         costume.skinId = runtime.renderer.createSVGSkin(costumeAsset.decodeText(), rotationCenter);
+        costume.size = runtime.renderer.getSkinSize(costume.skinId);
         return costume;
     }
 
@@ -50,6 +51,7 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
         imageElement.src = costumeAsset.encodeDataURI();
     }).then(imageElement => {
         costume.skinId = runtime.renderer.createBitmapSkin(imageElement, costume.bitmapResolution, rotationCenter);
+        costume.size = runtime.renderer.getSkinSize(costume.skinId);
         return costume;
     });
 };

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -355,7 +355,7 @@ class RenderedTarget extends Target {
         if (this.renderer) {
             // Clamp to scales relative to costume and stage size.
             // See original ScratchSprite.as:setSize.
-            const costumeSize = this.renderer.getSkinSize(this.drawableID);
+            const costumeSize = this.renderer.getCurrentSkinSize(this.drawableID);
             const origW = costumeSize[0];
             const origH = costumeSize[1];
             const minScale = Math.min(1, Math.max(5 / origW, 5 / origH));

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -541,6 +541,7 @@ class VirtualMachine extends EventEmitter {
             costume.rotationCenterX = rotationCenterX;
             costume.rotationCenterY = rotationCenterY;
             this.runtime.renderer.updateSVGSkin(costume.skinId, svg, [rotationCenterX, rotationCenterY]);
+            costume.size = this.runtime.renderer.getSkinSize(costume.skinId);
         }
         const storage = this.runtime.storage;
         costume.assetId = storage.builtinHelper.cache(

--- a/test/fixtures/fake-renderer.js
+++ b/test/fixtures/fake-renderer.js
@@ -22,7 +22,7 @@ FakeRenderer.prototype.updateDrawableProperties = function (d, p) { // eslint-di
     return true;
 };
 
-FakeRenderer.prototype.getSkinSize = function (d) { // eslint-disable-line no-unused-vars
+FakeRenderer.prototype.getCurrentSkinSize = function (d) { // eslint-disable-line no-unused-vars
     return [0, 0];
 };
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Required to complete LLK/scratch-gui#1754

### Proposed Changes

_Describe what this Pull Request does_

Attach the costume size to the costume when loaded and modified.

Also https://github.com/LLK/scratch-render/pull/254 includes an API change, changing the old `getSkinSize(drawableId)` to `getCurrentSkinSize(drawableId)` so that the new `getSkinSize(skinId)` could be used.

### Reason for Changes

_Explain why these changes should be made_

The costume size is needed by the GUI in order to display costume meta data on the costume tiles. 