### PR TITLE
Translate block defaults to a random language

### DIFF
--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -43,6 +43,14 @@ class Scratch3TranslateBlocks {
         });
 
         /**
+         * A randomly selected language code, for use as the default value in the language menu.
+         * @type {string}
+         * @private
+         */
+        this._randomLanguageCode = this._supportedLanguages[
+            Math.floor(Math.random() * this._supportedLanguages.length)].value;
+
+        /**
          * The result from the most recent translation.
          * @type {string}
          * @private
@@ -102,7 +110,7 @@ class Scratch3TranslateBlocks {
                         LANGUAGE: {
                             type: ArgumentType.STRING,
                             menu: 'languages',
-                            defaultValue: this._viewerLanguageCode
+                            defaultValue: this._randomLanguageCode
                         }
                     }
                 },


### PR DESCRIPTION
### Proposed Changes

When the translate extension loads, select a random language from the list of supported languages to display as the default in the language menu in the translate block.

### Reason for Changes

Other options include defaulting to the first entry (Albanian) or to the viewer's language (e.g. English). This seems like more of a fun way to first experience the extension.

Note that we do not right now have a way to dynamically update this default value after the extension has loaded (that I know of). So it will not change when you switch sprites- only when you re-load the editor and load the extension again.