### PR TITLE
Don't run release stage for PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ jobs:
 stages:
 - test
 - name: release
-  if: branch in (master, develop)
+  if: branch in (master, develop) and type != pull_request


### PR DESCRIPTION
In the Travis build for this PR, there shouldn't be any "Release" stage

### Resolves

_What Github issue does this resolve (please include link)?_
Follow on to #1130 that does what I wanted — PR builds, even if the branch is technically master or develop, should not contain the release stage at all.

### Proposed Changes

_Describe what this Pull Request does_
Restrict pr builds from the release stage

### Reason for Changes

_Explain why these changes should be made_
This should reduce the overall number of builds the vm produces, so should speed up our use of Travis.

### Test Coverage

_Please show how you have added tests to cover your changes_
N/A