### PR TITLE
Use default asset if asset cannot be loaded

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -16,6 +16,7 @@ const log = require('../util/log');
  * @returns {?Promise} - a promise which will resolve after skinId is set, or null on error.
  */
 const loadCostumeFromAsset = function (costume, costumeAsset, runtime, optVersion) {
+
     costume.assetId = costumeAsset.assetId;
     const renderer = runtime.renderer;
     if (!renderer) {
@@ -119,9 +120,18 @@ const loadCostume = function (md5ext, costume, runtime, optVersion) {
     const ext = idParts[1].toLowerCase();
     const assetType = (ext === 'svg') ? AssetType.ImageVector : AssetType.ImageBitmap;
 
+    const onLoad = asset => {
+        costume.dataFormat = asset.dataFormat;
+        return loadCostumeFromAsset(costume, asset, runtime, optVersion);
+    };
+
     return runtime.storage.load(assetType, md5, ext).then(costumeAsset => {
-        costume.dataFormat = ext;
-        return loadCostumeFromAsset(costume, costumeAsset, runtime, optVersion);
+        if (costumeAsset) {
+            return onLoad(costumeAsset);
+        }
+        const defaultAssetId = runtime.storage.getDefaultAssetId(assetType);
+        return runtime.storage.load(assetType, defaultAssetId).then(onLoad);
+
     });
 };
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes an issue where scratch crashes if you try to load a project with an asset that isn't on the servers.

### Proposed Changes

_Describe what this Pull Request does_

Use the default asset which is in storage.

### Reason for Changes

_Explain why these changes should be made_

Projects with unlinked assets should not crash.

### Test Coverage

_Please show how you have added tests to cover your changes_

None, there are no unit test around this code right now. 