### PR TITLE
Add language reporter block to translate extension

### DIFF
--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -100,6 +100,12 @@ class Scratch3TranslateBlocks {
                             defaultValue: this._viewerLanguageCode
                         }
                     }
+                },
+                {
+                    opcode: 'getViewerLanguage',
+                    text: 'viewer language',
+                    blockType: BlockType.REPORTER,
+                    arguments: {}
                 }
             ],
             menus: {
@@ -108,6 +114,13 @@ class Scratch3TranslateBlocks {
         };
     }
 
+    /**
+     * Get the viewer language for the reporter block.
+     * @return {string} the language code of the project viewer.
+     */
+    getViewerLanguage () {
+        return this._viewerLanguageCode;
+    }
 
     /**
      * Get the viewer's language code.

--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -79,7 +79,7 @@ class Scratch3TranslateBlocks {
         return {
             id: 'translate',
             name: 'Translate',
-            menuIconURI: '',  // TODO: Add the final icons.
+            menuIconURI: '', // TODO: Add the final icons.
             blockIconURI: '',
             blocks: [
                 {

--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -6,9 +6,6 @@ const nets = require('nets');
 const languageNames = require('scratch-translate-extension-languages');
 const formatMessage = require('format-message');
 
-// TODO: Change these to the correct icons.
-const blockIconURI = 'https://www.gstatic.com/images/icons/material/system/1x/translate_white_24dp.png';
-const menuIconURI = 'https://www.gstatic.com/images/icons/material/system/1x/translate_grey600_24dp.png';
 
 /**
  * The url of the translate server.
@@ -82,17 +79,25 @@ class Scratch3TranslateBlocks {
         return {
             id: 'translate',
             name: 'Translate',
-            menuIconURI: menuIconURI,
-            blockIconURI: blockIconURI,
+            menuIconURI: '',  // TODO: Add the final icons.
+            blockIconURI: '',
             blocks: [
                 {
                     opcode: 'getTranslate',
-                    text: 'translate [WORDS] to [LANGUAGE]',
+                    text: formatMessage({
+                        id: 'translate.translateBlock',
+                        default: 'translate [WORDS] to [LANGUAGE]',
+                        description: 'translate some text to a different language'
+                    }),
                     blockType: BlockType.REPORTER,
                     arguments: {
                         WORDS: {
                             type: ArgumentType.STRING,
-                            defaultValue: 'hello'
+                            defaultValue: formatMessage({
+                                id: 'translate.defaultTextToTranslate',
+                                default: 'hello',
+                                description: 'hello: the default text to translate'
+                            })
                         },
                         LANGUAGE: {
                             type: ArgumentType.STRING,
@@ -103,7 +108,11 @@ class Scratch3TranslateBlocks {
                 },
                 {
                     opcode: 'getViewerLanguage',
-                    text: 'viewer language',
+                    text: formatMessage({
+                        id: 'translate.viewerLanguage',
+                        default: 'viewer language',
+                        description: 'the languge of the project viewer'
+                    }),
                     blockType: BlockType.REPORTER,
                     arguments: {}
                 }
@@ -115,11 +124,18 @@ class Scratch3TranslateBlocks {
     }
 
     /**
-     * Get the viewer language for the reporter block.
-     * @return {string} the language code of the project viewer.
+     * Get the human readable language value for the reporter block.
+     * @return {string} the language name of the project viewer.
      */
     getViewerLanguage () {
-        return this._viewerLanguageCode;
+        this._viewerLanguageCode = this.getViewerLanguageCode();
+        const names = languageNames.menuMap[this._viewerLanguageCode];
+        const langNameObj = names.find(obj => obj.code === this._viewerLanguageCode);
+        let langName = this._viewerLanguageCode;
+        if (langNameObj) {
+            langName = langNameObj.name;
+        }
+        return langName;
     }
 
     /**


### PR DESCRIPTION
### Resolves
Progress toward https://github.com/LLK/scratch-vm/issues/1029

Adding the reporter block for viewer language. The block reports the human readable language name since that is easier to understand and the translate block accepts language names dropped on top of the menu.

Also adds messages for the text in the blocks

Removes the icons from the blocks. These will be replaced in a subsequent PR.

