### PR TITLE
Persist comment state.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -295,8 +295,9 @@ class Blocks {
                 oldInput: e.oldInputName,
                 newParent: e.newParentId,
                 newInput: e.newInputName,
-                newCoordinate: e.newCoordinate
-            });
+                newCoordinate: e.newCoordinate,
+                oldCoordinate: e.oldCoordinate
+            }, optRuntime);
             break;
         case 'dragOutside':
             if (optRuntime) {
@@ -551,8 +552,10 @@ class Blocks {
     /**
      * Block management: move blocks from parent to parent
      * @param {!object} e Blockly move event to be processed
+     * @param {?Runtime} optRuntime Optional runtime for updating the position
+     * of a comment on the block that moved.
      */
-    moveBlock (e) {
+    moveBlock (e, optRuntime) {
         if (!this._blocks.hasOwnProperty(e.id)) {
             return;
         }
@@ -561,6 +564,19 @@ class Blocks {
         if (e.newCoordinate) {
             this._blocks[e.id].x = e.newCoordinate.x;
             this._blocks[e.id].y = e.newCoordinate.y;
+
+            // If the moved block has a comment, update the position of the comment.
+            if (typeof this._blocks[e.id].comment === 'string' && optRuntime &&
+                e.oldCoordinate) {
+                const commentId = this._blocks[e.id].comment;
+                const currTarget = optRuntime.getEditingTarget();
+                if (currTarget && currTarget.comments.hasOwnProperty(commentId)) {
+                    const deltaX = e.newCoordinate.x - e.oldCoordinate.x;
+                    const deltaY = e.newCoordinate.y - e.oldCoordinate.y;
+                    currTarget.comments[commentId].x += deltaX;
+                    currTarget.comments[commentId].y += deltaY;
+                }
+            }
         }
 
         // Remove from any old parent.

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -358,14 +358,14 @@ class Blocks {
             stage.deleteVariable(e.varId);
             break;
         case 'comment_create':
-            if (optRuntime.getEditingTarget()) {
+            if (optRuntime && optRuntime.getEditingTarget()) {
                 const currTarget = optRuntime.getEditingTarget();
                 currTarget.createComment(e.commentId, e.blockId, e.text,
                     e.xy.x, e.xy.y, e.width, e.height, e.minimized);
             }
             break;
         case 'comment_change':
-            if (optRuntime) {
+            if (optRuntime && optRuntime.getEditingTarget()) {
                 const currTarget = optRuntime.getEditingTarget();
                 if (!currTarget.comments.hasOwnProperty(e.commentId)) {
                     log.warn(`Cannot change comment with id ${e.commentId} because it does not exist.`);
@@ -392,9 +392,9 @@ class Blocks {
             }
             break;
         case 'comment_move':
-            if (optRuntime) {
+            if (optRuntime && optRuntime.getEditingTarget()) {
                 const currTarget = optRuntime.getEditingTarget();
-                if (!currTarget.comments.hasOwnProperty(e.commentId)) {
+                if (currTarget && !currTarget.comments.hasOwnProperty(e.commentId)) {
                     log.warn(`Cannot change comment with id ${e.commentId} because it does not exist.`);
                     return;
                 }
@@ -405,7 +405,7 @@ class Blocks {
             }
             break;
         case 'comment_delete':
-            if (optRuntime) {
+            if (optRuntime && optRuntime.getEditingTarget()) {
                 const currTarget = optRuntime.getEditingTarget();
                 if (!currTarget.comments.hasOwnProperty(e.commentId)) {
                     // If we're in this state, we have probably received

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -400,8 +400,8 @@ class Blocks {
                 }
                 const comment = currTarget.comments[e.commentId];
                 const newCoord = e.newCoordinate_;
-                comment.x = Math.floor(newCoord.x);
-                comment.y = Math.floor(newCoord.y);
+                comment.x = newCoord.x;
+                comment.y = newCoord.y;
             }
             break;
         case 'comment_delete':

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events');
 
 const Blocks = require('./blocks');
 const Variable = require('../engine/variable');
+const Comment = require('../engine/comment');
 const uid = require('../util/uid');
 const {Map} = require('immutable');
 const log = require('../util/log');
@@ -187,6 +188,30 @@ class Target extends EventEmitter {
         if (!this.variables.hasOwnProperty(id)) {
             const newVariable = new Variable(id, name, type, false);
             this.variables[id] = newVariable;
+        }
+    }
+
+    /**
+     * Creates a comment with the given properties.
+     * @param {string} id Id of the comment.
+     * @param {string} blockId Optional id of the block the comment is attached
+     * to if it is a block comment.
+     * @param {string} text The text the comment contains.
+     * @param {number} x The x coordinate of the comment on the workspace.
+     * @param {number} y The y coordinate of the comment on the workspace.
+     * @param {number} width The width of the comment when it is full size
+     * @param {number} height The height of the comment when it is full size
+     * @param {boolean} minimized Whether the comment is minimized.
+     */
+    createComment (id, blockId, text, x, y, width, height, minimized) {
+        if (!this.comments.hasOwnProperty(id)) {
+            const newComment = new Comment(id, text, x, y,
+                width, height, minimized);
+            if (blockId) {
+                newComment.blockId = blockId;
+                this.blocks.getBlock(blockId).comment = id;
+            }
+            this.comments[id] = newComment;
         }
     }
 

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -209,7 +209,13 @@ class Target extends EventEmitter {
                 width, height, minimized);
             if (blockId) {
                 newComment.blockId = blockId;
-                this.blocks.getBlock(blockId).comment = id;
+                const blockWithComment = this.blocks.getBlock(blockId);
+                if (blockWithComment) {
+                    blockWithComment.comment = id;
+                } else {
+                    log.warn(`Could not find block with id ${blockId
+                    } associated with commentId: ${id}`);
+                }
             }
             this.comments[id] = newComment;
         }


### PR DESCRIPTION
### Resolves

VM portion of `Persist comment state` in LLK/scratch-blocks#1554.

### Proposed Changes

Persist changes made to comments (modifying text, moving, resizing, minimizing, deleting) across the sprite switches and tab switches.

### Reason for Changes

Main comment functionality.

### Test Coverage

Tested in scratch-gui along with changes from LLK/scratch-blocks#1557.
