### PR TITLE
Only select the original target after a drag.

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -900,7 +900,8 @@ class VirtualMachine extends EventEmitter {
         if (target) {
             this._dragTarget = null;
             target.stopDrag();
-            this.setEditingTarget(target.sprite.clones[0].id);
+            this.setEditingTarget(target.sprite && target.sprite.clones[0] ?
+                target.sprite.clones[0].id : target.id);
         }
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -900,7 +900,7 @@ class VirtualMachine extends EventEmitter {
         if (target) {
             this._dragTarget = null;
             target.stopDrag();
-            this.setEditingTarget(target.id);
+            this.setEditingTarget(target.sprite.clones[0].id);
         }
     }
 

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -379,3 +379,30 @@ test('drag IO redirect', t => {
     t.equal(sprite2Info[1], 'sprite2 info 2');
     t.end();
 });
+
+test('select original after dragging clone', t => {
+    const vm = new VirtualMachine();
+    let newEditingTargetId = null;
+    vm.setEditingTarget = id => {
+        newEditingTargetId = id;
+    };
+    vm.runtime.targets = [
+        {
+            id: 'sprite1_clone',
+            sprite: {clones: [{id: 'sprite1_original'}]},
+            stopDrag: () => {}
+        }, {
+            id: 'sprite2',
+            stopDrag: () => {}
+        }
+    ];
+
+    // Stop drag on a bare target selects that target
+    vm.stopDrag('sprite2');
+    t.equal(newEditingTargetId, 'sprite2');
+
+    // Stop drag on target with parent sprite selects the 0th clone of that sprite
+    vm.stopDrag('sprite1_clone');
+    t.equal(newEditingTargetId, 'sprite1_original');
+    t.end();
+});


### PR DESCRIPTION
This allows you to still drag clones around, but when you stop dragging,
the original sprite gets selected.

### Resolves

_What Github issue does this resolve (please include link)?_
Resolves https://github.com/LLK/scratch-gui/issues/638
Resolves https://github.com/LLK/scratch-gui/issues/721

### Proposed Changes

_Describe what this Pull Request does_
Select the original sprite after dragging a clone.

### Reason for Changes

_Explain why these changes should be made_

It was putting the UI into a broken state. 

![clone-dragging](https://user-images.githubusercontent.com/654102/38576506-53d29c54-3ccc-11e8-9f7c-e21fc5981097.gif)

