### PR TITLE
Allow override of icons per block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ npm-*
 /.nyc_output
 /coverage
 
-# IDEA
+# Editor
 /.idea
+/.vscode
 
 # Build
 /dist

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -649,11 +649,15 @@ class Runtime extends EventEmitter {
         };
 
         // If an icon for the extension exists, prepend it to each block, with a vertical separator.
-        if (categoryInfo.blockIconURI) {
+        // We can overspecify an icon for each block, but if no icon exists on a block, fall back to
+        // the category block icon.
+        const iconURI = blockInfo.blockIconURI || categoryInfo.blockIconURI;
+
+        if (iconURI) {
             blockJSON.message0 = '%1 %2';
             const iconJSON = {
                 type: 'field_image',
-                src: categoryInfo.blockIconURI,
+                src: iconURI,
                 width: 40,
                 height: 40
             };


### PR DESCRIPTION
### Resolves

#1152 

### Proposed Changes

current behavior of Extension icons: 

Use a menu icon if there is one. Otherwise, use the block icon. If there's no icon, the category menu will show its default colored circle.

this adds the capability to specify an icon per block if it needs to be overwritten, instead of using the specified blockIconURI from the extension specification itself.

### Reason for Changes

It would allow us to specify individual icons on the blocks, without having to add this in the block definition itself, to avoid mixing the location where to add icons

