### PR TITLE
Set/change sound effect and volume blocks yield until the next tick

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -229,6 +229,7 @@ class Scratch3SoundBlocks {
 
         if (util.target.audioPlayer === null) return;
         util.target.audioPlayer.setEffect(effect, soundState.effects[effect]);
+        this.runtime.requestRedraw();
     }
 
     _syncEffectsForTarget (target) {
@@ -277,6 +278,7 @@ class Scratch3SoundBlocks {
         util.target.volume = volume;
         if (util.target.audioPlayer === null) return;
         util.target.audioPlayer.setVolume(util.target.volume);
+        this.runtime.requestRedraw();
     }
 
     getVolume (args, util) {

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -204,11 +204,11 @@ class Scratch3SoundBlocks {
     }
 
     setEffect (args, util) {
-        this._updateEffect(args, util, false);
+        return this._updateEffect(args, util, false);
     }
 
     changeEffect (args, util) {
-        this._updateEffect(args, util, true);
+        return this._updateEffect(args, util, true);
     }
 
     _updateEffect (args, util, change) {
@@ -229,7 +229,11 @@ class Scratch3SoundBlocks {
 
         if (util.target.audioPlayer === null) return;
         util.target.audioPlayer.setEffect(effect, soundState.effects[effect]);
-        this.runtime.requestRedraw();
+
+        // Yield until the next tick.
+        return new Promise(resolve => {
+            resolve();
+        });
     }
 
     _syncEffectsForTarget (target) {
@@ -265,12 +269,12 @@ class Scratch3SoundBlocks {
 
     setVolume (args, util) {
         const volume = Cast.toNumber(args.VOLUME);
-        this._updateVolume(volume, util);
+        return this._updateVolume(volume, util);
     }
 
     changeVolume (args, util) {
         const volume = Cast.toNumber(args.VOLUME) + util.target.volume;
-        this._updateVolume(volume, util);
+        return this._updateVolume(volume, util);
     }
 
     _updateVolume (volume, util) {
@@ -278,7 +282,11 @@ class Scratch3SoundBlocks {
         util.target.volume = volume;
         if (util.target.audioPlayer === null) return;
         util.target.audioPlayer.setVolume(util.target.volume);
-        this.runtime.requestRedraw();
+
+        // Yield until the next tick.
+        return new Promise(resolve => {
+            resolve();
+        });
     }
 
     getVolume (args, util) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1063

### Proposed Changes

Make these blocks yield until the next tick:

- set pitch effect by 10
- change pitch effect by 10
- set volume to 100%
- change volume by -10%

### Reason for Changes

Prior to this change, the sound effect and volume blocks could run "as fast as possible" if they were in a loop body without any block that yields or requests a redraw. This could have unexpected effects. For example you might expect this stack to let you use a key to change the pitch: 

forever [ if space key pressed [ change pitch by 10 ] ]

Instead, it would instantly set the pitch to its maximum value when you press the key.

After the change, it's possible to use code like the above to continuously change the pitch, pan or volume at 30fps. 