### PR TITLE
Fix importing hidden monitors from Scratch 2 projects

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -541,7 +541,7 @@ class Blocks {
                         params: this._getBlockParams(block),
                         // @todo(vm#565) for numerical values with decimals, some countries use comma
                         value: '',
-                        mode: block.opcode === 'data_listcontents' ? 'list' : block.mode
+                        mode: block.opcode === 'data_listcontents' ? 'list' : 'default'
                     }));
                 }
             }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -529,22 +529,21 @@ class Blocks {
             block.targetId = isSpriteSpecific ? optRuntime.getEditingTarget().id : null;
 
             if (wasMonitored && !block.isMonitored) {
-                optRuntime.requestRemoveMonitor(block.id);
+                optRuntime.requestHideMonitor(block.id);
             } else if (!wasMonitored && block.isMonitored) {
-                optRuntime.requestAddMonitor(MonitorRecord({
-                    id: block.id,
-                    targetId: block.targetId,
-                    spriteName: block.targetId ? optRuntime.getTargetById(block.targetId).getName() : null,
-                    opcode: block.opcode,
-                    params: this._getBlockParams(block),
-                    // @todo(vm#565) for numerical values with decimals, some countries use comma
-                    value: '',
-                    x: block.x,
-                    y: block.y,
-                    mode: block.opcode === 'data_listcontents' ? 'list' : block.mode,
-                    sliderMin: block.sliderMin,
-                    sliderMax: block.sliderMax
-                }));
+                // Tries to show the monitor for specified block. If it doesn't exist, add the monitor.
+                if (!optRuntime.requestShowMonitor(block.id)) {
+                    optRuntime.requestAddMonitor(MonitorRecord({
+                        id: block.id,
+                        targetId: block.targetId,
+                        spriteName: block.targetId ? optRuntime.getTargetById(block.targetId).getName() : null,
+                        opcode: block.opcode,
+                        params: this._getBlockParams(block),
+                        // @todo(vm#565) for numerical values with decimals, some countries use comma
+                        value: '',
+                        mode: block.opcode === 'data_listcontents' ? 'list' : block.mode
+                    }));
+                }
             }
             break;
         }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -539,6 +539,8 @@ class Blocks {
                     params: this._getBlockParams(block),
                     // @todo(vm#565) for numerical values with decimals, some countries use comma
                     value: '',
+                    x: block.x,
+                    y: block.y,
                     mode: block.opcode === 'data_listcontents' ? 'list' : block.mode,
                     sliderMin: block.sliderMin,
                     sliderMax: block.sliderMax

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -540,12 +540,8 @@ class Blocks {
                     // @todo(vm#565) for numerical values with decimals, some countries use comma
                     value: '',
                     mode: block.opcode === 'data_listcontents' ? 'list' : block.mode,
-                    x: block.x,
-                    y: block.y,
                     sliderMin: block.sliderMin,
-                    sliderMax: block.sliderMax,
-                    width: block.width,
-                    height: block.height
+                    sliderMax: block.sliderMax
                 }));
             }
             break;

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -539,7 +539,13 @@ class Blocks {
                     params: this._getBlockParams(block),
                     // @todo(vm#565) for numerical values with decimals, some countries use comma
                     value: '',
-                    mode: block.opcode === 'data_listcontents' ? 'list' : 'default'
+                    mode: block.opcode === 'data_listcontents' ? 'list' : block.mode,
+                    x: block.x,
+                    y: block.y,
+                    sliderMin: block.sliderMin,
+                    sliderMax: block.sliderMax,
+                    width: block.width,
+                    height: block.height
                 }));
             }
             break;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1524,8 +1524,9 @@ class Runtime extends EventEmitter {
     requestAddMonitor (monitor) {
         const id = monitor.get('id');
         if (this._monitorState.has(id)) {
+            // Use mergeWith here to prevent undefined values from overwriting existing ones
             this._monitorState = this._monitorState.set(id, this._monitorState.get(id).mergeWith((prev, next) => {
-                if (!next) {
+                if (typeof next === 'undefined' || next === null) {
                     return prev;
                 }
                 return next;
@@ -1546,8 +1547,9 @@ class Runtime extends EventEmitter {
         const id = monitor.get('id');
         if (this._monitorState.has(id)) {
             this._monitorState =
+                // Use mergeWith here to prevent undefined values from overwriting existing ones
                 this._monitorState.set(id, this._monitorState.get(id).mergeWith((prev, next) => {
-                    if (!next) {
+                    if (typeof next === 'undefined' || next === null) {
                         return prev;
                     }
                     return next;
@@ -1561,8 +1563,6 @@ class Runtime extends EventEmitter {
      * @param {!string} monitorId ID of the monitor to remove.
      */
     requestRemoveMonitor (monitorId) {
-        // this._monitorState = this._monitorState.delete(monitorId);
-        // TODO is this performant?
         if (this._monitorState.has(monitorId)) {
             this._monitorState = this._monitorState.set(
                 monitorId, this._monitorState.get(monitorId).merge({visible: false})

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1518,7 +1518,7 @@ class Runtime extends EventEmitter {
 
     /**
      * Add a monitor to the state. If the monitor already exists in the state,
-     * overwrites it.
+     * updates those properties that are defined in the given monitor record.
      * @param {!MonitorRecord} monitor Monitor to add.
      */
     requestAddMonitor (monitor) {
@@ -1530,8 +1530,7 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Update a monitor in the state. Does nothing and returns false if the monitor does not already
-     * exist in the state.
+     * Update a monitor in the state and report success/failure of update.
      * @param {!Map} monitor Monitor values to update. Values on the monitor with overwrite
      *     values on the old monitor with the same ID. If a value isn't defined on the new monitor,
      *     the old monitor will keep its old value.
@@ -1552,7 +1551,7 @@ class Runtime extends EventEmitter {
         }
         return false;
     }
-    
+
     /**
      * Removes a monitor from the state. Does nothing if the monitor already does
      * not exist in the state.
@@ -1563,9 +1562,8 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Hides a monitor. Does nothing if the monitor already does
-     * not exist in the state.
-     * @param {!string} monitorId ID of the monitor to remove.
+     * Hides a monitor and returns success/failure of action.
+     * @param {!string} monitorId ID of the monitor to hide.
      * @return {boolean} true if monitor exists and was updated, false otherwise
      */
     requestHideMonitor (monitorId) {
@@ -1576,9 +1574,9 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Shows a monitor. Does nothing if the monitor already does
+     * Shows a monitor and returns success/failure of action.
      * not exist in the state.
-     * @param {!string} monitorId ID of the monitor to remove.
+     * @param {!string} monitorId ID of the monitor to show.
      * @return {boolean} true if monitor exists and was updated, false otherwise
      */
     requestShowMonitor (monitorId) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1561,7 +1561,13 @@ class Runtime extends EventEmitter {
      * @param {!string} monitorId ID of the monitor to remove.
      */
     requestRemoveMonitor (monitorId) {
-        this._monitorState = this._monitorState.delete(monitorId);
+        // this._monitorState = this._monitorState.delete(monitorId);
+        // TODO is this performant?
+        if (this._monitorState.has(monitorId)) {
+            this._monitorState = this._monitorState.set(
+                monitorId, this._monitorState.get(monitorId).merge({visible: false})
+            );
+        }
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1522,7 +1522,17 @@ class Runtime extends EventEmitter {
      * @param {!MonitorRecord} monitor Monitor to add.
      */
     requestAddMonitor (monitor) {
-        this._monitorState = this._monitorState.set(monitor.get('id'), monitor);
+        const id = monitor.get('id');
+        if (this._monitorState.has(id)) {
+            this._monitorState = this._monitorState.set(id, this._monitorState.get(id).mergeWith((prev, next) => {
+                if (!next) {
+                    return prev;
+                }
+                return next;
+            }, monitor));
+        } else {
+            this._monitorState = this._monitorState.set(id, monitor);
+        }
     }
 
     /**
@@ -1536,7 +1546,12 @@ class Runtime extends EventEmitter {
         const id = monitor.get('id');
         if (this._monitorState.has(id)) {
             this._monitorState =
-                this._monitorState.set(id, this._monitorState.get(id).merge(monitor));
+                this._monitorState.set(id, this._monitorState.get(id).mergeWith((prev, next) => {
+                    if (!next) {
+                        return prev;
+                    }
+                    return next;
+                }, monitor));
         }
     }
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1535,7 +1535,7 @@ class Runtime extends EventEmitter {
      * @param {!Map} monitor Monitor values to update. Values on the monitor with overwrite
      *     values on the old monitor with the same ID. If a value isn't defined on the new monitor,
      *     the old monitor will keep its old value.
-     * @returns {boolean} true if monitor exists in the state and was updated, false if it did not exist.
+     * @return {boolean} true if monitor exists in the state and was updated, false if it did not exist.
      */
     requestUpdateMonitor (monitor) {
         const id = monitor.get('id');
@@ -1552,18 +1552,40 @@ class Runtime extends EventEmitter {
         }
         return false;
     }
-
+    
     /**
      * Removes a monitor from the state. Does nothing if the monitor already does
      * not exist in the state.
      * @param {!string} monitorId ID of the monitor to remove.
      */
     requestRemoveMonitor (monitorId) {
-        if (this._monitorState.has(monitorId)) {
-            this._monitorState = this._monitorState.set(
-                monitorId, this._monitorState.get(monitorId).merge({visible: false})
-            );
-        }
+        this._monitorState = this._monitorState.delete(monitorId);
+    }
+
+    /**
+     * Hides a monitor. Does nothing if the monitor already does
+     * not exist in the state.
+     * @param {!string} monitorId ID of the monitor to remove.
+     * @return {boolean} true if monitor exists and was updated, false otherwise
+     */
+    requestHideMonitor (monitorId) {
+        return this.requestUpdateMonitor(new Map([
+            ['id', monitorId],
+            ['visible', false]
+        ]));
+    }
+
+    /**
+     * Shows a monitor. Does nothing if the monitor already does
+     * not exist in the state.
+     * @param {!string} monitorId ID of the monitor to remove.
+     * @return {boolean} true if monitor exists and was updated, false otherwise
+     */
+    requestShowMonitor (monitorId) {
+        return this.requestUpdateMonitor(new Map([
+            ['id', monitorId],
+            ['visible', true]
+        ]));
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1523,25 +1523,19 @@ class Runtime extends EventEmitter {
      */
     requestAddMonitor (monitor) {
         const id = monitor.get('id');
-        if (this._monitorState.has(id)) {
-            // Use mergeWith here to prevent undefined values from overwriting existing ones
-            this._monitorState = this._monitorState.set(id, this._monitorState.get(id).mergeWith((prev, next) => {
-                if (typeof next === 'undefined' || next === null) {
-                    return prev;
-                }
-                return next;
-            }, monitor));
-        } else {
+        if (!this.requestUpdateMonitor(monitor)) { // update monitor if it exists in the state
+            // if the monitor did not exist in the state, add it
             this._monitorState = this._monitorState.set(id, monitor);
         }
     }
 
     /**
-     * Update a monitor in the state. Does nothing if the monitor does not already
+     * Update a monitor in the state. Does nothing and returns false if the monitor does not already
      * exist in the state.
      * @param {!Map} monitor Monitor values to update. Values on the monitor with overwrite
      *     values on the old monitor with the same ID. If a value isn't defined on the new monitor,
      *     the old monitor will keep its old value.
+     * @returns {boolean} true if monitor exists in the state and was updated, false if it did not exist.
      */
     requestUpdateMonitor (monitor) {
         const id = monitor.get('id');
@@ -1554,7 +1548,9 @@ class Runtime extends EventEmitter {
                     }
                     return next;
                 }, monitor));
+            return true;
         }
+        return false;
     }
 
     /**


### PR DESCRIPTION
### Resolves
This PR fixes #1165, and addresses some of llk/scratch-gui#2033.

### Proposed Changes
* Changes to the `changeBlock` function in blocks.js to add monitors with additional relevant parameters (x, y, mode, sliderMin, sliderMax) so shown monitors are created with those parameters
* Changes to the behavior of `requestRemoveMonitor` so it sets the `visible` parameter to false instead of deleting monitor state on remove
* Changes to how `requestAddMonitor` and `requestChangeMonitor` merge in a passes object
   * The `merge` function allows undefined objects to overwrite keys that already have a defined value, so I changed it to `mergeWith` and some extra logic to handle undefined or null values.

### Potential Gotchas
Monitor position is handled in scratch-gui, so there might be some weird interactions with the logic added here in edge cases. I wasn't able to find any examples of this, though.