### PR TITLE
Fix video motion in Safari/Firefox

### DIFF
--- a/src/extensions/scratch3_video_sensing/library.js
+++ b/src/extensions/scratch3_video_sensing/library.js
@@ -162,7 +162,7 @@ class VideoMotion {
         this.prev = this.curr;
         // Create a clone of the array so any modifications made to the source
         // array do not affect the work done in here.
-        this.curr = new Uint32Array(source.buffer.slice());
+        this.curr = new Uint32Array(source.buffer.slice(0));
 
         // Swap _prev and _curr. Copy one of the color components of the new
         // array into _curr overwriting what was the old _prev data.

--- a/src/io/video.js
+++ b/src/io/video.js
@@ -255,7 +255,6 @@ class Video {
                 } catch (error) {
                     this._video.src = window.URL.createObjectURL(stream);
                 }
-                this._video.play();
                 // Hint to the stream that it should load. A standard way to do this
                 // is add the video tag to the DOM. Since this extension wants to
                 // hide the video tag and instead render a sample of the stream into

--- a/src/io/video.js
+++ b/src/io/video.js
@@ -240,23 +240,28 @@ class Video {
             return this._singleSetup;
         }
 
-        this._singleSetup = new Promise((resolve, reject) => {
-            navigator.getUserMedia({
-                audio: false,
-                video: {
-                    width: {min: 480, ideal: 640},
-                    height: {min: 360, ideal: 480}
-                }
-            }, resolve, reject);
+        this._singleSetup = navigator.mediaDevices.getUserMedia({
+            audio: false,
+            video: {
+                width: {min: 480, ideal: 640},
+                height: {min: 360, ideal: 480}
+            }
         })
             .then(stream => {
                 this._video = document.createElement('video');
-                this._video.src = window.URL.createObjectURL(stream);
+                // Use the new srcObject API, falling back to createObjectURL
+                try {
+                    this._video.srcObject = stream;
+                } catch (error) {
+                    this._video.src = window.URL.createObjectURL(stream);
+                }
+                this._video.play();
                 // Hint to the stream that it should load. A standard way to do this
                 // is add the video tag to the DOM. Since this extension wants to
                 // hide the video tag and instead render a sample of the stream into
                 // the webgl rendered Scratch canvas, another hint like this one is
                 // needed.
+                this._video.play(); // Needed for Safari/Firefox, Chrome auto-plays.
                 this._track = stream.getTracks()[0];
                 this._setupPreview();
                 return this;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/1055

### Proposed Changes

_Describe what this Pull Request does_

Most of the diff is actually just an indentation change, so just look for these three things.

1. Use the new `mediaDevices` API the same way the loudness block does.
2. Use `srcObject`, falling back to `createObjectURL`
3. Call `video.play` to start video on Safari/Firefox when using `srcObject`
3. Fix bug with ArrayBuffer.slice() with no params throwing in Safari.

### Reason for Changes

_Explain why these changes should be made_

Fix browser compatibility for video motion!

### Test Coverage

_Please show how you have added tests to cover your changes_
