### PR TITLE
Activate stage click hats if no other sprites are clicked

### DIFF
--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -44,6 +44,12 @@ class Mouse {
                     return;
                 }
             }
+            // If haven't returned, activate click hats for stage.
+            // Still using both blocks for sharing compatibility.
+            this.runtime.startHats('event_whenthisspriteclicked',
+                null, this.runtime.getTargetForStage());
+            this.runtime.startHats('event_whenstageclicked',
+                null, this.runtime.getTargetForStage());
         }
     }
 
@@ -70,7 +76,10 @@ class Mouse {
         }
         if (typeof data.isDown !== 'undefined') {
             this._isDown = data.isDown;
-            if (!this._isDown) {
+            // Make sure click is within the canvas bounds to activate click hats
+            if (!this._isDown &&
+                data.x > 0 && data.x < data.canvasWidth &&
+                data.y > 0 && data.y < data.canvasHeight) {
                 this._activateClickHats(data.x, data.y, data.wasDragged);
             }
         }


### PR DESCRIPTION
Also check the bounds before to make sure clicks are inside the stage bounds.

### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-gui/issues/1668
### Proposed Changes

_Describe what this Pull Request does_
Check if the x/y are within the bounds sent along with the mouse io events, and trigger the when clicked hats for the stage if no other targets are hit.

### Reason for Changes

_Explain why these changes should be made_

Stage click is activated even if the stage is transparent, so make all clicks end up hitting the stage if they hit nothing else.

### Test Coverage

_Please show how you have added tests to cover your changes_

I used this test case to make sure it worked, including making sure that clicks "pass through" stamped sprites.

#218122026

This gif shows testing in scratch 2, scratch3/develop and finally scratch3 w/ this fix.

![click-test](https://user-images.githubusercontent.com/654102/39145957-5e9fda16-4703-11e8-94f7-12700dfa9a59.gif)
