### PR TITLE
Fix say flickering

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -59,6 +59,14 @@ class Scratch3LooksBlocks {
     }
 
     /**
+     * Max block time we use the "soft clear" optimization to prevent flickering in "typewriter" projects.
+     * @type {string}
+     */
+    static get MAX_SOFT_CLEAR_TIME () {
+        return 0.02; // seconds
+    }
+
+    /**
      * @param {Target} target - collect bubble state for this target. Probably, but not necessarily, a RenderedTarget.
      * @returns {BubbleState} the mutable bubble state associated with that target. This will be created if necessary.
      * @private
@@ -282,12 +290,17 @@ class Scratch3LooksBlocks {
         this.say(args, util);
         const target = util.target;
         const usageId = this._getBubbleState(target).usageId;
+        const secs = args.SECS;
         return new Promise(resolve => {
             this._bubbleTimeout = setTimeout(() => {
                 this._bubbleTimeout = null;
                 // Clear say bubble if it hasn't been changed and proceed.
                 if (this._getBubbleState(target).usageId === usageId) {
-                    this._updateBubble(target, 'say', '');
+                    if (secs < this.MAX_SOFT_CLEAR_TIME) {
+                        this._updateBubble(target, 'say', '');
+                    } else {
+                        this._onTargetWillExit(target);
+                    }
                 }
                 resolve();
             }, 1000 * args.SECS);
@@ -302,12 +315,17 @@ class Scratch3LooksBlocks {
         this.think(args, util);
         const target = util.target;
         const usageId = this._getBubbleState(target).usageId;
+        const secs = args.SECS;
         return new Promise(resolve => {
             this._bubbleTimeout = setTimeout(() => {
                 this._bubbleTimeout = null;
                 // Clear think bubble if it hasn't been changed and proceed.
                 if (this._getBubbleState(target).usageId === usageId) {
-                    this._updateBubble(target, 'think', '');
+                    if (secs < this.MAX_SOFT_CLEAR_TIME) {
+                        this._updateBubble(target, 'think', '');
+                    } else {
+                        this._onTargetWillExit(target);
+                    }
                 }
                 resolve();
             }, 1000 * args.SECS);

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -7,8 +7,6 @@ const uid = require('../util/uid');
  * @typedef {object} BubbleState - the bubble state associated with a particular target.
  * @property {Boolean} onSpriteRight - tracks whether the bubble is right or left of the sprite.
  * @property {?int} drawableId - the ID of the associated bubble Drawable, null if none.
- * @property {Boolean} drawableVisible - false if drawable has been hidden by blank text.
- *      See _renderBubble for explanation of this optimization.
  * @property {string} text - the text of the bubble.
  * @property {string} type - the type of the bubble, "say" or "think"
  * @property {?string} usageId - ID indicating the most recent usage of the say/think bubble.
@@ -43,7 +41,6 @@ class Scratch3LooksBlocks {
     static get DEFAULT_BUBBLE_STATE () {
         return {
             drawableId: null,
-            drawableVisible: true,
             onSpriteRight: true,
             skinId: null,
             text: '',
@@ -58,14 +55,6 @@ class Scratch3LooksBlocks {
      */
     static get STATE_KEY () {
         return 'Scratch.looks';
-    }
-
-    /**
-     * Max block time we use the "soft clear" optimization to prevent flickering in "typewriter" projects.
-     * @type {string}
-     */
-    static get MAX_SOFT_CLEAR_TIME () {
-        return 0.02; // seconds
     }
 
     /**
@@ -106,7 +95,6 @@ class Scratch3LooksBlocks {
             this.runtime.renderer.destroySkin(bubbleState.skinId);
             bubbleState.drawableId = null;
             bubbleState.skinId = null;
-            bubbleState.drawableVisible = true; // Reset back to default value
             this.runtime.requestRedraw();
         }
         target.removeListener(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this._onTargetChanged);
@@ -181,27 +169,16 @@ class Scratch3LooksBlocks {
         if (!this.runtime.renderer) return;
 
         const bubbleState = this._getBubbleState(target);
-        const {drawableVisible, type, text, onSpriteRight} = bubbleState;
+        const {type, text, onSpriteRight} = bubbleState;
 
-        // Remove the bubble if target is not visible, or text is being set to blank
-        // without being initialized. See comment below about blank text optimization.
-        if (!target.visible || (text === '' && !bubbleState.skinId)) {
+        // Remove the bubble if target is not visible, or text is being set to blank.
+        if (!target.visible || text === '') {
             this._onTargetWillExit(target);
             return;
         }
 
         if (bubbleState.skinId) {
-            // Optimization: if text is set to blank, hide the drawable instead of
-            // getting rid of it. This prevents flickering in "typewriter" projects
-            if ((text === '' && drawableVisible) || (text !== '' && !drawableVisible)) {
-                bubbleState.drawableVisible = text !== '';
-                this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {
-                    visible: bubbleState.drawableVisible
-                });
-            }
-            if (bubbleState.drawableVisible) {
-                this.runtime.renderer.updateTextSkin(bubbleState.skinId, type, text, onSpriteRight, [0, 0]);
-            }
+            this.runtime.renderer.updateTextSkin(bubbleState.skinId, type, text, onSpriteRight, [0, 0]);
         } else {
             target.addListener(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this._onTargetChanged);
 
@@ -292,17 +269,12 @@ class Scratch3LooksBlocks {
         this.say(args, util);
         const target = util.target;
         const usageId = this._getBubbleState(target).usageId;
-        const secs = args.SECS;
         return new Promise(resolve => {
             this._bubbleTimeout = setTimeout(() => {
                 this._bubbleTimeout = null;
                 // Clear say bubble if it hasn't been changed and proceed.
                 if (this._getBubbleState(target).usageId === usageId) {
-                    if (secs < this.MAX_SOFT_CLEAR_TIME) {
-                        this._updateBubble(target, 'say', '');
-                    } else {
-                        this._onTargetWillExit(target);
-                    }
+                    this._onTargetWillExit(target);
                 }
                 resolve();
             }, 1000 * args.SECS);
@@ -317,17 +289,12 @@ class Scratch3LooksBlocks {
         this.think(args, util);
         const target = util.target;
         const usageId = this._getBubbleState(target).usageId;
-        const secs = args.SECS;
         return new Promise(resolve => {
             this._bubbleTimeout = setTimeout(() => {
                 this._bubbleTimeout = null;
                 // Clear think bubble if it hasn't been changed and proceed.
                 if (this._getBubbleState(target).usageId === usageId) {
-                    if (secs < this.MAX_SOFT_CLEAR_TIME) {
-                        this._updateBubble(target, 'think', '');
-                    } else {
-                        this._onTargetWillExit(target);
-                    }
+                    this._onTargetWillExit(target);
                 }
                 resolve();
             }, 1000 * args.SECS);


### PR DESCRIPTION
Only this commit https://github.com/LLK/scratch-vm/commit/3019d05181594360b0838775b9916abaf1be2f6d 

The other commit is part of https://github.com/LLK/scratch-vm/pull/1088, but i stacked them to avoid merge conflicts.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1817 

### Proposed Changes

_Describe what this Pull Request does_

There is an "optimization" in the speech bubble code that tries to hide/show the speech bubble texture instead of disposing of it completely when it is hidden. This was to prevent "flickering" with projects that use rapid "say" in a loop to get a typewriter effect. However, it was causing the previous message to flicker on projects that take turns in talking as well (issue #1817). 

Since the optimization is already in place, I just put an upper bound (200ms, arbitraryish) on whether we do a "hard clear" vs the "soft clear" that the hide/show optimization uses. The idea is that if the speech bubbles are being shown rapidly, use the hide/show optimization, but if they are being shown slowly, clear the drawable completely between says.

Honestly this doesn't feel great, but it is the only way I could think of supporting both "typewriter" style and regular conversations. I'm also ok with disabling the "optimization" and just making those typewriter projects flicker....