### PR TITLE
Add implementations for hiding and showing variables and lists.

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -18,6 +18,8 @@ class Scratch3DataBlocks {
             data_variable: this.getVariable,
             data_setvariableto: this.setVariableTo,
             data_changevariableby: this.changeVariableBy,
+            data_hidevariable: this.hideVariable,
+            data_showvariable: this.showVariable,
             data_listcontents: this.getListContents,
             data_addtolist: this.addToList,
             data_deleteoflist: this.deleteOfList,
@@ -26,7 +28,9 @@ class Scratch3DataBlocks {
             data_itemoflist: this.getItemOfList,
             data_itemnumoflist: this.getItemNumOfList,
             data_lengthoflist: this.lengthOfList,
-            data_listcontainsitem: this.listContainsItem
+            data_listcontainsitem: this.listContainsItem,
+            data_hidelist: this.hideList,
+            data_showlist: this.showList
         };
     }
 
@@ -48,6 +52,32 @@ class Scratch3DataBlocks {
         const castedValue = Cast.toNumber(variable.value);
         const dValue = Cast.toNumber(args.VALUE);
         variable.value = castedValue + dValue;
+    }
+
+    changeMonitorVisibility (id, visible) {
+        // Send the monitor blocks an event like the flyout checkbox event.
+        // This both updates the monitor state and changes the isMonitored block flag.
+        this.runtime.monitorBlocks.changeBlock({
+            id: id, // Monitor blocks for variables are the variable ID.
+            element: 'checkbox', // Mimic checkbox event from flyout.
+            value: visible
+        }, this.runtime);
+    }
+
+    showVariable (args) {
+        this.changeMonitorVisibility(args.VARIABLE.id, true);
+    }
+
+    hideVariable (args) {
+        this.changeMonitorVisibility(args.VARIABLE.id, false);
+    }
+
+    showList (args) {
+        this.changeMonitorVisibility(args.LIST.id, true);
+    }
+
+    hideList (args) {
+        this.changeMonitorVisibility(args.LIST.id, false);
     }
 
     getListContents (args, util) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/308

### Proposed Changes

_Describe what this Pull Request does_

Implement the show/hide list and variable blocks by simply issuing the same change event to the runtime monitor blocks as scratch-blocks does when the monitor checkboxes are checked.

### Reason for Changes

_Explain why these changes should be made_

The opcodes need to be implemented in the VM. 

Note: to get them back into the toolbox, we need to change that in blocks.

Tested using this example project: #221755484

It has keyboard controls for show/hide variable ("space", "left arrow") and show/hide list ("a", "b").

---

@kchadha currently the blocks container responds to these events by slicing the monitor record out of the monitor state, which like we talked about will lose some state we might want to keep track of. In the future, as an improvement, we could follow up with this by setting the visibility instead of removing the monitor.