### PR TITLE
Load costume without metadata

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -69,8 +69,8 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
 
         if (!rotationCenter) {
             rotationCenter = renderer.getSkinRotationCenter(costume.skinId);
-            costume.rotationCenterX = rotationCenter[0];
-            costume.rotationCenterY = rotationCenter[1];
+            costume.rotationCenterX = rotationCenter[0] * 2;
+            costume.rotationCenterY = rotationCenter[1] * 2;
         }
         return costume;
     });

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -15,7 +15,8 @@ const log = require('../util/log');
  */
 const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
     costume.assetId = costumeAsset.assetId;
-    if (!runtime.renderer) {
+    const renderer = runtime.renderer;
+    if (!renderer) {
         log.error('No rendering module present; cannot load costume: ', costume.name);
         return costume;
     }
@@ -30,8 +31,15 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
     if (costumeAsset.assetType === AssetType.ImageVector) {
         // createSVGSkin does the right thing if rotationCenter isn't provided, so it's okay if it's
         // undefined here
-        costume.skinId = runtime.renderer.createSVGSkin(costumeAsset.decodeText(), rotationCenter);
-        costume.size = runtime.renderer.getSkinSize(costume.skinId);
+        costume.skinId = renderer.createSVGSkin(costumeAsset.decodeText(), rotationCenter);
+        costume.size = renderer.getSkinSize(costume.skinId);
+        // Now we should have a rotationCenter even if we didn't before
+        if (!rotationCenter) {
+            rotationCenter = renderer.getSkinRotationCenter(costume.skinId);
+            costume.rotationCenterX = rotationCenter[0];
+            costume.rotationCenterY = rotationCenter[1];
+        }
+
         return costume;
     }
 
@@ -56,8 +64,14 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
         imageElement.src = costumeAsset.encodeDataURI();
     }).then(imageElement => {
         // createBitmapSkin does the right thing if costume.bitmapResolution or rotationCenter are undefined...
-        costume.skinId = runtime.renderer.createBitmapSkin(imageElement, costume.bitmapResolution, rotationCenter);
-        costume.size = runtime.renderer.getSkinSize(costume.skinId);
+        costume.skinId = renderer.createBitmapSkin(imageElement, costume.bitmapResolution, rotationCenter);
+        costume.size = renderer.getSkinSize(costume.skinId);
+
+        if (!rotationCenter) {
+            rotationCenter = renderer.getSkinRotationCenter(costume.skinId);
+            costume.rotationCenterX = rotationCenter[0];
+            costume.rotationCenterY = rotationCenter[1];
+        }
         return costume;
     });
 };

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -20,11 +20,16 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
         return costume;
     }
     const AssetType = runtime.storage.AssetType;
-    const rotationCenter = [
-        costume.rotationCenterX / costume.bitmapResolution,
-        costume.rotationCenterY / costume.bitmapResolution
-    ];
+    let rotationCenter;
+    if (costume.rotationCenterX && costume.rotationCenterY && costume.bitmapResolution) {
+        rotationCenter = [
+            costume.rotationCenterX / costume.bitmapResolution,
+            costume.rotationCenterY / costume.bitmapResolution
+        ];
+    }
     if (costumeAsset.assetType === AssetType.ImageVector) {
+        // createSVGSkin does the right thing if rotationCenter isn't provided, so it's okay if it's
+        // undefined here
         costume.skinId = runtime.renderer.createSVGSkin(costumeAsset.decodeText(), rotationCenter);
         costume.size = runtime.renderer.getSkinSize(costume.skinId);
         return costume;
@@ -50,6 +55,7 @@ const loadCostumeFromAsset = function (costume, costumeAsset, runtime) {
         imageElement.addEventListener('load', onLoad);
         imageElement.src = costumeAsset.encodeDataURI();
     }).then(imageElement => {
+        // createBitmapSkin does the right thing if costume.bitmapResolution or rotationCenter are undefined...
         costume.skinId = runtime.renderer.createBitmapSkin(imageElement, costume.bitmapResolution, rotationCenter);
         costume.size = runtime.renderer.getSkinSize(costume.skinId);
         return costume;

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -438,7 +438,7 @@ class RenderedTarget extends Target {
                 typeof costume.rotationCenterX !== 'undefined' &&
                 typeof costume.rotationCenterY !== 'undefined'
             ) {
-                const scale = costume.bitmapResolution || 1;
+                const scale = costume.bitmapResolution || 2;
                 drawableProperties.rotationCenter = [
                     costume.rotationCenterX / scale,
                     costume.rotationCenterY / scale
@@ -625,7 +625,7 @@ class RenderedTarget extends Target {
         if (this.renderer) {
             const renderedDirectionScale = this._getRenderedDirectionAndScale();
             const costume = this.getCostumes()[this.currentCostume];
-            const bitmapResolution = costume.bitmapResolution || 1;
+            const bitmapResolution = costume.bitmapResolution || 2;
             const props = {
                 position: [this.x, this.y],
                 direction: renderedDirectionScale.direction,

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -405,8 +405,8 @@ class VirtualMachine extends EventEmitter {
      * @returns {?Promise} - a promise that resolves when the costume has been added
      */
     addCostume (md5ext, costumeObject) {
-        return loadCostume(md5ext, costumeObject, this.runtime).then(loadedCostume => {
-            this.editingTarget.addCostume(loadedCostume);
+        return loadCostume(md5ext, costumeObject, this.runtime).then(() => {
+            this.editingTarget.addCostume(costumeObject);
             this.editingTarget.setCostume(
                 this.editingTarget.getCostumes().length - 1
             );

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -405,8 +405,8 @@ class VirtualMachine extends EventEmitter {
      * @returns {?Promise} - a promise that resolves when the costume has been added
      */
     addCostume (md5ext, costumeObject) {
-        return loadCostume(md5ext, costumeObject, this.runtime).then(() => {
-            this.editingTarget.addCostume(costumeObject);
+        return loadCostume(md5ext, costumeObject, this.runtime).then(loadedCostume => {
+            this.editingTarget.addCostume(loadedCostume);
             this.editingTarget.setCostume(
                 this.editingTarget.getCostumes().length - 1
             );


### PR DESCRIPTION
### Resolves

Towards resolving LLK/scratch-gui#1777

### Proposed Changes

Allows for loading costume data without having associated metadata like resolutionCenterX/Y and bitmapResolution. If resolutionCenter is not provided, gets it from the renderer after the costume has been loaded there. This makes it so that the paint editor can also make use of this value in determining where to place the freshly loaded costume.

### Reason for Changes

LLK/scratch-gui#1777, also in support of: LLK/scratch-gui#1836 and depends on LLK/scratch-render#260

### Test Coverage

Existing tests pass.