### PR TITLE
fix: resolve scratch-*/src/index.js for expose-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,15 +119,15 @@ module.exports = [
                     loader: 'expose-loader?Blockly'
                 },
                 {
-                    test: require.resolve('scratch-audio'),
+                    test: require.resolve('scratch-audio/src/index.js'),
                     loader: 'expose-loader?AudioEngine'
                 },
                 {
-                    test: require.resolve('scratch-storage'),
+                    test: require.resolve('scratch-storage/src/index.js'),
                     loader: 'expose-loader?ScratchStorage'
                 },
                 {
-                    test: require.resolve('scratch-render'),
+                    test: require.resolve('scratch-render/src/index.js'),
                     loader: 'expose-loader?ScratchRender'
                 }
             ])


### PR DESCRIPTION
require.resolve is a nodejs api that resolves as node resolves. An
enhanced-resolve instance, the library webpack uses, could resolve as
webpack will or we can use some slightly more manual definitions here
for exposing parts of scratch on the global object for the playground's
benchmark to use.