### PR TITLE
Add when touching hat

### DIFF
--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -63,15 +63,7 @@ class Scratch3EventBlocks {
     }
 
     touchingObject (args, util) {
-        const requestedObject = args.TOUCHINGOBJECTMENU;
-        if (requestedObject === '_mouse_') {
-            const mouseX = util.ioQuery('mouse', 'getClientX');
-            const mouseY = util.ioQuery('mouse', 'getClientY');
-            return util.target.isTouchingPoint(mouseX, mouseY);
-        } else if (requestedObject === '_edge_') {
-            return util.target.isTouchingEdge();
-        }
-        return util.target.isTouchingSprite(requestedObject);
+        return util.target.touchingObject(args.TOUCHINGOBJECTMENU);
     }
 
     hatGreaterThanPredicate (args, util) {

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -63,7 +63,7 @@ class Scratch3EventBlocks {
     }
 
     touchingObject (args, util) {
-        return util.target.touchingObject(args.TOUCHINGOBJECTMENU);
+        return util.target.isTouchingObject(args.TOUCHINGOBJECTMENU);
     }
 
     hatGreaterThanPredicate (args, util) {

--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -24,6 +24,7 @@ class Scratch3EventBlocks {
      */
     getPrimitives () {
         return {
+            event_whentouchingobject: this.touchingObject,
             event_broadcast: this.broadcast,
             event_broadcastandwait: this.broadcastAndWait,
             event_whengreaterthan: this.hatGreaterThanPredicate
@@ -41,6 +42,10 @@ class Scratch3EventBlocks {
             event_whenthisspriteclicked: {
                 restartExistingThreads: true
             },
+            event_whentouchingobject: {
+                restartExistingThreads: false,
+                edgeActivated: true
+            },
             event_whenstageclicked: {
                 restartExistingThreads: true
             },
@@ -55,6 +60,18 @@ class Scratch3EventBlocks {
                 restartExistingThreads: true
             }
         };
+    }
+
+    touchingObject (args, util) {
+        const requestedObject = args.TOUCHINGOBJECTMENU;
+        if (requestedObject === '_mouse_') {
+            const mouseX = util.ioQuery('mouse', 'getClientX');
+            const mouseY = util.ioQuery('mouse', 'getClientY');
+            return util.target.isTouchingPoint(mouseX, mouseY);
+        } else if (requestedObject === '_edge_') {
+            return util.target.isTouchingEdge();
+        }
+        return util.target.isTouchingSprite(requestedObject);
     }
 
     hatGreaterThanPredicate (args, util) {

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -150,7 +150,7 @@ class Scratch3SensingBlocks {
     }
 
     touchingObject (args, util) {
-        return util.target.touchingObject(args.TOUCHINGOBJECTMENU);
+        return util.target.isTouchingObject(args.TOUCHINGOBJECTMENU);
     }
 
     touchingColor (args, util) {

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -150,16 +150,7 @@ class Scratch3SensingBlocks {
     }
 
     touchingObject (args, util) {
-        const requestedObject = args.TOUCHINGOBJECTMENU;
-        if (requestedObject === '_mouse_') {
-            const mouseX = util.ioQuery('mouse', 'getClientX');
-            const mouseY = util.ioQuery('mouse', 'getClientY');
-            return util.target.isTouchingPoint(mouseX, mouseY);
-        } else if (requestedObject === '_edge_') {
-            return util.target.isTouchingEdge();
-        }
-        return util.target.isTouchingSprite(requestedObject);
-
+        return util.target.touchingObject(args.TOUCHINGOBJECTMENU);
     }
 
     touchingColor (args, util) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -725,11 +725,11 @@ class RenderedTarget extends Target {
     }
 
     /**
-     * Return whether touching the mouse, an edge, or a sprite.
+     * Return whether this target is touching the mouse, an edge, or a sprite.
      * @param {string} requestedObject an id for mouse or edge, or a sprite name.
      * @return {boolean} True if the sprite is touching the object.
      */
-    touchingObject (requestedObject) {
+    isTouchingObject (requestedObject) {
         if (requestedObject === '_mouse_') {
             if (!this.runtime.ioDevices.mouse) return false;
             const mouseX = this.runtime.ioDevices.mouse.getClientX();

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -725,6 +725,23 @@ class RenderedTarget extends Target {
     }
 
     /**
+     * Return whether touching the mouse, an edge, or a sprite.
+     * @param {string} requestedObject an id for mouse or edge, or a sprite name.
+     * @return {boolean} True if the sprite is touching the object.
+     */
+    touchingObject (requestedObject) {
+        if (requestedObject === '_mouse_') {
+            if (!this.runtime.ioDevices.mouse) return false;
+            const mouseX = this.runtime.ioDevices.mouse.getClientX();
+            const mouseY = this.runtime.ioDevices.mouse.getClientY();
+            return this.isTouchingPoint(mouseX, mouseY);
+        } else if (requestedObject === '_edge_') {
+            return this.isTouchingEdge();
+        }
+        return this.isTouchingSprite(requestedObject);
+    }
+
+    /**
      * Return whether touching a point.
      * @param {number} x X coordinate of test point.
      * @param {number} y Y coordinate of test point.


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-gui/issues/607
Depends on https://github.com/LLK/scratch-blocks/pull/1559

### Proposed Changes

Add a hat block for when a sprite is touching the mouse pointer, edge of the stage, or another sprite.

This includes moving the touchingObject function into renderedTarget, since it is now used by both a sensing block (the boolean reporter) and an event block (the hat).

### Reason for Changes

This is a "low floor" feature, making it easier to make simple projects where you want a sprite to do something when it touches e.g. another sprite. 