### PR TITLE
Add a project to benchmark sensing_touchingobject vs other sprites

### DIFF
--- a/src/playground/suite.js
+++ b/src/playground/suite.js
@@ -589,6 +589,18 @@ window.onload = function () {
         recordingTime: 5000
     }));
 
+    suite.add(new BenchFixture({
+        projectId: 219313833,
+        warmUpTime: 0,
+        recordingTime: 5000
+    }));
+
+    suite.add(new BenchFixture({
+        projectId: 219313833,
+        warmUpTime: 5000,
+        recordingTime: 5000
+    }));
+
     const frame = document.getElementsByTagName('iframe')[0];
     const runner = new BenchRunner({frame, suite});
     const resultsView = suiteView = new BenchSuiteResultView({runner}).render();


### PR DESCRIPTION
### Proposed Changes

* Add a project that does a lot of various sprite touching other sprite blocks

### Reason for Changes

* No current project in the benchmark measures `isTouchingDrawables` speed.
