### PR TITLE
Update to webpack 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-es2015": "^6.24.1",
     "buffer-loader": "0.0.1",
     "canvas-toBlob": "1.0.0",
-    "copy-webpack-plugin": "4.2.1",
+    "copy-webpack-plugin": "^4.5.1",
     "decode-html": "2.0.0",
     "escape-html": "1.0.3",
     "eslint": "^4.5.0",
@@ -67,8 +67,9 @@
     "tap": "^11.0.1",
     "text-encoding": "0.6.4",
     "tiny-worker": "^2.1.1",
-    "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.4.1",
-    "worker-loader": "1.1.0"
+    "webpack": "4",
+    "webpack-cli": "^2.0.15",
+    "webpack-dev-server": "^3.1.3",
+    "worker-loader": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "tap": "^11.0.1",
     "text-encoding": "0.6.4",
     "tiny-worker": "^2.1.1",
-    "webpack": "4",
+    "webpack": "^4.8.0",
     "webpack-cli": "^2.0.15",
     "webpack-dev-server": "^3.1.3",
     "worker-loader": "^1.1.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,10 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const defaultsDeep = require('lodash.defaultsdeep');
 const path = require('path');
-const webpack = require('webpack');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const base = {
+    mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     devServer: {
         contentBase: false,
         host: '0.0.0.0',
@@ -28,12 +29,14 @@ const base = {
             loader: 'file-loader'
         }]
     },
-    plugins: process.env.NODE_ENV === 'production' ? [
-        new webpack.optimize.UglifyJsPlugin({
-            include: /\.min\.js$/,
-            minimize: true
-        })
-    ] : []
+    optimization: {
+        minimizer: [
+            new UglifyJsPlugin({
+                include: /\.min\.js$/
+            })
+        ]
+    },
+    plugins: []
 };
 
 module.exports = [
@@ -128,6 +131,9 @@ module.exports = [
                     loader: 'expose-loader?ScratchRender'
                 }
             ])
+        },
+        performance: {
+            hints: false
         },
         plugins: base.plugins.concat([
             new CopyWebpackPlugin([{


### PR DESCRIPTION
### Proposed Changes

- Update to webpack 4
- <del>Replace buffer-loader with arraybuffer-loader</del> (https://github.com/LLK/scratch-vm/pull/1111)
- <del>Replace babel-preset-es2015 with babel-preset-env</del> (https://github.com/LLK/scratch-vm/pull/1112)

### Reason for Changes

This PR updates scratch-vm and represents what will be PRs for the other 8 projects (including scratch-gui) with webpack builds used by scratch-gui. It should be easier to use this as a launch pad for discussing what will be very similar PRs once this one is figured out.

One of the goals of this PR and its siblings for the other repos is to standardize the build tools across the repos. Some packages use webpack 1, 2, or 3 and some use babel-preset-es2015 while others use babel-preset-env.

#### webpack 4 ####

webpack 4 launched a stable version at the end of February. Along with a continued focus in build performance, webpack 4 introduces a number of quality of life features. webpack 4 has minimal to no configuration with its `mode` option that can be set to development or production. Each mode then configures defaults for other webpack options following "good practices".

The development mode helps debugging in a few ways. One benefit that's easy to notice for anyone that's looked at webpack output is the module identifier.

<img width="712" alt="screen shot 2018-05-01 at 4 22 56 pm" src="https://user-images.githubusercontent.com/833298/39491962-fb008e60-4d5b-11e8-8c6c-56f36aac4ab3.png">

Instead of numbers by default webpack 4 development mode defaults to the relative path to the resolved file and require calls display the path the statement requested.

Production mode focuses on better optimizations like using uglify-es, supporting more recent js syntax and, and adding side effect free optimizations. Using the latest `lodash-es` in js modules (`import {isObject} from 'lodash'` syntax), webpack can import only the functions needed from `lodash-es` as those functions are modified with side effects in `lodash-es` and uglify-es will prune the remaining dead code.

#### buffer-loader => arraybuffer-loader ####

https://github.com/LLK/scratch-vm/pull/1111

buffer-loader inlines binary files in webpack builds by encoding them as numeric literals. Each byte encoded this way uses 2 to 4 bytes. arraybuffer-loader encodes the data as base64 and decodes it back into numbers at runtime using 1.33 bytes for each encoded bytes. arraybuffer-loader saves on bandwidth to download the resulting js and the amount of space in memory the script takes.

#### babel-preset-env ####

https://github.com/LLK/scratch-vm/pull/1112

babel-preset-es2015 is no longer maintained. If newer syntax from ES7 (ES2016) or ES8 (ES2017) is not used, babel-preset-env when updated to newer minor versions will keep transforms for used syntax up to date. Like autoprefixer used in `scratch-paint` and `scratch-gui` we can set the target browsers babel-preset-env should transform for with [browserlist](http://browserl.ist/?q=last+3+versions%2C+Safari+%3E%3D+8%2C+iOS+%3E%3D+8).

#### RAM used ####

This change to webpack-4 (arraybuffer-loader) in a built copy of scratch-gui opening a default project reduces the memory reported in use for the JS heap on a recent MacBook Pro from 54MB to 42MB.

A Samsung Chromebook Plus goes from 28MB to 21MB.

#### File size ####

scratch-gui built with webpack-4 (arraybuffer-loader) versions of the module reduces the file size of the produced lib.min.js file from 12.7MB (4.0MB gzipped) to 9.2MB (3.6 gzipped).

### Test Coverage

Passes lint, builds, and supports existing tests.

I'll update this PR soon with links to scratch-vm builds on my fork's github pages.

#### scratch-gui builds with vm change ####

With this pr's change: https://mzgoddard.github.io/scratch-gui/20180502/webpack-4/
Develop when this PR was made: https://mzgoddard.github.io/scratch-gui/20180502/develop/
Build with this change https://github.com/LLK/scratch-vm/pull/1105 and https://github.com/LLK/scratch-vm/pull/1106: https://mzgoddard.github.io/scratch-gui/20180502/no-boiler/
