### PR TITLE
Comment state fixes

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -295,9 +295,8 @@ class Blocks {
                 oldInput: e.oldInputName,
                 newParent: e.newParentId,
                 newInput: e.newInputName,
-                newCoordinate: e.newCoordinate,
-                oldCoordinate: e.oldCoordinate
-            }, optRuntime);
+                newCoordinate: e.newCoordinate
+            });
             break;
         case 'dragOutside':
             if (optRuntime) {
@@ -550,10 +549,8 @@ class Blocks {
     /**
      * Block management: move blocks from parent to parent
      * @param {!object} e Blockly move event to be processed
-     * @param {?Runtime} optRuntime Optional runtime for updating the position
-     * of a comment on the block that moved.
      */
-    moveBlock (e, optRuntime) {
+    moveBlock (e) {
         if (!this._blocks.hasOwnProperty(e.id)) {
             return;
         }
@@ -562,19 +559,6 @@ class Blocks {
         if (e.newCoordinate) {
             this._blocks[e.id].x = e.newCoordinate.x;
             this._blocks[e.id].y = e.newCoordinate.y;
-
-            // If the moved block has a comment, update the position of the comment.
-            if (typeof this._blocks[e.id].comment === 'string' && optRuntime &&
-                e.oldCoordinate) {
-                const commentId = this._blocks[e.id].comment;
-                const currTarget = optRuntime.getEditingTarget();
-                if (currTarget && currTarget.comments.hasOwnProperty(commentId)) {
-                    const deltaX = e.newCoordinate.x - e.oldCoordinate.x;
-                    const deltaY = e.newCoordinate.y - e.oldCoordinate.y;
-                    currTarget.comments[commentId].x += deltaX;
-                    currTarget.comments[commentId].y += deltaY;
-                }
-            }
         }
 
         // Remove from any old parent.

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -375,18 +375,14 @@ class Blocks {
                 const change = e.newContents_;
                 if (change.hasOwnProperty('minimized')) {
                     comment.minimized = change.minimized;
-                    break;
-                } else if (change.hasOwnProperty('width') && change.hasOwnProperty('height')){
+                }
+                if (change.hasOwnProperty('width') && change.hasOwnProperty('height')){
                     comment.width = change.width;
                     comment.height = change.height;
-                    break;
-                } else if (change.hasOwnProperty('text')) {
-                    comment.text = change.text;
-                    break;
                 }
-                log.warn(`Unrecognized comment change: ${
-                    JSON.stringify(change)} for comment with id: ${e.commentId}.`);
-                return;
+                if (change.hasOwnProperty('text')) {
+                    comment.text = change.text;
+                }
             }
             break;
         case 'comment_move':

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -374,17 +374,15 @@ class Blocks {
                 }
                 const comment = currTarget.comments[e.commentId];
                 const change = e.newContents_;
-                if (typeof change === 'object') {
-                    if (change.hasOwnProperty('minimized')) {
-                        comment.minimized = change.minimized;
-                        break;
-                    } else if (change.hasOwnProperty('width') && change.hasOwnProperty('height')){
-                        comment.width = change.width;
-                        comment.height = change.height;
-                        break;
-                    }
-                } else if (typeof change === 'string') {
-                    comment.text = change;
+                if (change.hasOwnProperty('minimized')) {
+                    comment.minimized = change.minimized;
+                    break;
+                } else if (change.hasOwnProperty('width') && change.hasOwnProperty('height')){
+                    comment.width = change.width;
+                    comment.height = change.height;
+                    break;
+                } else if (change.hasOwnProperty('text')) {
+                    comment.text = change.text;
                     break;
                 }
                 log.warn(`Unrecognized comment change: ${


### PR DESCRIPTION
### Proposed Changes

Changes to comment state-keeping.

The API for the CommentChange event emitted by scratch-blocks has been updated. Now, when a text change is emitted, the text change is represented as an object containing a 'text' property (to match the other kinds of changes a CommentChange event can encompass) instead of just a string. 

This change needs to be accommodated in the VM, addressed by this PR.

Previously, I had added code to update a block comment's position if the block it's attached to was moved. This causes bugs where the comment keeps moving on sprite switch even if the user did not indicate a move. This is because a block move event is emitted every time the workspace containing the block is updated. This PR reverts this change. 

There is now instead, a different bug where moving a block (with a comment attached to it) and switching sprites and back shows the comment in a different position relative to the block. This bug will be fixed with the fix for LLK/scratch-blocks#1566.


### Reason for Changes

See above.

### Test Coverage

Manual testing with scratch-gui.
