### PR TITLE
"Implement" scroll blocks

### DIFF
--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -34,7 +34,12 @@ class Scratch3MotionBlocks {
             motion_sety: this.setY,
             motion_xposition: this.getX,
             motion_yposition: this.getY,
-            motion_direction: this.getDirection
+            motion_direction: this.getDirection,
+            motion_scroll_right: this.doNothing,
+            motion_scroll_up: this.doNothing,
+            motion_align_scene: this.doNothing,
+            motion_xscroll: this.doNothing,
+            motion_yscroll: this.doNothing
         };
     }
 
@@ -254,6 +259,8 @@ class Scratch3MotionBlocks {
     getDirection (args, util) {
         return util.target.direction;
     }
+
+    doNothing () {}
 }
 
 module.exports = Scratch3MotionBlocks;

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -35,11 +35,12 @@ class Scratch3MotionBlocks {
             motion_xposition: this.getX,
             motion_yposition: this.getY,
             motion_direction: this.getDirection,
-            motion_scroll_right: this.doNothing,
-            motion_scroll_up: this.doNothing,
-            motion_align_scene: this.doNothing,
-            motion_xscroll: this.doNothing,
-            motion_yscroll: this.doNothing
+            // Legacy no-op blocks:
+            motion_scroll_right: () => {},
+            motion_scroll_up: () => {},
+            motion_align_scene: () => {},
+            motion_xscroll: () => {},
+            motion_yscroll: () => {}
         };
     }
 
@@ -259,8 +260,6 @@ class Scratch3MotionBlocks {
     getDirection (args, util) {
         return util.target.direction;
     }
-
-    doNothing () {}
 }
 
 module.exports = Scratch3MotionBlocks;

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -206,6 +206,45 @@ const specMap = {
         argMap: [
         ]
     },
+    'scrollRight': {
+        opcode: 'motion_scroll_right',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'DISTANCE'
+            }
+        ]
+    },
+    'scrollUp': {
+        opcode: 'motion_scroll_up',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'DISTANCE'
+            }
+        ]
+    },
+    'scrollAlign': {
+        opcode: 'motion_align_scene',
+        argMap: [
+            {
+                type: 'field',
+                fieldName: 'ALIGNMENT'
+            }
+        ]
+    },
+    'xScroll': {
+        opcode: 'motion_xscroll',
+        argMap: [
+        ]
+    },
+    'yScroll': {
+        opcode: 'motion_yscroll',
+        argMap: [
+        ]
+    },
     'say:duration:elapsed:from:': {
         opcode: 'looks_sayforsecs',
         argMap: [


### PR DESCRIPTION
### Resolves

Towards #355 (implements scroll blocks). Should be merged alongside LLK/scratch-blocks#1484.

### Proposed Changes

Adds spec mappings from `scrollRight`, `scrollUp`, `scrollAlign`, `xScroll`, and `yScroll` to their respective Scratch 3.0 opcodes.

Adds implementations for those blocks:

* `motion_scroll_right`: Do nothing.
* `motion_scroll_up`: Do nothing.
* `motion_align_scene`: Do nothing.
* `motion_xscroll`: Do nothing.
* `motion_yscroll`: Do nothing.

("x scroll" and "y scroll" return undefined, as they do in 2.0.)

### Reason for Changes

Compatibility with Scratch 2.0 projects. These are hacked blocks; in total, [around 130 projects use scroll blocks](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752).

### Test Coverage

Tested manually with [this](https://scratch.mit.edu/projects/219768763/) project. No new unit tests; since the blocks don't do anything, there isn't anything to test.
