### PR TITLE
Publish specific files and folders to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,20 @@
+# Development files
+.eslintrc.js
+/.editorconfig
+/.eslintignore
+/.gitattributes
+/.github
+/.travis.yml
+/.tx
+/test
+/webpack.config.js
+
+# Build created files
+/playground
+
+# Coverage created files
 /.nyc_output
 /coverage
+
+# Exclude already built packages from testing with npm pack
+/scratch-vm-*.{tar,tgz}


### PR DESCRIPTION
### Proposed Changes

- Publish only `src`, `dist`, `TRADEMARK`, `README.md`, `package.json`, and `LICENSE` to npm

### Reason for Changes

Other packages that depend on scratch-vm need to download it and locally install a copy to require into. As scratch-vm is, it's publishing `playground` and `test`. These folders are not used by scratch-vm dependents. These directories take up a relatively large amount of space in the download file and once extracted on disk. Importantly this extra space means that CI servers along with the developers working on another scratch-* package need to spend more time downloading and for CI, more time storing and retrieving the node_modules cache to perform CI work quicker.

Specifying the files published with this change, reduces the download from **27MB** to **15MB**, and space used once extracted from **64MB** to **35MB**. Most of the savings is from omitting `playground`.

-----

`README.md`, `package.json` and `LICENSE` are automatically included in the files published to npm whether they are stated in `package.json` or not. I can add those if the explicit nature of stating them that way would be preferred.
