### PR TITLE
Fix say bug with show/hide

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -291,7 +291,7 @@ class Scratch3LooksBlocks {
                 this._bubbleTimeout = null;
                 // Clear say bubble if it hasn't been changed and proceed.
                 if (this._getBubbleState(target).usageId === usageId) {
-                    this._onTargetWillExit(target);
+                    this._updateBubble(target, 'say', '');
                 }
                 resolve();
             }, 1000 * args.SECS);
@@ -311,7 +311,7 @@ class Scratch3LooksBlocks {
                 this._bubbleTimeout = null;
                 // Clear think bubble if it hasn't been changed and proceed.
                 if (this._getBubbleState(target).usageId === usageId) {
-                    this._onTargetWillExit(target);
+                    this._updateBubble(target, 'think', '');
                 }
                 resolve();
             }, 1000 * args.SECS);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/2078

### Proposed Changes

_Describe what this Pull Request does_

Revert a small part of the change from https://github.com/LLK/scratch-vm/pull/1089. Make sure that the bubble state text is set to blank after a timed say/hide. 

### Reason for Changes

_Explain why these changes should be made_
Previously it was not clearing the say text, but there was a second flag which considered whether to show/hide the bubble. We removed that other flag in https://github.com/LLK/scratch-vm/pull/1089, so now only the text of the bubble is used to decide if it is visible. The bubble drawable gets torn down when the target is hidden, but the text is left around in case the target is re-shown. Make sure to explicitly set the text to '' in timed say/hide to make sure it doesn't come back. Intervening say/thinks are handled by the `usageId` conditional. 

### Test Coverage

_Please show how you have added tests to cover your changes_

I repeated the steps for the bug: 
- say for 2 seconds
- hide
- show (bubble came back, no longer does)

as well as a few other tests for the bubbles, including 
- say
- hide
- show (bubble should come back)

and made sure that https://github.com/LLK/scratch-gui/issues/1817 did not come back. 