### PR TITLE
Cast 'create clone' argument to string

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -144,15 +144,21 @@ class Scratch3ControlBlocks {
     }
 
     createClone (args, util) {
+        // Cast argument to string
+        args.CLONE_OPTION = Cast.toString(args.CLONE_OPTION);
+
+        // Set clone target
         let cloneTarget;
         if (args.CLONE_OPTION === '_myself_') {
             cloneTarget = util.target;
         } else {
             cloneTarget = this.runtime.getSpriteTargetByName(args.CLONE_OPTION);
         }
-        if (!cloneTarget) {
-            return;
-        }
+
+        // If clone target is not found, return
+        if (!cloneTarget) return;
+
+        // Create clone
         const newClone = cloneTarget.makeClone();
         if (newClone) {
             this.runtime.targets.push(newClone);


### PR DESCRIPTION
### Resolves
Resolves GH-974

### Proposed Changes
Ensure that the `CLONE_OPTION` argument is a string before being passed to the `getSpriteTargetByName` runtime method.

### Reason for Changes
Because the `create clone of ( )` input is droppable, blocks like `pick random` may be used which return a numeric value.

### Reference
Screenshot of project as reported in the original issue after applying the patch:
![image](https://user-images.githubusercontent.com/747641/39312267-30b6be76-493d-11e8-9279-19bd8e9c1ec0.png)
