### PR TITLE
Add logged out version of username block

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -68,6 +68,7 @@ class Scratch3SensingBlocks {
             sensing_loud: this.isLoud,
             sensing_askandwait: this.askAndWait,
             sensing_answer: this.getAnswer,
+            sensing_username: this.getUsername,
             sensing_userid: () => {} // legacy no-op block
         };
     }
@@ -314,6 +315,11 @@ class Scratch3SensingBlocks {
 
         // Otherwise, 0
         return 0;
+    }
+
+    getUsername () {
+        // Logged out users get empty string. Return that for now.
+        return '';
     }
 }
 

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -143,3 +143,11 @@ test('loud? boolean', t => {
 
     t.end();
 });
+
+test('username block', t => {
+    const rt = new Runtime();
+    const sensing = new Sensing(rt);
+
+    t.equal(sensing.getUsername(), '');
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

I'll leave https://github.com/LLK/scratch-vm/issues/306 open, but this is the first step towards it. Scratch2 returns `''` for logged out users, so do that for the preview. 

### Proposed Changes

_Describe what this Pull Request does_

implement the `sensing_username` block to return '' always.

### Reason for Changes

_Explain why these changes should be made_

So that the block can be added!

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test....
