### PR TITLE
"Implement" miscellaneous no-op obsolete blocks

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -255,6 +255,8 @@ class Scratch3LooksBlocks {
             looks_cleargraphiceffects: this.clearEffects,
             looks_changesizeby: this.changeSize,
             looks_setsizeto: this.setSize,
+            looks_changestretchby: this.doNothing,
+            looks_setstretchto: this.doNothing,
             looks_gotofrontback: this.goToFrontBack,
             looks_goforwardbackwardlayers: this.goForwardBackwardLayers,
             looks_size: this.getSize,

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -481,7 +481,7 @@ class Scratch3LooksBlocks {
         return util.target.getCostumes()[util.target.currentCostume].name;
     }
 
-    doNothing() {}
+    doNothing () {}
 }
 
 module.exports = Scratch3LooksBlocks;

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -244,6 +244,7 @@ class Scratch3LooksBlocks {
             looks_thinkforsecs: this.thinkforsecs,
             looks_show: this.show,
             looks_hide: this.hide,
+            looks_hideallsprites: this.doNothing,
             looks_switchcostumeto: this.switchCostume,
             looks_switchbackdropto: this.switchBackdrop,
             looks_switchbackdroptoandwait: this.switchBackdropAndWait,
@@ -479,6 +480,8 @@ class Scratch3LooksBlocks {
         // Else return name
         return util.target.getCostumes()[util.target.currentCostume].name;
     }
+
+    doNothing() {}
 }
 
 module.exports = Scratch3LooksBlocks;

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -244,7 +244,7 @@ class Scratch3LooksBlocks {
             looks_thinkforsecs: this.thinkforsecs,
             looks_show: this.show,
             looks_hide: this.hide,
-            looks_hideallsprites: this.doNothing,
+            looks_hideallsprites: () => {}, // legacy no-op block
             looks_switchcostumeto: this.switchCostume,
             looks_switchbackdropto: this.switchBackdrop,
             looks_switchbackdroptoandwait: this.switchBackdropAndWait,
@@ -255,8 +255,8 @@ class Scratch3LooksBlocks {
             looks_cleargraphiceffects: this.clearEffects,
             looks_changesizeby: this.changeSize,
             looks_setsizeto: this.setSize,
-            looks_changestretchby: this.doNothing,
-            looks_setstretchto: this.doNothing,
+            looks_changestretchby: () => {}, // legacy no-op blocks
+            looks_setstretchto: () => {},
             looks_gotofrontback: this.goToFrontBack,
             looks_goforwardbackwardlayers: this.goForwardBackwardLayers,
             looks_size: this.getSize,
@@ -482,8 +482,6 @@ class Scratch3LooksBlocks {
         // Else return name
         return util.target.getCostumes()[util.target.currentCostume].name;
     }
-
-    doNothing () {}
 }
 
 module.exports = Scratch3LooksBlocks;

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -67,7 +67,7 @@ class Scratch3SensingBlocks {
             sensing_loudness: this.getLoudness,
             sensing_askandwait: this.askAndWait,
             sensing_answer: this.getAnswer,
-            sensing_userid: this.doNothing
+            sensing_userid: () => {} // legacy no-op block
         };
     }
 
@@ -294,8 +294,6 @@ class Scratch3SensingBlocks {
         // Otherwise, 0
         return 0;
     }
-
-    doNothing () {}
 }
 
 module.exports = Scratch3SensingBlocks;

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -66,7 +66,8 @@ class Scratch3SensingBlocks {
             sensing_dayssince2000: this.daysSince2000,
             sensing_loudness: this.getLoudness,
             sensing_askandwait: this.askAndWait,
-            sensing_answer: this.getAnswer
+            sensing_answer: this.getAnswer,
+            sensing_userid: this.doNothing
         };
     }
 
@@ -293,6 +294,8 @@ class Scratch3SensingBlocks {
         // Otherwise, 0
         return 0;
     }
+
+    doNothing() {}
 }
 
 module.exports = Scratch3SensingBlocks;

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -295,7 +295,7 @@ class Scratch3SensingBlocks {
         return 0;
     }
 
-    doNothing() {}
+    doNothing () {}
 }
 
 module.exports = Scratch3SensingBlocks;

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -266,6 +266,11 @@ const specMap = {
         argMap: [
         ]
     },
+    'hideAll': {
+        opcode: 'looks_hideallsprites',
+        argMap: [
+        ]
+    },
     'lookLike:': {
         opcode: 'looks_switchcostumeto',
         argMap: [
@@ -1040,6 +1045,11 @@ const specMap = {
     },
     'getUserName': {
         opcode: 'sensing_username',
+        argMap: [
+        ]
+    },
+    'getUserId': {
+        opcode: 'sensing_userid',
         argMap: [
         ]
     },

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -349,6 +349,26 @@ const specMap = {
             }
         ]
     },
+    'changeStretchBy:': {
+        opcode: 'looks_changestretchby',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'CHANGE'
+            }
+        ]
+    },
+    'setStretchTo:': {
+        opcode: 'looks_setstretchto',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'STRETCH'
+            }
+        ]
+    },
     'comeToFront': {
         opcode: 'looks_gotofrontback',
         argMap: [


### PR DESCRIPTION
### Resolves

Towards #355 (implements "hide all sprites", "set stretch to", "change stretch by", and "user id"). Should be merged alongside LLK/scratch-blocks#1488.

### Proposed Changes

Adds spec mappings from `hideAll`, `setStretchTo`, `changeStretchBy`, and `getUserId` to their respective 3.0 opcodes.

Adds implementations for those blocks - none of them do anything.

### Reason for Changes

Compatibility with Scratch 2.0 projects. In total, [around 350 projects use the change/set stretch blocks](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379418752). I don't have stats on how often "hide all sprites" and "user id" were used.

### Test Coverage

No new tests (since the blocks don't do anything), but tested manually with [this](https://scratch.mit.edu/projects/219797286/) project.