### PR TITLE
 Re-write keyboard IO for droppability support

### DIFF
--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -85,7 +85,7 @@ class Keyboard {
         keyArg = Cast.toString(keyArg);
 
         // If the arg matches a special key name, return it.
-        const keyNameList = Object.values(Keyboard.KEY_NAMES);
+        const keyNameList = Object.keys(Keyboard.KEY_NAMES).map(name => Keyboard.KEY_NAMES[name]);
         if (keyNameList.includes(keyArg)) {
             return keyArg;
         }

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -22,21 +22,15 @@ class Keyboard {
      * @private
      */
     _scratchKeyToKeyCode (keyName) {
-        if (typeof keyName === 'number') {
-            // Key codes placed in with number blocks.
-            return keyName;
-        }
         const keyString = Cast.toString(keyName);
         switch (keyString) {
-        case 'space': return 32;
-        case 'left arrow': return 37;
-        case 'up arrow': return 38;
-        case 'right arrow': return 39;
-        case 'down arrow': return 40;
-        // @todo: Consider adding other special keys here.
+        case ' ': return 'space';
+        case 'ArrowLeft': return 'left arrow';
+        case 'ArrowRight': return 'right arrow';
+        case 'ArrowUp': return 'up arrow';
+        case 'ArrowDown': return 'down arrow';
         }
-        // Keys reported by DOM keyCode are upper case.
-        return keyString.toUpperCase().charCodeAt(0);
+        return keyName;
     }
 
     /**
@@ -46,18 +40,7 @@ class Keyboard {
      * @private
      */
     _keyCodeToScratchKey (keyCode) {
-        if (keyCode >= 48 && keyCode <= 90) {
-            // Standard letter.
-            return String.fromCharCode(keyCode).toLowerCase();
-        }
-        switch (keyCode) {
-        case 32: return 'space';
-        case 37: return 'left arrow';
-        case 38: return 'up arrow';
-        case 39: return 'right arrow';
-        case 40: return 'down arrow';
-        }
-        return '';
+        return keyCode;
     }
 
     /**
@@ -65,16 +48,17 @@ class Keyboard {
      * @param  {object} data Data from DOM event.
      */
     postData (data) {
-        if (data.keyCode) {
-            const index = this._keysPressed.indexOf(data.keyCode);
+        const keyCode = this._scratchKeyToKeyCode(data.key);
+        if (keyCode) {
+            const index = this._keysPressed.indexOf(keyCode);
             if (data.isDown) {
                 // If not already present, add to the list.
                 if (index < 0) {
-                    this._keysPressed.push(data.keyCode);
+                    this._keysPressed.push(keyCode);
                 }
                 // Always trigger hats, even if it was already pressed.
                 this.runtime.startHats('event_whenkeypressed', {
-                    KEY_OPTION: this._keyCodeToScratchKey(data.keyCode)
+                    KEY_OPTION: this._keyCodeToScratchKey(keyCode)
                 });
                 this.runtime.startHats('event_whenkeypressed', {
                     KEY_OPTION: 'any'

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -90,6 +90,11 @@ class Keyboard {
             keyArg = keyArg[0];
         }
 
+        // Check for the space character.
+        if (keyArg === ' ') {
+            return 'space';
+        }
+
         return keyArg.toUpperCase();
     }
 

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -1,5 +1,23 @@
 const Cast = require('../util/cast');
 
+/**
+ * Names used internally for keys used in scratch, also known as "scratch keys".
+ * @enum {string}
+ */
+const KEY_NAME = {
+    SPACE: 'space',
+    LEFT: 'left arrow',
+    UP: 'up arrow',
+    RIGHT: 'right arrow',
+    DOWN: 'down arrow'
+};
+
+/**
+ * An array of the names of scratch keys.
+ * @type {Array<string>}
+ */
+const KEY_NAME_LIST = Object.keys(KEY_NAME).map(name => KEY_NAME[name]);
+
 class Keyboard {
     constructor (runtime) {
         /**
@@ -21,20 +39,6 @@ class Keyboard {
     }
 
     /**
-     * Names used for a set of special keys in Scratch.
-     * @type {ScratchKey}
-     */
-    static get KEY_NAMES () {
-        return {
-            SPACE: 'space',
-            LEFT: 'left arrow',
-            UP: 'up arrow',
-            RIGHT: 'right arrow',
-            DOWN: 'down arrow'
-        };
-    }
-
-    /**
      * Convert from a keyboard event key name to a Scratch key name.
      * @param  {string} keyString the input key string.
      * @return {string} the corresponding Scratch key, or an empty string.
@@ -43,15 +47,15 @@ class Keyboard {
         keyString = Cast.toString(keyString);
         // Convert space and arrow keys to their Scratch key names.
         switch (keyString) {
-        case ' ': return Keyboard.KEY_NAMES.SPACE;
+        case ' ': return KEY_NAME.SPACE;
         case 'ArrowLeft':
-        case 'Left': return Keyboard.KEY_NAMES.LEFT;
+        case 'Left': return KEY_NAME.LEFT;
         case 'ArrowUp':
-        case 'Up': return Keyboard.KEY_NAMES.UP;
+        case 'Up': return KEY_NAME.UP;
         case 'Right':
-        case 'ArrowRight': return Keyboard.KEY_NAMES.RIGHT;
+        case 'ArrowRight': return KEY_NAME.RIGHT;
         case 'Down':
-        case 'ArrowDown': return Keyboard.KEY_NAMES.DOWN;
+        case 'ArrowDown': return KEY_NAME.DOWN;
         }
         // Ignore modifier keys
         if (keyString.length > 1) {
@@ -74,19 +78,18 @@ class Keyboard {
                 return String.fromCharCode(keyArg);
             }
             switch (keyArg) {
-            case 32: return Keyboard.KEY_NAMES.SPACE;
-            case 37: return Keyboard.KEY_NAMES.LEFT;
-            case 38: return Keyboard.KEY_NAMES.UP;
-            case 39: return Keyboard.KEY_NAMES.RIGHT;
-            case 40: return Keyboard.KEY_NAMES.DOWN;
+            case 32: return KEY_NAME.SPACE;
+            case 37: return KEY_NAME.LEFT;
+            case 38: return KEY_NAME.UP;
+            case 39: return KEY_NAME.RIGHT;
+            case 40: return KEY_NAME.DOWN;
             }
         }
 
         keyArg = Cast.toString(keyArg);
 
         // If the arg matches a special key name, return it.
-        const keyNameList = Object.keys(Keyboard.KEY_NAMES).map(name => Keyboard.KEY_NAMES[name]);
-        if (keyNameList.includes(keyArg)) {
+        if (KEY_NAME_LIST.includes(keyArg)) {
             return keyArg;
         }
 
@@ -97,7 +100,7 @@ class Keyboard {
 
         // Check for the space character.
         if (keyArg === ' ') {
-            return Keyboard.KEY_NAMES.SPACE;
+            return KEY_NAME.SPACE;
         }
 
         return keyArg.toUpperCase();

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -44,9 +44,13 @@ class Keyboard {
         // Convert space and arrow keys to their Scratch key names.
         switch (keyString) {
         case ' ': return 'space';
-        case 'ArrowLeft': return 'left arrow';
-        case 'ArrowUp': return 'up arrow';
+        case 'ArrowLeft':
+        case 'Left': return 'left arrow';
+        case 'ArrowUp':
+        case 'Up': return 'up arrow';
+        case 'Right':
         case 'ArrowRight': return 'right arrow';
+        case 'Down':
         case 'ArrowDown': return 'down arrow';
         }
         // Ignore modifier keys

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -22,16 +22,16 @@ class Keyboard {
 
     /**
      * Names used for a set of special keys in Scratch.
-     * @type {Array.<string>}
+     * @type {ScratchKey}
      */
-    static get SPECIAL_KEY_NAMES () {
-        return [
-            'space',
-            'left arrow',
-            'up arrow',
-            'right arrow',
-            'down arrow'
-        ];
+    static get KEY_NAMES () {
+        return {
+            SPACE: 'space',
+            LEFT: 'left arrow',
+            UP: 'up arrow',
+            RIGHT: 'right arrow',
+            DOWN: 'down arrow'
+        };
     }
 
     /**
@@ -43,15 +43,15 @@ class Keyboard {
         keyString = Cast.toString(keyString);
         // Convert space and arrow keys to their Scratch key names.
         switch (keyString) {
-        case ' ': return 'space';
+        case ' ': return Keyboard.KEY_NAMES.SPACE;
         case 'ArrowLeft':
-        case 'Left': return 'left arrow';
+        case 'Left': return Keyboard.KEY_NAMES.LEFT;
         case 'ArrowUp':
-        case 'Up': return 'up arrow';
+        case 'Up': return Keyboard.KEY_NAMES.UP;
         case 'Right':
-        case 'ArrowRight': return 'right arrow';
+        case 'ArrowRight': return Keyboard.KEY_NAMES.RIGHT;
         case 'Down':
-        case 'ArrowDown': return 'down arrow';
+        case 'ArrowDown': return Keyboard.KEY_NAMES.DOWN;
         }
         // Ignore modifier keys
         if (keyString.length > 1) {
@@ -74,18 +74,19 @@ class Keyboard {
                 return String.fromCharCode(keyArg);
             }
             switch (keyArg) {
-            case 32: return 'space';
-            case 37: return 'left arrow';
-            case 38: return 'up arrow';
-            case 39: return 'right arrow';
-            case 40: return 'down arrow';
+            case 32: return Keyboard.KEY_NAMES.SPACE;
+            case 37: return Keyboard.KEY_NAMES.LEFT;
+            case 38: return Keyboard.KEY_NAMES.UP;
+            case 39: return Keyboard.KEY_NAMES.RIGHT;
+            case 40: return Keyboard.KEY_NAMES.DOWN;
             }
         }
 
         keyArg = Cast.toString(keyArg);
 
         // If the arg matches a special key name, return it.
-        if (Keyboard.SPECIAL_KEY_NAMES.includes(keyArg)) {
+        const keyNameList = Object.values(Keyboard.KEY_NAMES);
+        if (keyNameList.includes(keyArg)) {
             return keyArg;
         }
 
@@ -96,7 +97,7 @@ class Keyboard {
 
         // Check for the space character.
         if (keyArg === ' ') {
-            return 'space';
+            return Keyboard.KEY_NAMES.SPACE;
         }
 
         return keyArg.toUpperCase();

--- a/test/unit/io_keyboard.js
+++ b/test/unit/io_keyboard.js
@@ -12,45 +12,75 @@ test('spec', t => {
     t.end();
 });
 
-test('space', t => {
+test('space key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
 
     k.postData({
-        keyCode: 32,
+        key: ' ',
         isDown: true
     });
-    t.strictDeepEquals(k._keysPressed, [32]);
+    t.strictDeepEquals(k._keysPressed, ['space']);
     t.strictEquals(k.getKeyIsDown('space'), true);
     t.strictEquals(k.getKeyIsDown('any'), true);
     t.end();
 });
 
-test('letter', t => {
+test('letter key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
 
     k.postData({
-        keyCode: 65,
+        key: 'a',
         isDown: true
     });
-    t.strictDeepEquals(k._keysPressed, [65]);
+    t.strictDeepEquals(k._keysPressed, ['A']);
+    t.strictEquals(k.getKeyIsDown(65), true);
     t.strictEquals(k.getKeyIsDown('a'), true);
+    t.strictEquals(k.getKeyIsDown('A'), true);
     t.strictEquals(k.getKeyIsDown('any'), true);
     t.end();
 });
 
-test('number', t => {
+test('number key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
 
     k.postData({
-        keyCode: 49,
+        key: '1',
         isDown: true
     });
-    t.strictDeepEquals(k._keysPressed, [49]);
+    t.strictDeepEquals(k._keysPressed, ['1']);
     t.strictEquals(k.getKeyIsDown(49), true);
+    t.strictEquals(k.getKeyIsDown('1'), true);
     t.strictEquals(k.getKeyIsDown('any'), true);
+    t.end();
+});
+
+test('non-english key', t => {
+    const rt = new Runtime();
+    const k = new Keyboard(rt);
+
+    k.postData({
+        key: '日',
+        isDown: true
+    });
+    t.strictDeepEquals(k._keysPressed, ['日']);
+    t.strictEquals(k.getKeyIsDown('日'), true);
+    t.strictEquals(k.getKeyIsDown('any'), true);
+    t.end();
+});
+
+test('ignore modifier key', t => {
+    const rt = new Runtime();
+    const k = new Keyboard(rt);
+
+    k.postData({
+        key: 'Shift',
+        isDown: true
+    });
+    t.strictDeepEquals(k._keysPressed, []);
+    t.strictEquals(k.getKeyIsDown('any'), false);
     t.end();
 });
 
@@ -59,15 +89,15 @@ test('keyup', t => {
     const k = new Keyboard(rt);
 
     k.postData({
-        keyCode: 37,
+        key: 'ArrowLeft',
         isDown: true
     });
     k.postData({
-        keyCode: 37,
+        key: 'ArrowLeft',
         isDown: false
     });
     t.strictDeepEquals(k._keysPressed, []);
-    t.strictEquals(k.getKeyIsDown(37), false);
+    t.strictEquals(k.getKeyIsDown('left arrow'), false);
     t.strictEquals(k.getKeyIsDown('any'), false);
     t.end();
 });


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/980
Depends on https://github.com/LLK/scratch-gui/pull/1869

### Proposed Changes

Update the keyboard IO system to support new use cases for the droppable input to the `key pressed?` boolean block.

A "scratch key" is defined internally as: 
- A key you can press on a keyboard, excluding modifier keys.
- It is an uppercase string of length one;
- Except for special key names for arrow keys and space (e.g. 'left arrow').
- Can be a non-english unicode letter like: æ ø ש נ 手 廿.

Generally, the key pressed hat and key pressed boolean should work as before, when their menu items are used.

But now, you can drop a variable onto the input of the key pressed boolean, with these behaviors:

- If you drop in a block that reports a string matching any of the standard scratch keys (such as 'space', 'left arrow', '1' or 'a') it should work.
- If you drop in a block that reports a number that matches the numeric key code of any of the standard scratch keys, it should work (32 for space, 37 for left arrow, 65 for A, etc).
- If you drop in a number that does not match a scratch key, it should detect the key matching the first digit of the number (e.g. dropped-in 99 should detect pressing the key '9'). 
- Similarly, if you drop in a multi-letter string, it should detect the key matching the first letter.
- Case is ignored: dropped-in 65, 'A' or 'a' should report true for pressing 'A' or 'a'.
- Dropped-in single letter non-english unicode characters should work as expected. Typing them generally requires switching to a non-english keyboard (I tried a few characters in Danish, Hebrew and Cangjie).

Note that I made a little test project that lets you play with many of these behaviors:
#218695578

**'any' key option does not respond to modifiers**
Note that this change causes a difference in the behavior when the 'any' key option is used: in Scratch 2.0, it returns true for modifier keys, but after this change it does not. I think this behavior matches the intent of @thisandagain's recommendation to not allow blocks to respond to modifier keys.

**Some unicode characters don't work on Mac Firefox**
Using the Cangjie keyboard on Mac Chrome, for example, you can set a variable to the character 日 (by pressing the key labeled 'a' on an English keyboard), drop it into the key pressed block, and it will return true if you hold down that same key. On Mac Firefox, you can set the variable by typing the character in the same way, but pressing the same key does not make the key pressed block return true. Instead, the keyboard event.key comes through as an 'a'. 

### Reason for Changes

- Maintaining support for some projects that used hacked key pressed blocks.
- Expanding support for dropped-in unicode characters.

### Test Coverage

I've updated the tests and added a couple additional ones.
