### PR TITLE
Use renderer bounds instead of stage bounds for positioning bubbles.

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -137,7 +137,13 @@ class Scratch3LooksBlocks {
                 bottom: target.y
             };
         }
-        const stageBounds = this.runtime.getTargetForStage().getBounds();
+        const stageSize = this.runtime.renderer.getNativeSize();
+        const stageBounds = {
+            left: -stageSize[0] / 2,
+            right: stageSize[0] / 2,
+            top: stageSize[1] / 2,
+            bottom: -stageSize[1] / 2
+        };
         if (bubbleState.onSpriteRight && bubbleWidth + targetBounds.right > stageBounds.right &&
             (targetBounds.left - bubbleWidth > stageBounds.left)) { // Only flip if it would fit
             bubbleState.onSpriteRight = false;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1569

### Proposed Changes

_Describe what this Pull Request does_

Instead of using the rendered bounds of the stage (which can be larger than the actual rendering area of the stage due to large costumes), use the `nativeSize` which is the size in scratch coords of the rendering area. Note that `nativeSize` is not the size of the canvas element or anything like that, it is the "logical size", i.e. the [width, height] in scratch coords.


### Test Coverage

_Please show how you have added tests to cover your changes_

Tested manually by using a large costume for the stage (like the basketball court), and testing the bubble bounds. 

![bubble-positioning-scratch3-develop](https://user-images.githubusercontent.com/654102/39443699-6ee34e3c-4c83-11e8-9900-aa725578cbbb.gif)
![bubble-positioning-scratch3-fixed](https://user-images.githubusercontent.com/654102/39443700-6eeef82c-4c83-11e8-92dd-2e031f7593ed.gif)



