### PR TITLE
Fix downloadProjectId method

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -240,7 +240,7 @@ class VirtualMachine extends EventEmitter {
         const vm = this;
         const promise = storage.load(storage.AssetType.Project, id);
         promise.then(projectAsset => {
-            vm.loadProject(projectAsset.data.buffer);
+            vm.loadProject(projectAsset.data);
         });
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -240,7 +240,7 @@ class VirtualMachine extends EventEmitter {
         const vm = this;
         const promise = storage.load(storage.AssetType.Project, id);
         promise.then(projectAsset => {
-            vm.loadProject(projectAsset.decodeText());
+            vm.loadProject(projectAsset.data.buffer);
         });
     }
 


### PR DESCRIPTION
### Reason for Changes
* I noticed while trying to benchmark my collision detect that `downloadProjectId` was assuming the project url gave us a project.json instead of a zipped sb2.

