### PR TITLE
Update sound metadata and retrieve mp3 correctly from storage

### DIFF
--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -25,7 +25,7 @@ const loadSoundFromAsset = function (sound, soundAsset, runtime) {
         // Set the sound sample rate and sample count based on the
         // the audio buffer from the audio engine since the sound
         // gets resampled by the audio engine
-        const soundBuffer = runtime.udioEngine.getSoundBuffer(soundId);
+        const soundBuffer = runtime.audioEngine.getSoundBuffer(soundId);
         sound.rate = soundBuffer.sampleRate;
         sound.sampleCount = soundBuffer.length;
 

--- a/src/import/load-sound.js
+++ b/src/import/load-sound.js
@@ -22,6 +22,13 @@ const loadSoundFromAsset = function (sound, soundAsset, runtime) {
         {data: soundAsset.data}
     )).then(soundId => {
         sound.soundId = soundId;
+        // Set the sound sample rate and sample count based on the
+        // the audio buffer from the audio engine since the sound
+        // gets resampled by the audio engine
+        const soundBuffer = runtime.udioEngine.getSoundBuffer(soundId);
+        sound.rate = soundBuffer.sampleRate;
+        sound.sampleCount = soundBuffer.length;
+
         return sound;
     });
 };

--- a/src/serialization/deserialize-assets.js
+++ b/src/serialization/deserialize-assets.js
@@ -38,10 +38,8 @@ const deserializeSound = function (sound, runtime, zip, assetFileName) {
         log.error(`Could not find sound file associated with the ${sound.name} sound.`);
         return Promise.resolve(null);
     }
-    let dataFormat = null;
-    if (sound.dataFormat.toLowerCase() === 'wav') {
-        dataFormat = storage.DataFormat.WAV;
-    }
+    const dataFormat = sound.dataFormat.toLowerCase() === 'mp3' ?
+        storage.DataFormat.MP3 : storage.DataFormat.WAV;
     if (!JSZip.support.uint8array) {
         log.error('JSZip uint8array is not supported in this browser.');
         return Promise.resolve(null);


### PR DESCRIPTION
Use sound returned from audio engine to set sample rate and sample count since the sound gets resampled by the audio engine. Also, check for an mp3 format in deserialize assets, and otherwise default to wav.

### Reason for Changes

Towards the support of LLK/scratch-gui#1776

### Test Coverage

Existing tests pass.

### Related PRs
LLK/scratch-gui#1779