### PR TITLE
Rename pen 'clear' to 'erase all'

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -297,7 +297,7 @@ class Scratch3PenBlocks {
                     blockType: BlockType.COMMAND,
                     text: formatMessage({
                         id: 'pen.clear',
-                        default: 'clear',
+                        default: 'erase all',
                         description: 'erase all pen trails and stamps'
                     })
                 },


### PR DESCRIPTION
### Resolves

Resolves GH-1056

### Proposed Changes

- Changes pen "clear" to "erase all"

### Reason for Changes

- There is a sense that the word "clear" may be confusing / ambiguous. As per discussion we decided to narrow the scope of this change to just the pen block.

### Note

- I only changed the block text and not the underlying opcode naming. This was intentional until we are sure that this change will "stick".

/cc @ntlrsk 