### PR TITLE
Always give backdrops a certain rotation center

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -337,11 +337,12 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip)
     if (object.hasOwnProperty('costumes')) {
         for (let i = 0; i < object.costumes.length; i++) {
             const costumeSource = object.costumes[i];
+            const bitmapResolution = costumeSource.bitmapResolution || 1;
             const costume = {
                 name: costumeSource.costumeName,
-                bitmapResolution: costumeSource.bitmapResolution || 1,
-                rotationCenterX: topLevel ? 240 : costumeSource.rotationCenterX,
-                rotationCenterY: topLevel ? 180 : costumeSource.rotationCenterY,
+                bitmapResolution: bitmapResolution,
+                rotationCenterX: topLevel ? 240 * bitmapResolution : costumeSource.rotationCenterX,
+                rotationCenterY: topLevel ? 180 * bitmapResolution : costumeSource.rotationCenterY,
                 // TODO we eventually want this next property to be called
                 // md5ext to reflect what it actually contains, however this
                 // will be a very extensive change across many repositories

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -340,8 +340,8 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip)
             const costume = {
                 name: costumeSource.costumeName,
                 bitmapResolution: costumeSource.bitmapResolution || 1,
-                rotationCenterX: costumeSource.rotationCenterX,
-                rotationCenterY: costumeSource.rotationCenterY,
+                rotationCenterX: topLevel ? 240 : costumeSource.rotationCenterX,
+                rotationCenterY: topLevel ? 180 : costumeSource.rotationCenterY,
                 // TODO we eventually want this next property to be called
                 // md5ext to reflect what it actually contains, however this
                 // will be a very extensive change across many repositories


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/342, https://github.com/LLK/scratch-gui/issues/1614

### Proposed Changes
Scratch 2 ignores rotation center on backdrops and always sets it to 240, 180
When loading scratch 2 projects in scratch 3, convert the rotation center to 240, 180

### Reason for Changes

Compatibility when playing scratch 2 projects
