### PR TITLE
Update scratch-parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "promise": "8.0.1",
     "scratch-audio": "latest",
     "scratch-blocks": "latest",
-    "scratch-parser": "^4.1.0",
+    "scratch-parser": "4.1.1",
     "scratch-render": "latest",
     "scratch-storage": "^0.4.0",
     "script-loader": "0.7.2",


### PR DESCRIPTION
Update scratch-parser version to fix issue with uploading sprites (that don't have any sounds) from .sprite2 files (e.g. bananas sprite from scratch 2.0 library).

Pin scratch-parser to specific version so that greenkeeper PRs get created for any updates to scratch-parser.