### PR TITLE
yield a tick if broadcastandwait is waiting on threads waiting for a future tick

### DIFF
--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -100,7 +100,17 @@ class Scratch3EventBlocks {
             const instance = this;
             const waiting = util.stackFrame.startedThreads.some(thread => instance.runtime.isActiveThread(thread));
             if (waiting) {
-                util.yield();
+                // If all threads are waiting for the next tick or later yield
+                // for a tick as well. Otherwise yield until the next loop of
+                // the threads.
+                if (
+                    util.stackFrame.startedThreads
+                        .every(thread => instance.runtime.isWaitingThread(thread))
+                ) {
+                    util.yieldTick();
+                } else {
+                    util.yield();
+                }
             }
         }
     }

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -409,7 +409,17 @@ class Scratch3LooksBlocks {
         const instance = this;
         const waiting = util.stackFrame.startedThreads.some(thread => instance.runtime.isActiveThread(thread));
         if (waiting) {
-            util.yield();
+            // If all threads are waiting for the next tick or later yield
+            // for a tick as well. Otherwise yield until the next loop of
+            // the threads.
+            if (
+                util.stackFrame.startedThreads
+                    .every(thread => instance.runtime.isWaitingThread(thread))
+            ) {
+                util.yieldTick();
+            } else {
+                util.yield();
+            }
         }
     }
 

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -231,9 +231,7 @@ class Scratch3SoundBlocks {
         util.target.audioPlayer.setEffect(effect, soundState.effects[effect]);
 
         // Yield until the next tick.
-        return new Promise(resolve => {
-            resolve();
-        });
+        return Promise.resolve();
     }
 
     _syncEffectsForTarget (target) {
@@ -284,9 +282,7 @@ class Scratch3SoundBlocks {
         util.target.audioPlayer.setVolume(util.target.volume);
 
         // Yield until the next tick.
-        return new Promise(resolve => {
-            resolve();
-        });
+        return Promise.resolve();
     }
 
     getVolume (args, util) {

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -58,6 +58,13 @@ class BlockUtility {
     }
 
     /**
+     * Set the thread to yield until the next tick of the runtime.
+     */
+    yieldTick () {
+        this.thread.status = Thread.STATUS_YIELD_TICK;
+    }
+
+    /**
      * Start a branch in the current block.
      * @param {number} branchNum Which branch to step to (i.e., 1, 2).
      * @param {boolean} isLoop Whether this block is a loop.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1018,6 +1018,19 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Return whether a thread is waiting for more information or done.
+     * @param {?Thread} thread Thread object to check.
+     * @return {boolean} True if the thread is waiting
+     */
+    isWaitingThread (thread) {
+        return (
+            thread.status === Thread.STATUS_PROMISE_WAIT ||
+            thread.status === Thread.STATUS_YIELD_TICK ||
+            !this.isActiveThread(thread)
+        );
+    }
+
+    /**
      * Toggle a script.
      * @param {!string} topBlockId ID of block that starts the script.
      * @param {?object} opts optional arguments to toggle script


### PR DESCRIPTION
### Resolves

Fix #1196

### Proposed Changes

Use STATUS_YIELD_TICK in event_broadcastandwait and looks_switchbackdroptoandwait if all threads are waiting for a some future time.

### Reason for Changes

Normal yielding lets other threads do work. Yielding a tick pauses the thread until the next tick of the runtime. This way if threads are looped 10 times, the block yielding a tick runs once instead of 10 times.

This is important for benchmarking as it makes these block deterministic in the number of times they run. If they are waiting on "waiting" threads and normally yield instead of yielding a tick they case the runtime to busy wait checking for a change that will not happen for up to 33 milliseconds.

### Test Coverage

As a performance issue this can be "tested" in the benchmark suite. Before this change event_broadcastandwait in http://llk.github.io/scratch-vm/index.html#155128646,5000,5000 might run hundreds of thousands of times. With the change event_broadcastandwait returns to its previous behaviour for this project running hundreds or thousands of times depending on the performance of the local hardware.
