### PR TITLE
Recycle block args

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -876,21 +876,22 @@ class Blocks {
  * @param {string} blockId blockId for the desired execute cache
  * @return {object} execute cache object
  */
-BlocksExecuteCache.getCached = function (blocks, blockId) {
-    const block = blocks.getBlock(blockId);
-    if (typeof block === 'undefined') return null;
+BlocksExecuteCache.getCached = function (blocks, blockId, CacheType = Object) {
     let cached = blocks._cache._executeCached[blockId];
     if (typeof cached !== 'undefined') {
         return cached;
     }
 
-    cached = {
+    const block = blocks.getBlock(blockId);
+    if (typeof block === 'undefined') return null;
+
+    cached = new CacheType({
         _initialized: false,
         opcode: blocks.getOpcode(block),
         fields: blocks.getFields(block),
         inputs: blocks.getInputs(block),
         mutation: blocks.getMutation(block)
-    };
+    });
     blocks._cache._executeCached[blockId] = cached;
     return cached;
 };

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -874,9 +874,10 @@ class Blocks {
  * reset.
  * @param {Blocks} blocks Blocks containing the expected blockId
  * @param {string} blockId blockId for the desired execute cache
+ * @param {function} CacheType constructor for cached block information
  * @return {object} execute cache object
  */
-BlocksExecuteCache.getCached = function (blocks, blockId, CacheType = Object) {
+BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
     let cached = blocks._cache._executeCached[blockId];
     if (typeof cached !== 'undefined') {
         return cached;
@@ -885,13 +886,22 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType = Object) {
     const block = blocks.getBlock(blockId);
     if (typeof block === 'undefined') return null;
 
-    cached = new CacheType({
-        _initialized: false,
-        opcode: blocks.getOpcode(block),
-        fields: blocks.getFields(block),
-        inputs: blocks.getInputs(block),
-        mutation: blocks.getMutation(block)
-    });
+    if (typeof CacheType === 'undefined') {
+        cached = {
+            opcode: blocks.getOpcode(block),
+            fields: blocks.getFields(block),
+            inputs: blocks.getInputs(block),
+            mutation: blocks.getMutation(block)
+        };
+    } else {
+        cached = new CacheType(blocks, {
+            opcode: blocks.getOpcode(block),
+            fields: blocks.getFields(block),
+            inputs: blocks.getInputs(block),
+            mutation: blocks.getMutation(block)
+        });
+    }
+
     blocks._cache._executeCached[blockId] = cached;
     return cached;
 };


### PR DESCRIPTION
### Proposed Changes

Create an object on the BlockExecuteCache for each block that is assigned the arguments that is passed on to a block function call.

### Reason for Changes

Reuse the args object built for each block function call. The args can be reused in relation to their BlockExecuteCache data. The shape of the args instance is defined by its fields and inputs, and every field and input is assigned each iteration of the same block so old values can <ins>not</ins> persist into a call of a block function with data from another block.

In a performance critical region like `execute` reducing object instantiation greatly improves performance.
