### PR TITLE
Update microbit extension for latest firmware

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -560,6 +560,7 @@ class Scratch3MicroBitBlocks {
      */
     displaySymbol (args) {
         const hex = symbols2hex[args.SYMBOL];
+        if (!hex) return;
         const output = new Uint8Array(6);
         output[0] = BLECommand.CMD_DISPLAY_LED;
         output[1] = (hex >> 20) & 0x1F;


### PR DESCRIPTION
### Proposed Changes

Update the micro:bit extension for the simplified TX/RX bluetooth firmware

### Reason for Changes

The current model of having many bluetooth characteristics isn't scalable with the memory constraints of the micro:bit

### Test Coverage

Load the latest scratch-firmware-combined.hex and run the extension
