### PR TITLE
Only run before_deploy once during deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,14 @@ jobs:
       node_js: 8
       env: NPM_SCRIPT=build
       before_deploy:
-      - npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
-      - git config --global user.email $(git log --pretty=format:"%ae" -n1)
-      - git config --global user.name $(git log --pretty=format:"%an" -n1)
+      - >
+        # Only run this once for both deploys (avoids weird double version number)
+        if ![ "$BEFORE_DEPLOY_RAN" ]; then
+          export BEFORE_DEPLOY_RAN=1;
+          npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s);
+          git config --global user.email $(git log --pretty=format:"%ae" -n1);
+          git config --global user.name $(git log --pretty=format:"%an" -n1);
+        fi
       deploy:
       - provider: npm
         skip_cleanup: true


### PR DESCRIPTION
This prevents the package.json version number from doubling up no matter how many times or in what order we deploy.

### Resolves

_What Github issue does this resolve (please include link)?_
We've already fixed it with a hack (put the NPM deploy step first), but this should permanently fix the issue where the VM is released with a version number like 0.1.0-prerelease.12345-prerelease.67890.

### Proposed Changes

_Describe what this Pull Request does_
Only run `before_deploy` if an environment variable `BEFORE_DEPLOY_RAN` isn't set (which it isn't when the build starts). Then set that variable in `before_deploy`. This ensures the hook only runs the first time.

### Reason for Changes

_Explain why these changes should be made_
Eventually we might change the `deploy` section, or Travis might make the deploys run in non-deterministic order which might cause the double version suffix issue to come back. This future-proofs us against that.

### Test Coverage

_Please show how you have added tests to cover your changes_
N/A