### PR TITLE
Implement "all at once" block

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -185,6 +185,12 @@ class Scratch3ControlBlocks {
     }
 
     allAtOnce (args, util) {
+        // Since the "all at once" block is implemented for compatiblity with
+        // Scratch 2.0 projects, it behaves the same way it did in 2.0, which
+        // is to simply run the contained script (like "if 1 = 1").
+        // (In early versions of Scratch 2.0, it would work the same way as
+        // "run without screen refresh" custom blocks do now, but this was
+        // removed before the release of 2.0.)
         util.startBranch(1, false);
     }
 }

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -35,7 +35,8 @@ class Scratch3ControlBlocks {
             control_delete_this_clone: this.deleteClone,
             control_get_counter: this.getCounter,
             control_incr_counter: this.incrCounter,
-            control_clear_counter: this.clearCounter
+            control_clear_counter: this.clearCounter,
+            control_all_at_once: this.allAtOnce
         };
     }
 
@@ -181,6 +182,10 @@ class Scratch3ControlBlocks {
 
     incrCounter () {
         this._counter++;
+    }
+
+    allAtOnce (args, util) {
+        util.startBranch(1, false);
     }
 }
 

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -874,6 +874,15 @@ const specMap = {
         argMap: [
         ]
     },
+    'warpSpeed': {
+        opcode: 'control_all_at_once',
+        argMap: [
+            {
+                type: 'input',
+                inputName: 'SUBSTACK'
+            }
+        ]
+    },
     'touching:': {
         opcode: 'sensing_touchingobject',
         argMap: [

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -208,3 +208,21 @@ test('counter, incrCounter, clearCounter', t => {
 
     t.end();
 });
+
+test('allAtOnce', t => {
+    const rt = new Runtime();
+    const c = new Control(rt);
+
+    // Test harness (mocks `util`)
+    let ran = false;
+    const util = {
+        startBranch: function () {
+            ran = true;
+        }
+    };
+
+    // Execute test
+    c.allAtOnce({}, util);
+    t.true(ran);
+    t.end();
+});


### PR DESCRIPTION
### Resolves

Towards #355 (implements "all at once" block). Should be merged alongside LLK/scratch-blocks#1483.

### Proposed Changes

Adds a spec mapping from `warpSpeed` to `control_all_at_once`.

Adds an implementation for `control_all_at_once`: When the block is called, run the inside blocks. It's functionally equivalent to "if 1 = 1".

### Reason for Changes

Compatibility with Scratch 2.0 projects. This is a hacked block; in total, [around 1800 projects use the "all at once" block](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752). (Its opcode is `warpSpeed` in 2.0.)

### Test Coverage

Unit test for the new block (it just makes sure `startBranch` is called). Existing tests pass. Tested manually with [this](https://scratch.mit.edu/projects/74719650/) project.
