### PR TITLE
Rename getCostumeSvg to getCostume

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -545,7 +545,7 @@ class VirtualMachine extends EventEmitter {
      * @param {int} costumeIndex - the index of the costume to be got.
      * @return {string} the costume's SVG string, or null if it's not an SVG costume.
      */
-    getCostumeSvg (costumeIndex) {
+    getCostume (costumeIndex) {
         const id = this.editingTarget.getCostumes()[costumeIndex].assetId;
         if (id && this.runtime && this.runtime.storage &&
                 this.runtime.storage.get(id).dataFormat === 'svg') {


### PR DESCRIPTION
### Proposed Changes
Renames getCostumeSvg to getCostume

### Reason for Changes
getCostume will be a better name for the function soon, when it provides both SVGs and PNGs from storage.

Getting this change in independently of https://github.com/LLK/scratch-vm/pull/1082 will ensure that updates to VM in GUI aren't blocked by https://github.com/LLK/scratch-vm/pull/1082