### PR TITLE
Update the format of the language menu to match the changes made to d…

### DIFF
--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -102,7 +102,7 @@ class Scratch3TranslateBlocks {
             if (langs) {
                 this._supportedLanguages =
                       langs.map(entry => {
-                          const obj = [entry.name, entry.code];
+                          const obj = {text: entry.name, value: entry.code};
                           return obj;
                       });
             }


### PR DESCRIPTION
…eal with translations. This allows the menu to pass through the maybeFormatMessage code correctly.

### Resolves

No github issue, but the menu in the translate extension currently doesn't display any text :)

### Proposed Changes
Update the menu to return objects of format {text: "languageName" value: "languageCode"}

### Reason for Changes

https://github.com/LLK/scratch-vm/commit/f8db6c3f02b64785a1b420dd0e9b4759bf1a0a44#diff-acd6d8353286f96544b673f07db06611
changed some things and the old format of ["languageName", "languageCode"] no longer works.
