### PR TITLE
Check that bubble bounds do not extend past stage boundaries

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -153,10 +153,17 @@ class Scratch3LooksBlocks {
             this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {
                 position: [
                     bubbleState.onSpriteRight ? (
-                        Math.min(stageBounds.right - bubbleWidth, targetBounds.right)
+                        Math.max(
+                            stageBounds.left, // Bubble should not extend past left edge of stage
+                            Math.min(stageBounds.right - bubbleWidth, targetBounds.right)
+                        )
                     ) : (
-                        Math.max(stageBounds.left, targetBounds.left - bubbleWidth)
+                        Math.min(
+                            stageBounds.right - bubbleWidth, // Bubble should not extend past right edge of stage
+                            Math.max(stageBounds.left, targetBounds.left - bubbleWidth)
+                        )
                     ),
+                    // Bubble should not extend past the top of the stage
                     Math.min(stageBounds.top, targetBounds.bottom + bubbleHeight)
                 ]
             });


### PR DESCRIPTION
### Resolves
Fixes #1135.

### Proposed Changes
This PR adds additional logic (and comments) to the `_positionBubble` function to check that a bubble's boundaries do not extend past the stage boundaries, even when the bubble cannot be flipped.

### How to test
In any sprite, set the x position to either a very large number or a very negative one. Use a say or think block. The resulting bubble should stay fully on the stage.
![demonstration of bug fix](https://user-images.githubusercontent.com/3019167/41000277-7b8226c6-68db-11e8-8ee2-8c2fff17bb7a.gif)