### PR TITLE
Make Travis release stage conditional by branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,13 @@ jobs:
       - git config --global user.name $(git log --pretty=format:"%an" -n1)
       deploy:
       - provider: npm
-        "on":
-          all_branches: true
-          condition: $RELEASE_BRANCHES =~ $TRAVIS_BRANCH
         skip_cleanup: true
         email: $NPM_EMAIL
         api_key: $NPM_TOKEN
       - provider: script
-        "on":
-          all_branches: true
-          condition: $RELEASE_BRANCHES =~ $TRAVIS_BRANCH
         skip_cleanup: true
         script: npm run --silent deploy -- -x -r $GH_PAGES_REPO
+stages:
+- test
+- name: release
+  if: branch in (master, develop)


### PR DESCRIPTION
If the branch isn't master or develop, don't even try to do the release stage. We don't release anything that isn't one of these.  This should speed up PR tests.