### PR TITLE
Drag Fix Part 2

### DIFF
--- a/scratch-render.js
+++ b/scratch-render.js
@@ -13211,6 +13211,7 @@ var RenderWebGL = function (_EventEmitter) {
             // and readback by returning early.
             candidateIDs = candidateIDs.filter(function (testID) {
                 if (testID === drawableID) return false;
+		    if (dragginglist[testID]=true) return false;
                 // Only draw items which could possibly overlap target Drawable.
                 var candidate = _this3._allDrawables[testID];
                 var candidateBounds = candidate.getFastBounds();


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/1039

### Proposed Changes

This will apply the new array to the scratch-render.js file in the gh-pages branch.

### Reason for Changes

To only allow touching []? booleans if the candidate drawable isn't being dragged.
 
### Test Coverage

I unfortunately couldn't test it due to downloading errors for the vm.