### PR TITLE
Add Thread.StackFrame class

### DIFF
--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -43,7 +43,11 @@ class BlockUtility {
      * @type {object}
      */
     get stackFrame () {
-        return this.thread.peekStackFrame().executionContext;
+        const frame = this.thread.peekStackFrame();
+        if (frame.executionContext === null) {
+            frame.executionContext = {};
+        }
+        return frame.executionContext;
     }
 
     /**

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -277,6 +277,9 @@ const execute = function (sequencer, thread, recursiveCall) {
             // Actually execute the block.
             execute(sequencer, thread, RECURSIVE);
             if (thread.status === Thread.STATUS_PROMISE_WAIT) {
+                // Create a reported value on the stack frame to store the
+                // already built values.
+                currentStackFrame.reported = {};
                 // Waiting for the block to resolve, store the current argValues
                 // onto a member of the currentStackFrame that can be used once
                 // the nested block resolves to rebuild argValues up to this
@@ -310,10 +313,10 @@ const execute = function (sequencer, thread, recursiveCall) {
             currentStackFrame.justReported = null;
             // We have rebuilt argValues with all the stored values in the
             // currentStackFrame from the nested block's promise resolving.
-            // Using the reported value from the block we waited on, reset the
-            // storage member of currentStackFrame so the next execute call at
-            // this level can use it in a clean state.
-            currentStackFrame.reported = {};
+            // Using the reported value from the block we waited on, unset the
+            // value. The next execute needing to store reported values will
+            // creates its own temporary storage.
+            currentStackFrame.reported = null;
         } else if (typeof currentStackFrame.reported[inputName] !== 'undefined') {
             inputValue = currentStackFrame.reported[inputName];
         }


### PR DESCRIPTION
### Proposed Changes

Use a private StackFrame class to help internally manage use of Stack Frame values and memory. Create params, reported, and executionContext on demand.

### Reason for Changes

params, reported and executionContext are created whether a stack frame will need them or not. Creating those members on demand in the stack frame saves time instantiating them and later garbage collecting them.
