### PR TITLE
Add option for Extensions to have different colour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ npm-*
 /.nyc_output
 /coverage
 
-# IDEA
+# Editor
 /.idea
+/.vscode
 
 # Build
 /dist

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -498,9 +498,9 @@ class Runtime extends EventEmitter {
             name: maybeFormatMessage(extensionInfo.name),
             blockIconURI: extensionInfo.blockIconURI,
             menuIconURI: extensionInfo.menuIconURI,
-            color1: '#FF6680',
-            color2: '#FF4D6A',
-            color3: '#FF3355',
+            color1: extensionInfo.colour || '#FF6680',
+            color2: extensionInfo.colourSecondary || '#FF4D6A',
+            color3: extensionInfo.colourTertiary || '#FF3355',
             blocks: [],
             menus: []
         };


### PR DESCRIPTION
### Resolves

#1151 

### Proposed Changes

This pull request allows for an extension category to identify blocks in a separate colour

### Reason for Changes

We need a different colour than pink, as we are treating each category as a separate extension
