### PR TITLE
Track say/thinks per target so they can maintain correct timing.

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -11,6 +11,8 @@ const uid = require('../util/uid');
  *      See _renderBubble for explanation of this optimization.
  * @property {string} text - the text of the bubble.
  * @property {string} type - the type of the bubble, "say" or "think"
+ * @property {?string} usageId - ID indicating the most recent usage of the say/think bubble.
+ *      Used for comparison when determining whether to clear a say/think bubble.
  */
 
 class Scratch3LooksBlocks {
@@ -46,7 +48,7 @@ class Scratch3LooksBlocks {
             skinId: null,
             text: '',
             type: 'say',
-            usageId: null // ID for hiding a timed say/think block.
+            usageId: null
         };
     }
 

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -1,6 +1,7 @@
 const Cast = require('../util/cast');
 const Clone = require('../util/clone');
 const RenderedTarget = require('../sprites/rendered-target');
+const uid = require('../util/uid');
 
 /**
  * @typedef {object} BubbleState - the bubble state associated with a particular target.
@@ -44,7 +45,8 @@ class Scratch3LooksBlocks {
             onSpriteRight: true,
             skinId: null,
             text: '',
-            type: 'say'
+            type: 'say',
+            usageId: null // ID for hiding a timed say/think block.
         };
     }
 
@@ -224,6 +226,7 @@ class Scratch3LooksBlocks {
         const bubbleState = this._getBubbleState(target);
         bubbleState.type = type;
         bubbleState.text = text;
+        bubbleState.usageId = uid();
         this._renderBubble(target);
     }
 
@@ -277,12 +280,15 @@ class Scratch3LooksBlocks {
 
     sayforsecs (args, util) {
         this.say(args, util);
-        const _target = util.target;
+        const target = util.target;
+        const usageId = this._getBubbleState(target).usageId;
         return new Promise(resolve => {
             this._bubbleTimeout = setTimeout(() => {
                 this._bubbleTimeout = null;
-                // Clear say bubble and proceed.
-                this._updateBubble(_target, 'say', '');
+                // Clear say bubble if it hasn't been changed and proceed.
+                if (this._getBubbleState(target).usageId === usageId) {
+                    this._updateBubble(target, 'say', '');
+                }
                 resolve();
             }, 1000 * args.SECS);
         });
@@ -294,12 +300,15 @@ class Scratch3LooksBlocks {
 
     thinkforsecs (args, util) {
         this.think(args, util);
-        const _target = util.target;
+        const target = util.target;
+        const usageId = this._getBubbleState(target).usageId;
         return new Promise(resolve => {
             this._bubbleTimeout = setTimeout(() => {
                 this._bubbleTimeout = null;
-                // Clear say bubble and proceed.
-                this._updateBubble(_target, 'think', '');
+                // Clear think bubble if it hasn't been changed and proceed.
+                if (this._getBubbleState(target).usageId === usageId) {
+                    this._updateBubble(target, 'think', '');
+                }
                 resolve();
             }, 1000 * args.SECS);
         });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/1035

### Proposed Changes

_Describe what this Pull Request does_

Add a `usageId` to the bubble state (which is target specific) which changes each time it is updated. In the "say/think for secs" blocks, check that the usage ID is the same before clearing it when the timeout finishes.

### Reason for Changes

_Explain why these changes should be made_

There was a bug where interrupting a say with another timed say would keep the old timing. i.e.

![interrupting-say](https://user-images.githubusercontent.com/654102/39315777-897c4e60-4945-11e8-9382-d120e23f7fbd.gif)

This fixes that problem

![safely-interrupting-say](https://user-images.githubusercontent.com/654102/39315828-a757fb32-4945-11e8-8be2-46c26a94b5d3.gif)


---

It is worth noting that the "disappear but keep running" behavior of the say blocks matches 2.0, which may be important for compatibility. If a say block is interrupted by another, the block stays running for its original timing, and a stack won't keep going until that original time is up. That is why this change only impacts clearing the bubble at the end of the timeout, not the promise resolution itself.
