### PR TITLE
Clean up Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ script: npm run $NPM_SCRIPT
 jobs:
     include:
     - env: NPM_SCRIPT=lint
-      node_js: 6
+      node_js: 8
     - stage: release
-      node_js: 6
+      node_js: 8
       env: NPM_SCRIPT=build
       before_deploy:
       - npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 6
+- 8
 - node
 env:
   - NPM_SCRIPT="tap:unit -- --jobs=4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ node_js:
 - 8
 - node
 env:
+  global:
+  - NODE_ENV=production
+  matrix:
   - NPM_SCRIPT="tap:unit -- --jobs=4"
   - NPM_SCRIPT="tap:integration -- --jobs=4"
-  - NODE_ENV=production
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 8
+- 6
 - node
 env:
   - NPM_SCRIPT="tap:unit -- --jobs=4"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "escape-html": "1.0.3",
     "eslint": "^4.5.0",
     "eslint-config-scratch": "^5.0.0",
-    "expose-loader": "0.7.4",
+    "expose-loader": "0.7.5",
     "file-loader": "^1.1.6",
     "format-message": "5.2.1",
     "format-message-cli": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "adm-zip": "0.4.7",
     "arraybuffer-loader": "^1.0.3",
     "babel-core": "^6.24.1",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^8.0.1",
     "babel-loader": "^7.0.0",
     "babel-preset-env": "^1.6.1",
     "canvas-toBlob": "1.0.0",


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Failing Travis builds on develop

### Proposed Changes

_Describe what this Pull Request does_
- Bump Travis Node version to Node 8
- Update peer dependencies to clear warnings. It wasn't clear to me why Node 6 builds were failing after the webpack upgrade. A new warning was being produce on `install`, complaining about the `exports-loader`'s peer dependency on webpack < 4. And in some of the builds, there was an issue with `self` not being defined which seems similar to what `exports-loader` does.  So I resolved this defensively.
- Pull NODE_ENV variable from the build matrix, since it was producing 2 extraneous builds that did nothing, and wasn't set correctly in the other stages

### Reason for Changes

_Explain why these changes should be made_
After webpack was upgraded to 4, builds started failing on develop (even though they weren't failing on forks or on the PR for the upgrade).  Also we were doing unnecessary work on Travis and weren't building with a consistent `NODE_ENV`.

### Test Coverage

_Please show how you have added tests to cover your changes_
N/A