### PR TITLE
Round (x position) and (y position) to 8 places

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -238,6 +238,17 @@ class RenderedTarget extends Target {
     }
 
     /**
+     * Round a number to n digits
+     * @param {number} value The number to be rounded
+     * @param {number} places The number of decimal places to round to
+     * @return {number} The rounded number
+     */
+    _roundCoord (value, places) {
+        const power = Math.pow(10, places);
+        return Math.round(value * power) / power;
+    }
+
+    /**
      * Set the X and Y coordinates.
      * @param {!number} x New X coordinate, in Scratch coordinates.
      * @param {!number} y New Y coordinate, in Scratch coordinates.
@@ -250,6 +261,8 @@ class RenderedTarget extends Target {
         const oldY = this.y;
         if (this.renderer) {
             const position = this.renderer.getFencedPositionOfDrawable(this.drawableID, [x, y]);
+            position[0] = this._roundCoord(position[0], 8);
+            position[1] = this._roundCoord(position[1], 8);
             this.x = position[0];
             this.y = position[1];
 
@@ -261,8 +274,8 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         } else {
-            this.x = x;
-            this.y = y;
+            this.x = this._roundCoord(x, 8);
+            this.y = this._roundCoord(y, 8);
         }
         this.emit(RenderedTarget.EVENT_TARGET_MOVED, this, oldX, oldY, force);
         this.runtime.requestTargetsUpdate(this);


### PR DESCRIPTION
### Resolves

Fixes #1150 

### Proposed Changes

Adds a `round_coord` function as a quick and easy shortcut to rounding to N digits, then uses that in `getX` and `getY` to round the coordinates to 8 decimal places at most.

### Reason for Changes

To fix a help wanted issue