### PR TITLE
Layer group ordering.

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -2,6 +2,7 @@ const Cast = require('../util/cast');
 const Clone = require('../util/clone');
 const RenderedTarget = require('../sprites/rendered-target');
 const uid = require('../util/uid');
+const StageLayering = require('../engine/stage-layering');
 
 /**
  * @typedef {object} BubbleState - the bubble state associated with a particular target.
@@ -91,7 +92,7 @@ class Scratch3LooksBlocks {
     _onTargetWillExit (target) {
         const bubbleState = this._getBubbleState(target);
         if (bubbleState.drawableId && bubbleState.skinId) {
-            this.runtime.renderer.destroyDrawable(bubbleState.drawableId);
+            this.runtime.renderer.destroyDrawable(bubbleState.drawableId, StageLayering.BUBBLE_LAYER);
             this.runtime.renderer.destroySkin(bubbleState.skinId);
             bubbleState.drawableId = null;
             bubbleState.skinId = null;
@@ -195,10 +196,9 @@ class Scratch3LooksBlocks {
                 bubbleState.onSpriteRight = false;
             }
 
-            bubbleState.drawableId = this.runtime.renderer.createDrawable();
+            bubbleState.drawableId = this.runtime.renderer.createDrawable(StageLayering.BUBBLE_LAYER);
             bubbleState.skinId = this.runtime.renderer.createTextSkin(type, text, bubbleState.onSpriteRight, [0, 0]);
 
-            this.runtime.renderer.setDrawableOrder(bubbleState.drawableId, Infinity);
             this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {
                 skinId: bubbleState.skinId
             });

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -92,7 +92,7 @@ class Scratch3LooksBlocks {
     _onTargetWillExit (target) {
         const bubbleState = this._getBubbleState(target);
         if (bubbleState.drawableId && bubbleState.skinId) {
-            this.runtime.renderer.destroyDrawable(bubbleState.drawableId, StageLayering.BUBBLE_LAYER);
+            this.runtime.renderer.destroyDrawable(bubbleState.drawableId, StageLayering.SPRITE_LAYER);
             this.runtime.renderer.destroySkin(bubbleState.skinId);
             bubbleState.drawableId = null;
             bubbleState.skinId = null;
@@ -196,7 +196,7 @@ class Scratch3LooksBlocks {
                 bubbleState.onSpriteRight = false;
             }
 
-            bubbleState.drawableId = this.runtime.renderer.createDrawable(StageLayering.BUBBLE_LAYER);
+            bubbleState.drawableId = this.runtime.renderer.createDrawable(StageLayering.SPRITE_LAYER);
             bubbleState.skinId = this.runtime.renderer.createTextSkin(type, text, bubbleState.onSpriteRight, [0, 0]);
 
             this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -12,6 +12,7 @@ const TargetType = require('../extension-support/target-type');
 const Thread = require('./thread');
 const log = require('../util/log');
 const maybeFormatMessage = require('../util/maybe-format-message');
+const StageLayering = require('./stage-layering');
 
 // Virtual I/O devices.
 const Clock = require('../io/clock');
@@ -915,6 +916,7 @@ class Runtime extends EventEmitter {
      */
     attachRenderer (renderer) {
         this.renderer = renderer;
+        this.renderer.setLayerGroupOrdering(StageLayering.LAYER_GROUPS);
     }
 
     /**

--- a/src/engine/stage-layering.js
+++ b/src/engine/stage-layering.js
@@ -50,12 +50,7 @@ class StageLayering {
             {
                 group: StageLayering.SPRITE_LAYER,
                 explicitOrdering: false
-            },
-            {
-                group: StageLayering.BUBBLE_LAYER,
-                explicitOrdering: false
             }
-
         ];
     }
 }

--- a/src/engine/stage-layering.js
+++ b/src/engine/stage-layering.js
@@ -3,54 +3,25 @@ class StageLayering {
         return 'background';
     }
 
-    static get EXTENSION_LAYER () {
-        return 'extensions';
+    static get VIDEO_LAYER () {
+        return 'video';
+    }
+
+    static get PEN_LAYER () {
+        return 'pen';
     }
 
     static get SPRITE_LAYER () {
         return 'sprite';
     }
 
-    static get BUBBLE_LAYER () {
-        return 'bubble';
-    }
-
-    static get BACKGROUND_ORDER () {
-        return 0;
-    }
-
-    // Video should be in the back of the extension group
-    static get VIDEO_ORDER () {
-        return 0;
-    }
-
-    static get PEN_ORDER () {
-        return 1;
-    }
-
     // Order of layer groups relative to each other,
-    // and ordering style of each
-    // Currently extensions are the only layer group
-    // that have an explicit ordering (e.g. video must be behind pen).
-    // All other groups here are ordered based on when they get added
     static get LAYER_GROUPS () {
         return [
-            {
-                group: StageLayering.BACKGROUND_LAYER,
-                // This is a weird use case for a layer group ordering style,
-                // because in the main Scratch use case, this group has only one item,
-                // so ordering of the items doesn't really matter.
-                explicitOrdering: false
-
-            },
-            {
-                group: StageLayering.EXTENSION_LAYER,
-                explicitOrdering: true
-            },
-            {
-                group: StageLayering.SPRITE_LAYER,
-                explicitOrdering: false
-            }
+            StageLayering.BACKGROUND_LAYER,
+            StageLayering.VIDEO_LAYER,
+            StageLayering.PEN_LAYER,
+            StageLayering.SPRITE_LAYER
         ];
     }
 }

--- a/src/engine/stage-layering.js
+++ b/src/engine/stage-layering.js
@@ -1,0 +1,63 @@
+class StageLayering {
+    static get BACKGROUND_LAYER () {
+        return 'background';
+    }
+
+    static get EXTENSION_LAYER () {
+        return 'extensions';
+    }
+
+    static get SPRITE_LAYER () {
+        return 'sprite';
+    }
+
+    static get BUBBLE_LAYER () {
+        return 'bubble';
+    }
+
+    static get BACKGROUND_ORDER () {
+        return 0;
+    }
+
+    // Video should be in the back of the extension group
+    static get VIDEO_ORDER () {
+        return 0;
+    }
+
+    static get PEN_ORDER () {
+        return 1;
+    }
+
+    // Order of layer groups relative to each other,
+    // and ordering style of each
+    // Currently extensions are the only layer group
+    // that have an explicit ordering (e.g. video must be behind pen).
+    // All other groups here are ordered based on when they get added
+    static get LAYER_GROUPS () {
+        return [
+            {
+                group: StageLayering.BACKGROUND_LAYER,
+                // This is a weird use case for a layer group ordering style,
+                // because in the main Scratch use case, this group has only one item,
+                // so ordering of the items doesn't really matter.
+                explicitOrdering: false
+
+            },
+            {
+                group: StageLayering.EXTENSION_LAYER,
+                explicitOrdering: true
+            },
+            {
+                group: StageLayering.SPRITE_LAYER,
+                explicitOrdering: false
+            },
+            {
+                group: StageLayering.BUBBLE_LAYER,
+                explicitOrdering: false
+            }
+
+        ];
+    }
+}
+
+module.exports = StageLayering;

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -128,8 +128,7 @@ class Scratch3PenBlocks {
     _getPenLayerID () {
         if (this._penSkinId < 0 && this.runtime.renderer) {
             this._penSkinId = this.runtime.renderer.createPenSkin();
-            this._penDrawableId = this.runtime.renderer.createDrawable(
-                StageLayering.EXTENSION_LAYER, StageLayering.PEN_ORDER);
+            this._penDrawableId = this.runtime.renderer.createDrawable(StageLayering.PEN_LAYER);
             this.runtime.renderer.updateDrawableProperties(this._penDrawableId, {skinId: this._penSkinId});
         }
         return this._penSkinId;

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -7,6 +7,7 @@ const formatMessage = require('format-message');
 const MathUtil = require('../../util/math-util');
 const RenderedTarget = require('../../sprites/rendered-target');
 const log = require('../../util/log');
+const StageLayering = require('../../engine/stage-layering');
 
 /**
  * Icon svg to be displayed at the left edge of each extension block, encoded as a data URI.
@@ -87,15 +88,6 @@ class Scratch3PenBlocks {
         };
     }
 
-    /**
-     * Place the pen layer in front of the backdrop but behind everything else.
-     * We should probably handle this somewhere else... somewhere central that knows about pen, backdrop, video, etc.
-     * Maybe it should be in the GUI?
-     * @type {int}
-     */
-    static get PEN_ORDER () {
-        return 1;
-    }
 
     /**
      * The minimum and maximum allowed pen size.
@@ -136,8 +128,8 @@ class Scratch3PenBlocks {
     _getPenLayerID () {
         if (this._penSkinId < 0 && this.runtime.renderer) {
             this._penSkinId = this.runtime.renderer.createPenSkin();
-            this._penDrawableId = this.runtime.renderer.createDrawable();
-            this.runtime.renderer.setDrawableOrder(this._penDrawableId, Scratch3PenBlocks.PEN_ORDER);
+            this._penDrawableId = this.runtime.renderer.createDrawable(
+                StageLayering.EXTENSION_LAYER, StageLayering.PEN_ORDER);
             this.runtime.renderer.updateDrawableProperties(this._penDrawableId, {skinId: this._penSkinId});
         }
         return this._penSkinId;

--- a/src/io/video.js
+++ b/src/io/video.js
@@ -1,3 +1,5 @@
+const StageLayering = require('../engine/stage-layering');
+
 class Video {
     constructor (runtime) {
         this.runtime = runtime;
@@ -144,11 +146,7 @@ class Video {
         if (this._skinId === -1 && this._skin === null && this._drawable === -1) {
             this._skinId = renderer.createPenSkin();
             this._skin = renderer._allSkins[this._skinId];
-            this._drawable = renderer.createDrawable();
-            renderer.setDrawableOrder(
-                this._drawable,
-                Video.ORDER
-            );
+            this._drawable = renderer.createDrawable(StageLayering.EXTENSION_LAYER, StageLayering.VIDEO_ORDER);
             renderer.updateDrawableProperties(this._drawable, {
                 skinId: this._skinId
             });

--- a/src/io/video.js
+++ b/src/io/video.js
@@ -146,7 +146,7 @@ class Video {
         if (this._skinId === -1 && this._skin === null && this._drawable === -1) {
             this._skinId = renderer.createPenSkin();
             this._skin = renderer._allSkins[this._skinId];
-            this._drawable = renderer.createDrawable(StageLayering.EXTENSION_LAYER, StageLayering.VIDEO_ORDER);
+            this._drawable = renderer.createDrawable(StageLayering.VIDEO_LAYER);
             renderer.updateDrawableProperties(this._drawable, {
                 skinId: this._skinId
             });

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -15,6 +15,7 @@ const StringUtil = require('../util/string-util');
 const specMap = require('./sb2_specmap');
 const Variable = require('../engine/variable');
 const MonitorRecord = require('../engine/monitor-record');
+const StageLayering = require('../engine/stage-layering');
 
 const {loadCostume} = require('../import/load-costume.js');
 const {loadSound} = require('../import/load-sound.js');
@@ -327,7 +328,7 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip)
     // Blocks container for this object.
     const blocks = new Blocks();
     // @todo: For now, load all Scratch objects (stage/sprites) as a Sprite.
-    const sprite = new Sprite(blocks, runtime, topLevel /* whether this sprite is a stge or not */);
+    const sprite = new Sprite(blocks, runtime);
     // Sprite/stage name from JSON.
     if (object.hasOwnProperty('objName')) {
         sprite.name = topLevel ? 'Stage' : object.objName;
@@ -399,7 +400,7 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip)
     }
 
     // Create the first clone, and load its run-state from JSON.
-    const target = sprite.createClone();
+    const target = sprite.createClone(topLevel ? StageLayering.BACKGROUND_LAYER : StageLayering.SPRITE_LAYER);
 
     const getVariableId = generateVariableIdGetter(target.id, topLevel);
 

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -327,7 +327,7 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip)
     // Blocks container for this object.
     const blocks = new Blocks();
     // @todo: For now, load all Scratch objects (stage/sprites) as a Sprite.
-    const sprite = new Sprite(blocks, runtime);
+    const sprite = new Sprite(blocks, runtime, topLevel /* whether this sprite is a stge or not */);
     // Sprite/stage name from JSON.
     if (object.hasOwnProperty('objName')) {
         sprite.name = topLevel ? 'Stage' : object.objName;

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -8,6 +8,7 @@ const vmPackage = require('../../package.json');
 const Blocks = require('../engine/blocks');
 const Sprite = require('../sprites/sprite');
 const Variable = require('../engine/variable');
+const StageLayering = require('../engine/stage-layering');
 const log = require('../util/log');
 const uid = require('../util/uid');
 
@@ -684,7 +685,7 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     const blocks = new Blocks();
 
     // @todo: For now, load all Scratch objects (stage/sprites) as a Sprite.
-    const sprite = new Sprite(blocks, runtime, object.isStage);
+    const sprite = new Sprite(blocks, runtime);
 
     // Sprite/stage name from JSON.
     if (object.hasOwnProperty('name')) {
@@ -779,7 +780,7 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
         // process has been completed.
     });
     // Create the first clone, and load its run-state from JSON.
-    const target = sprite.createClone();
+    const target = sprite.createClone(object.isStage ? StageLayering.BACKGROUND_LAYER : StageLayering.SPRITE_LAYER);
     // Load target properties from JSON.
     if (object.hasOwnProperty('tempo')) {
         target.tempo = object.tempo;

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -684,7 +684,7 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     const blocks = new Blocks();
 
     // @todo: For now, load all Scratch objects (stage/sprites) as a Sprite.
-    const sprite = new Sprite(blocks, runtime);
+    const sprite = new Sprite(blocks, runtime, object.isStage);
 
     // Sprite/stage name from JSON.
     if (object.hasOwnProperty('name')) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -847,11 +847,9 @@ class RenderedTarget extends Target {
      */
     goBehindOther (other) {
         if (this.renderer) {
-            this.renderer.positionDrawableRelativeToOther(
-                this.drawableID, other.drawableID, -1, StageLayering.SPRITE_LAYER);
-            // const otherLayer = this.renderer.setDrawableOrder(
-            //     other.drawableID, 0, StageLayering.SPRITE_LAYER, true);
-            // this.renderer.setDrawableOrder(this.drawableID, otherLayer, StageLayering.SPRITE_LAYER);
+            const otherLayer = this.renderer.setDrawableOrder(
+                other.drawableID, 0, StageLayering.SPRITE_LAYER, true);
+            this.renderer.setDrawableOrder(this.drawableID, otherLayer, StageLayering.SPRITE_LAYER);
         }
     }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -156,6 +156,8 @@ class RenderedTarget extends Target {
 
     /**
      * Create a drawable with the this.renderer.
+     * @param {boolean} isStage Whether the drawable should be initialized as
+     * the stage or a sprite
      */
     initDrawable (isStage) {
         if (this.renderer) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -156,13 +156,11 @@ class RenderedTarget extends Target {
 
     /**
      * Create a drawable with the this.renderer.
-     * @param {boolean} isStage Whether the drawable should be initialized as
-     * the stage or a sprite
+     * @param {boolean} layerGroup The layer group this drawable should be added to
      */
-    initDrawable (isStage) {
+    initDrawable (layerGroup) {
         if (this.renderer) {
-            this.drawableID = this.renderer.createDrawable(isStage ?
-                StageLayering.BACKGROUND_LAYER : StageLayering.SPRITE_LAYER);
+            this.drawableID = this.renderer.createDrawable(layerGroup);
         }
         // If we're a clone, start the hats.
         if (!this.isOriginal) {
@@ -920,7 +918,7 @@ class RenderedTarget extends Target {
         newClone.effects = JSON.parse(JSON.stringify(this.effects));
         newClone.variables = JSON.parse(JSON.stringify(this.variables));
         newClone.lists = JSON.parse(JSON.stringify(this.lists));
-        newClone.initDrawable(false); // this,sprite is not a stage if we're calling makeClone on it
+        newClone.initDrawable(StageLayering.SPRITE_LAYER); // TODO should sprite clones be in their own layer group?
         newClone.updateAllDrawableProperties();
         // Place behind the current target.
         newClone.goBehindOther(this);

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -847,9 +847,11 @@ class RenderedTarget extends Target {
      */
     goBehindOther (other) {
         if (this.renderer) {
-            const otherLayer = this.renderer.setDrawableOrder(
-                other.drawableID, 0, StageLayering.SPRITE_LAYER, true);
-            this.renderer.setDrawableOrder(this.drawableID, otherLayer, StageLayering.SPRITE_LAYER);
+            this.renderer.positionDrawableRelativeToOther(
+                this.drawableID, other.drawableID, -1, StageLayering.SPRITE_LAYER);
+            // const otherLayer = this.renderer.setDrawableOrder(
+            //     other.drawableID, 0, StageLayering.SPRITE_LAYER, true);
+            // this.renderer.setDrawableOrder(this.drawableID, otherLayer, StageLayering.SPRITE_LAYER);
         }
     }
 
@@ -918,7 +920,7 @@ class RenderedTarget extends Target {
         newClone.effects = JSON.parse(JSON.stringify(this.effects));
         newClone.variables = JSON.parse(JSON.stringify(this.variables));
         newClone.lists = JSON.parse(JSON.stringify(this.lists));
-        newClone.initDrawable(StageLayering.SPRITE_LAYER); // TODO should sprite clones be in their own layer group?
+        newClone.initDrawable(StageLayering.SPRITE_LAYER);
         newClone.updateAllDrawableProperties();
         // Place behind the current target.
         newClone.goBehindOther(this);
@@ -1055,7 +1057,9 @@ class RenderedTarget extends Target {
         this.runtime.stopForTarget(this);
         this.sprite.removeClone(this);
         if (this.renderer && this.drawableID !== null) {
-            this.renderer.destroyDrawable(this.drawableID, StageLayering.SPRITE_LAYER);
+            this.renderer.destroyDrawable(this.drawableID, this.isStage ?
+                StageLayering.BACKGROUND_LAYER :
+                StageLayering.SPRITE_LAYER);
             if (this.visible) {
                 this.emit(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this);
                 this.runtime.requestRedraw();

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -10,9 +10,10 @@ class Sprite {
      * All clones of a sprite have shared blocks, shared costumes, shared variables.
      * @param {?Blocks} blocks Shared blocks object for all clones of sprite.
      * @param {Runtime} runtime Reference to the runtime.
+     * @param {boolean=} isStage Whether or not this sprite is a stage
      * @constructor
      */
-    constructor (blocks, runtime) {
+    constructor (blocks, runtime, isStage) {
         this.runtime = runtime;
         if (!blocks) {
             // Shared set of blocks for all clones.
@@ -46,8 +47,12 @@ class Sprite {
          * @type {Array.<!RenderedTarget>}
          */
         this.clones = [];
+
+        // Needed for figuring out whether the associated drawable should
+        // go in the background layer or sprite layer
+        this.isStage = isStage || false;
     }
-    
+
     /**
      * Add an array of costumes, taking care to avoid duplicate names.
      * @param {!Array<object>} costumes Array of objects representing costumes.
@@ -103,7 +108,7 @@ class Sprite {
         this.clones.push(newClone);
         newClone.initAudio();
         if (newClone.isOriginal) {
-            newClone.initDrawable();
+            newClone.initDrawable(this.isStage);
             this.runtime.fireTargetWasCreated(newClone);
         } else {
             this.runtime.fireTargetWasCreated(newClone, this.clones[0]);

--- a/test/fixtures/fake-renderer.js
+++ b/test/fixtures/fake-renderer.js
@@ -42,7 +42,7 @@ FakeRenderer.prototype.getBounds = function (d) { // eslint-disable-line no-unus
     return {left: this.x, right: this.x, top: this.y, bottom: this.y};
 };
 
-FakeRenderer.prototype.setDrawableOrder = function (d, a, optA, optB) { // eslint-disable-line no-unused-vars
+FakeRenderer.prototype.setDrawableOrder = function (d, a, optG, optA, optB) { // eslint-disable-line no-unused-vars
     if (d === 999) return 1; // fake for test case
     if (optA) {
         a += this.order;
@@ -62,5 +62,7 @@ FakeRenderer.prototype.pick = function (x, y, a, b, c) { // eslint-disable-line 
 FakeRenderer.prototype.isTouchingColor = function (a, b) { // eslint-disable-line no-unused-vars
     return false;
 };
+
+FakeRenderer.prototype.setLayerGroupOrdering = function (a) {}; // eslint-disable-line no-unused-vars
 
 module.exports = FakeRenderer;

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -302,7 +302,7 @@ test('colorIsTouchingColor', t => {
     t.end();
 });
 
-test('layers', t => {
+test('layers', t => { // TODO this tests fake functionality. Move layering tests into Render.
     const s = new Sprite();
     const r = new Runtime();
     const renderer = new FakeRenderer();
@@ -315,9 +315,11 @@ test('layers', t => {
     a.goBackwardLayers(2);
     t.equals(a.renderer.order, 3);
     a.goToBack();
-    t.equals(a.renderer.order, 1);
+    // Note, there are only sprites in this test, no stage, and the addition
+    // of layer groups, goToBack no longer specifies a minimum order number
+    t.equals(a.renderer.order, 0);
     a.goForwardLayers(1);
-    t.equals(a.renderer.order, 2);
+    t.equals(a.renderer.order, 1);
     o.drawableID = 999;
     a.goBehindOther(o);
     t.equals(a.renderer.order, 1);


### PR DESCRIPTION
### Resolves

#1066

### Proposed Changes

Create layer groups. See LLK/scratch-render#285 for a more detailed description of how they work.
Note, I wasn't sure where to put the stage layering contents. I put it in src/engine for now. I wanted to put it in runtime, but then there's a circular dependency between runtime and video.

### Reason for Changes

#1066.

### Test Coverage

Existing tests pass.

#### Related PRs
LLK/scratch-render#285.
The tests for render depend on this PR so it should be merged first.