### PR TITLE
Change displayed name to Video Motion

### DIFF
--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -337,7 +337,7 @@ class Scratch3VideoSensingBlocks {
     getInfo () {
         return {
             id: 'videoSensing',
-            name: 'Video Sensing',
+            name: 'Video Motion',
             blocks: [
                 {
                     opcode: 'videoOn',


### PR DESCRIPTION
Update the name because of the name change in GUI. Didn't want to update all the other references to video sensing, but at some point we might want to do that. 

Because scroll-to-category is by category name, the other issue with having this name be out of sync is that it isn't automatically scrolling to the video motion blocks when you add the extension.