### PR TITLE
Handle random backdrop menu option

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -346,11 +346,9 @@ class Scratch3LooksBlocks {
             } else if (requestedCostume === 'random backdrop') {
                 const numCostumes = target.getCostumes().length;
                 if (numCostumes > 1) {
-                    let index;
-                    do {
-                        index = Math.floor(Math.random() * numCostumes);
-                    } while (index === target.currentCostume);
-                    target.setCostume(index);
+                    let selectedIndex = Math.floor(Math.random() * (numCostumes - 1));
+                    if (selectedIndex === target.currentCostume) selectedIndex += 1;
+                    target.setCostume(selectedIndex);
                 }
             } else {
                 const forcedNumber = Number(requestedCostume);

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -343,6 +343,8 @@ class Scratch3LooksBlocks {
             } else if (requestedCostume === 'next costume' ||
                        requestedCostume === 'next backdrop') {
                 target.setCostume(target.currentCostume + 1);
+            } else if (requestedCostume === 'random backdrop') {
+                target.setCostume(Math.floor(Math.random() * target.getCostumes().length));
             } else {
                 const forcedNumber = Number(requestedCostume);
                 if (!isNaN(forcedNumber)) {

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -344,7 +344,8 @@ class Scratch3LooksBlocks {
                        requestedCostume === 'next backdrop') {
                 target.setCostume(target.currentCostume + 1);
             } else if (requestedCostume === 'random backdrop') {
-                if ((numCostumes = target.getCostumes().length) > 1) {
+                const numCostumes = target.getCostumes().length;
+                if (numCostumes > 1) {
                     let index;
                     do {
                         index = Math.floor(Math.random() * numCostumes);

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -344,7 +344,13 @@ class Scratch3LooksBlocks {
                        requestedCostume === 'next backdrop') {
                 target.setCostume(target.currentCostume + 1);
             } else if (requestedCostume === 'random backdrop') {
-                target.setCostume(Math.floor(Math.random() * target.getCostumes().length));
+                if ((numCostumes = target.getCostumes().length) > 1) {
+                    let index;
+                    do {
+                        index = Math.floor(Math.random() * numCostumes);
+                    } while (index === target.currentCostume);
+                    target.setCostume(index);
+                }
             } else {
                 const forcedNumber = Number(requestedCostume);
                 if (!isNaN(forcedNumber)) {


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-blocks#1500
Must be merged BEFORE LLK/scratch-gui#1989

### Proposed Changes

Changes the `_setCostumeOrBackdrop` function to set the backdrop to backdrop no. `Math.floor(Math.random() * target.getCostumes().length))` if the `requestedCostume === 'random backdrop'`.

### Reason for Changes

To resolve a help wanted issue.

### Test Coverage

Existing tests pass.
