### PR TITLE
Filter out dragging targets from touching sprite check.

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -734,7 +734,11 @@ class RenderedTarget extends Target {
         if (!firstClone || !this.renderer) {
             return false;
         }
-        const drawableCandidates = firstClone.sprite.clones.map(clone => clone.drawableID);
+        // Filter out dragging targets. This means a sprite that is being dragged
+        // can detect other sprites using touching <sprite>, but cannot be detected
+        // by other sprites while it is being dragged. This matches Scratch 2.0 behavior.
+        const drawableCandidates = firstClone.sprite.clones.filter(clone => !clone.dragging)
+            .map(clone => clone.drawableID);
         return this.renderer.isTouchingDrawables(
             this.drawableID, drawableCandidates);
     }


### PR DESCRIPTION
This introduces an asymmetry that matches the Scratch 2 behavior, that
is, a sprite that is being dragged can detect other sprites using
touching <sprite>, but cannot be detected by other sprites while it is
being dragged.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/1039

![dragging-behavior--3](https://user-images.githubusercontent.com/654102/38576079-156113c0-3ccb-11e8-8b5a-3de6930b890d.gif)
![dragging-behavior](https://user-images.githubusercontent.com/654102/38576080-1572e0aa-3ccb-11e8-82e6-216f1cd777c2.gif)

Now scratch 3 matches scratch 2.