### PR TITLE
Add extension id to toolbox category XML

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -839,7 +839,7 @@ class Runtime extends EventEmitter {
             const menuIconXML = menuIconURI ?
                 `iconURI="${menuIconURI}"` : '';
 
-            xmlParts.push(`<category name="${name}" ${colorXML} ${menuIconXML}>`);
+            xmlParts.push(`<category name="${name}" id="${categoryInfo.id}" ${colorXML} ${menuIconXML}>`);
             xmlParts.push.apply(xmlParts, paletteBlocks.map(block => block.xml));
             xmlParts.push('</category>');
         }


### PR DESCRIPTION
### Resolves

Support for https://github.com/LLK/scratch-blocks/issues/1429

### Proposed Changes

Add an id attribute to the  category in the toolbox XML when generating it for an extension.

### Reason for Changes

All categories need ids to support scrolling behaviors.