### PR TITLE
Add webkitAudioContext if AudioContext does not exist. This might fix…

### DIFF
--- a/src/extensions/scratch3_speech/index.js
+++ b/src/extensions/scratch3_speech/index.js
@@ -546,7 +546,8 @@ class Scratch3SpeechBlocks {
      * @private
      */
     _initializeMicrophone () {
-        this._context = new AudioContext();
+        // Safari still needs a webkit prefix for audio context
+        this._context = new (window.AudioContext || window.webkitAudioContext)();
         this._audioPromise = navigator.mediaDevices.getUserMedia({
             audio: {
                 echoCancellation: true,


### PR DESCRIPTION
… the speech extension in safari, but it is tricky to tell since I am running into problems with permissions and localhost.

### Resolves

Helps with #1202. Might fix it completely.

### Test Coverage

Chrome still works and Safari no longer throws an error about the AudioContext object.  There are still some permissions issues with running on localhost so I can't quite tell if this completely fixes the problem just yet.