### PR TITLE
execute optimization by unwrapping recursion

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -981,6 +981,7 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
 
     if (typeof CacheType === 'undefined') {
         cached = {
+            id: blockId,
             opcode: blocks.getOpcode(block),
             fields: blocks.getFields(block),
             inputs: blocks.getInputs(block),
@@ -988,6 +989,7 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
         };
     } else {
         cached = new CacheType(blocks, {
+            id: blockId,
             opcode: blocks.getOpcode(block),
             fields: blocks.getFields(block),
             inputs: blocks.getInputs(block),

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -34,6 +34,7 @@ class Blocks {
          * @type {{inputs: {}, procedureParamNames: {}, procedureDefinitions: {}}}
          * @private
          */
+        Object.defineProperty(this, '_cache', {writable: true, enumerable: false});
         this._cache = {
             /**
              * Cache block inputs by block id

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -194,7 +194,7 @@ class Sequencer {
                 //
                 // this.runtime.profiler.start(executeProfilerId, null);
                 this.runtime.profiler.records.push(
-                    this.runtime.profiler.START, executeProfilerId, null, performance.now());
+                    this.runtime.profiler.START, executeProfilerId, null, 0);
             }
             if (thread.target === null) {
                 this.retireThread(thread);
@@ -203,7 +203,7 @@ class Sequencer {
             }
             if (this.runtime.profiler !== null) {
                 // this.runtime.profiler.stop();
-                this.runtime.profiler.records.push(this.runtime.profiler.STOP, performance.now());
+                this.runtime.profiler.records.push(this.runtime.profiler.STOP, 0);
             }
             thread.blockGlowInFrame = currentBlockId;
             // If the thread has yielded or is waiting, yield to other threads.

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -179,6 +179,8 @@ class Thread {
          * @type {?Timer}
          */
         this.warpTimer = null;
+
+        this.justReported = null;
     }
 
     /**
@@ -310,10 +312,7 @@ class Thread {
      * @param {*} value Reported value to push.
      */
     pushReportedValue (value) {
-        const parentStackFrame = this.peekParentStackFrame();
-        if (parentStackFrame !== null) {
-            parentStackFrame.justReported = typeof value === 'undefined' ? null : value;
-        }
+        this.justReported = typeof value === 'undefined' ? null : value;
     }
 
     /**

--- a/test/unit/engine_thread.js
+++ b/test/unit/engine_thread.js
@@ -89,7 +89,7 @@ test('pushReportedValue', t => {
     th.pushStack('arbitraryString');
     th.pushStack('secondString');
     th.pushReportedValue('value');
-    t.strictEquals(th.peekParentStackFrame().justReported, 'value');
+    t.strictEquals(th.justReported, 'value');
 
     t.end();
 });


### PR DESCRIPTION
### Proposed Changes

Invert the reporter block tree walking into a linear sequence that report directly into argument objects for future blocks in the sequence.

### Reason for Changes

`execute` is still expensive in relation to the block functions it executes. We can significantly improve performance (especially in Firefox it seems) by capturing the sequence block functions are executed during the reporter tree walk into a single array of operations. This maintains the order blocks are executed while letting us unwrap the recursive calls into a loop.

We maintain backwards compatibility to scratch features like running groups of reporter blocks in the editor and seeing their result as the operations are recorded for all blocks not just command blocks.

We can make an optimization on shadow blocks, considering that they perform no calculation. Their values can be directly inserted in any order into the future argument objects.

#### Benchmark Metrics

Recorded with a minor change disabling time recording for execute calls and block functions. Performance is fast enough that recording the time applies a heavy bias to the reported metrics and the benefit of the time recordings to find expensive blocks is not needed here as this PR is about execute itself.

| Project ID | Test Device / Browser     | Cache | Before  | After   | Change
| ---------- | ------------------------- | :---: | ------: | ------: | -----:
| 130041250  | MBP 15" 2017 Chrome       | Cold  | 421669  | 452092  | 7.2%
|            |                           | Hot   | 503463  | 530584  | 5.3%
|            | MBP 15" 2017 Safari       | Cold  | 529111  | 588013  | 11.1%
|            |                           | Hot   | 497902  | 592191  | 18.9%
|            | MBP 15" 2017 Firefox      | Cold  | 201919  | 229534  | 13.6%
|            |                           | Hot   | 242280  | 282991  | 16.8%
|            | SMS Chromebook Plus 2017  | Cold  | 51839   | 54581   | 5.2%
|            |                           | Hot   | 96005   | 97506   | 1.5%
|            | iPad Mini 2015            | Cold  | 35059   | 38603   | 10.1%
|            |                           | Hot   | 102847  | 117457  | 14.2%
| 173918262  | MBP 15" 2017 Chrome       | Cold  | 274311  | 340774  | 24.2%
|            |                           | Hot   | 337905  | 336952  | -0.2%
|            | MBP 15" 2017 Safari       | Cold  | 257685  | 328711  | 27.5%
|            |                           | Hot   | 298729  | 352239  | 17.9%
|            | MBP 15" 2017 Firefox      | Cold  | 186486  | 346247  | 85%
|            |                           | Hot   | 252384  | 362890  | 43.7%
|            | SMS Chromebook Plus 2017  | Cold  | 54834   | 57003   | 3.9%
|            |                           | Hot   | 60376   | 59133   | -2.0%
|            | iPad Mini 2015            | Cold  | 64458   | 61419   | -4.7%
|            |                           | Hot   | 75440   | 73233   | -2.9%
| 155128646  | MBP 15" 2017 Chrome       | Cold  | 769361  | 893301  | 16.1%
|            |                           | Hot   | 875781  | 878367  | 0.2%
|            | MBP 15" 2017 Safari       | Cold  | 668009  | 1078725 | 61.4%
|            |                           | Hot   | 650539  | 648040  | -0.3%
|            | MBP 15" 2017 Firefox      | Cold  | 283924  | 553815  | 95.0%
|            |                           | Hot   | 380046  | 503378  | 32.4%
|            | SMS Chromebook Plus 2017  | Cold  | 153189  | 164043  | 7.0%
|            |                           | Hot   | 225643  | 222350  | -1.4%
|            | iPad Mini 2015            | Cold  | 57938   | 86888   | 49.9%
|            |                           | Hot   | 128046  | 128035  | ~0%
| 87811578   | MBP 15" 2017 Chrome       | Cold  | 1219872 | 1443543 | 18.3%
|            |                           | Hot   | 1333216 | 1702649 | 27.7%
|            | MBP 15" 2017 Safari       | Cold  | 1335621 | 1658734 | 24.1%
|            |                           | Hot   | 1362491 | 1691327 | 24.1%
|            | MBP 15" 2017 Firefox      | Cold  | 534195  | 1031106 | 93.0%
|            |                           | Hot   | 511379  | 1121198 | 119.2%
|            | SMS Chromebook Plus 2017  | Cold  | 231268  | 331708  | 43.4%
|            |                           | Hot   | 268751  | 376954  | 40.2%
|            | iPad Mini 2015            | Cold  | 299316  | 414653  | 38.5%
|            |                           | Hot   | 340421  | 477957  | 40.4%
