### PR TITLE
Increase maximum pen size to 1200

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -91,10 +91,12 @@ class Scratch3PenBlocks {
 
     /**
      * The minimum and maximum allowed pen size.
+     * The maximum is twice the diagonal of the stage, so that even an
+     * off-stage sprite can fill it.
      * @type {{min: number, max: number}}
      */
     static get PEN_SIZE_RANGE () {
-        return {min: 1, max: 255};
+        return {min: 1, max: 1200};
     }
 
     /**


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/97

### Proposed Changes

Increase the maximum diameter of the pen in the pen extension to 1200px.

### Reason for Changes

The previous max of 255 was set by a limitation of flash. The new maximum was chosen to be twice the length of the diagonal of the stage, so that even if a sprite is off the stage, at the max pen size it can draw a single dot that completely fills it.

Some quick performance tests revealed that drawing with this very large pen size is very slightly slower, but we're still seeing thousands of pen operations per second, so it seems like an acceptable tradeoff for an edge case. 