### PR TITLE
Included a function to add sprite 3  to vm

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -396,10 +396,10 @@ class VirtualMachine extends EventEmitter {
 
     /**
      * Add a single sb3 sprite.
-     * @param {string} json JSON string representing the sprite/target.
+     * @param {string} target JSON string representing the sprite/target.
      * @returns {Promise} Promise that resolves after the sprite is added
      */
-    addSprite3(target) {
+    addSprite3 (target) {
         // Validate & parse
         if (typeof target !== 'string') {
             log.error('Failed to parse sprite. Non-string supplied to addSprite3.');
@@ -412,12 +412,12 @@ class VirtualMachine extends EventEmitter {
         }
 
         const jsonFormatted = {
-            targets: [target],
+            targets: [target]
         };
 
         return sb3
             .deserialize(jsonFormatted, this.runtime, null)
-            .then(({ targets, extensions }) => this.installTargets(targets, extensions, false));
+            .then(({targets, extensions}) => this.installTargets(targets, extensions, false));
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -395,6 +395,32 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * Add a single sb3 sprite.
+     * @param {string} json JSON string representing the sprite/target.
+     * @returns {Promise} Promise that resolves after the sprite is added
+     */
+    addSprite3(target) {
+        // Validate & parse
+        if (typeof target !== 'string') {
+            log.error('Failed to parse sprite. Non-string supplied to addSprite3.');
+            return;
+        }
+        target = JSON.parse(target);
+        if (typeof target !== 'object') {
+            log.error('Failed to parse sprite. JSON supplied to addSprite3 is not an object.');
+            return;
+        }
+
+        const jsonFormatted = {
+            targets: [target],
+        };
+
+        return sb3
+            .deserialize(jsonFormatted, this.runtime, null)
+            .then(({ targets, extensions }) => this.installTargets(targets, extensions, false));
+    }
+
+    /**
      * Add a costume to the current editing target.
      * @param {string} md5ext - the MD5 and extension of the costume to be loaded.
      * @param {!object} costumeObject Object representing the costume.


### PR DESCRIPTION
We would like to add and remove sb3 targets/sprites to a sb3 project.

We can see that it is only possible to add a sb2 target/sprite using 'addSprite2' at the moment. However using this method to add targets to a sb3 project results in errors - obviously.

We have experimented with modifying the VM by adding a addSprite3 function that uses the sb3 deserializer and it works. We made a pull request and was hoping that you could take a look at it and accept it, or find an alternative solution to adding sb3 targets to the vm. Is this something you can help us with?