### PR TITLE
Update babel-preset-es2015 to babel-preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^7.0.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "canvas-toBlob": "1.0.0",
     "copy-webpack-plugin": "4.2.1",
     "decode-html": "2.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ const base = {
             loader: 'babel-loader',
             include: path.resolve(__dirname, 'src'),
             query: {
-                presets: ['es2015']
+                presets: [['env', {targets: {browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']}}]]
             }
         },
         {


### PR DESCRIPTION
### Resolves

Pulls out the babel-preset-env change from https://github.com/LLK/scratch-vm/pull/1104.

### Proposed Changes

Replace babel-preset-es2015 with babel-preset-env.

### Reason for Changes

> babel-preset-es2015 is no longer maintained. If newer syntax from ES7 (ES2016) or ES8 (ES2017) is not used, babel-preset-env when updated to newer minor versions will keep transforms for used syntax up to date. Like autoprefixer used in `scratch-paint` and `scratch-gui` we can set the target browsers babel-preset-env should transform for with [browserlist](http://browserl.ist/?q=last+3+versions%2C+Safari+%3E%3D+8%2C+iOS+%3E%3D+8).

Quoted from https://github.com/LLK/scratch-vm/pull/1104.
