### PR TITLE
Actually do the deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,14 @@ jobs:
       - git config --global user.name $(git log --pretty=format:"%an" -n1)
       deploy:
       - provider: npm
+        on:
+          all_branches: true
         skip_cleanup: true
         email: $NPM_EMAIL
         api_key: $NPM_TOKEN
       - provider: script
+        on:
+          all_branches: true
         skip_cleanup: true
         script: npm run --silent deploy -- -x -r $GH_PAGES_REPO
 stages:


### PR DESCRIPTION
Now that the release stage is only created for master and develop, allow the deploy to run on any branch. This way we can control which branches get deployed from the stage condition alone.
