### PR TITLE
Runtime emits key pressed event

### DIFF
--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -7,6 +7,15 @@ class Scratch3EventBlocks {
          * @type {Runtime}
          */
         this.runtime = runtime;
+
+        this.runtime.on('KEY_PRESSED', key => {
+            this.runtime.startHats('event_whenkeypressed', {
+                KEY_OPTION: key
+            });
+            this.runtime.startHats('event_whenkeypressed', {
+                KEY_OPTION: 'any'
+            });
+        });
     }
 
     /**

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -116,17 +116,11 @@ class Keyboard {
         if (scratchKey === '') return;
         const index = this._keysPressed.indexOf(scratchKey);
         if (data.isDown) {
+            this.runtime.emit('KEY_PRESSED', scratchKey);
             // If not already present, add to the list.
             if (index < 0) {
                 this._keysPressed.push(scratchKey);
             }
-            // Always trigger hats, even if it was already pressed.
-            this.runtime.startHats('event_whenkeypressed', {
-                KEY_OPTION: scratchKey
-            });
-            this.runtime.startHats('event_whenkeypressed', {
-                KEY_OPTION: 'any'
-            });
         } else if (index > -1) {
             // If already present, remove from the list.
             this._keysPressed.splice(index, 1);


### PR DESCRIPTION
### Resolves

No issue for this- just an under-the-hood fix.

### Proposed Changes

- Keyboard io util makes the runtime emit a KEY_PRESSED event, instead of starting hats directly.
- The event blocks class handles the event and starts its own hats.

### Reason for Changes

- Separation of concerns, I suppose. 
- Also the key pressed event is useful for a certain extension I am making...

### Test Coverage

No tests