### PR TITLE
Implement "costume name" block

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -252,7 +252,6 @@ class Scratch3LooksBlocks {
             looks_goforwardbackwardlayers: this.goForwardBackwardLayers,
             looks_size: this.getSize,
             looks_costumenumbername: this.getCostumeNumberName,
-            looks_costumename: this.getCostumeName,
             looks_backdropnumbername: this.getBackdropNumberName
         };
     }
@@ -487,11 +486,6 @@ class Scratch3LooksBlocks {
             return util.target.currentCostume + 1;
         }
         // Else return name
-        return util.target.getCostumes()[util.target.currentCostume].name;
-    }
-
-    getCostumeName (args, util) {
-        // Obsolete block from earlier Scratch versions.
         return util.target.getCostumes()[util.target.currentCostume].name;
     }
 }

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -252,6 +252,7 @@ class Scratch3LooksBlocks {
             looks_goforwardbackwardlayers: this.goForwardBackwardLayers,
             looks_size: this.getSize,
             looks_costumenumbername: this.getCostumeNumberName,
+            looks_costumename: this.getCostumeName,
             looks_backdropnumbername: this.getBackdropNumberName
         };
     }
@@ -486,6 +487,11 @@ class Scratch3LooksBlocks {
             return util.target.currentCostume + 1;
         }
         // Else return name
+        return util.target.getCostumes()[util.target.currentCostume].name;
+    }
+
+    getCostumeName (args, util) {
+        // Obsolete block from earlier Scratch versions.
         return util.target.getCostumes()[util.target.currentCostume].name;
     }
 }

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -954,6 +954,12 @@ const parseBlock = function (sb2block, addBroadcastMsg, getVariableId, extension
             value: 'number'
         };
         break;
+    case 'costumeName':
+        activeBlock.fields.NUMBER_NAME = {
+            name: 'NUMBER_NAME',
+            value: 'name'
+        };
+        break;
     }
 
     // Special cases to generate mutations.

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -429,7 +429,7 @@ const specMap = {
         ]
     },
     'costumeName': {
-        opcode: 'looks_costumename',
+        opcode: 'looks_costumenumbername',
         argMap: [
         ]
     },

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -428,6 +428,11 @@ const specMap = {
         argMap: [
         ]
     },
+    'costumeName': {
+        opcode: 'looks_costumename',
+        argMap: [
+        ]
+    },
     'sceneName': {
         opcode: 'looks_backdropnumbername',
         argMap: [

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -34,8 +34,15 @@ test('getCostumeNumberName returns 1-indexed costume number', t => {
 test('getCostumeNumberName can return costume name', t => {
     util.target.currentCostume = 0; // This is 0-indexed.
     const args = {NUMBER_NAME: 'name'};
-    const number = blocks.getCostumeNumberName(args, util);
-    t.strictEqual(number, 'first name');
+    const name = blocks.getCostumeNumberName(args, util);
+    t.strictEqual(name, 'first name');
+    t.end();
+});
+
+test('getCostumeName returns costume name', t => {
+    util.target.currentCostume = 0; // This is 0-indexed.
+    const name = blocks.getCostumeNumberName({}, util);
+    t.strictEqual(name, 'first name');
     t.end();
 });
 

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -39,13 +39,6 @@ test('getCostumeNumberName can return costume name', t => {
     t.end();
 });
 
-test('getCostumeName returns costume name', t => {
-    util.target.currentCostume = 0; // This is 0-indexed.
-    const name = blocks.getCostumeNumberName({}, util);
-    t.strictEqual(name, 'first name');
-    t.end();
-});
-
 test('getBackdropNumberName returns 1-indexed costume number', t => {
     util.target.currentCostume = 2; // This is 0-indexed.
     const args = {NUMBER_NAME: 'number'};


### PR DESCRIPTION
### Resolves

Resolves #355, since this is the last obsolete block I've spotted. That issue can be reopened if any more are found, though.

Should be merged alongside (incoming blocks PR).

### Proposed Changes

Implements the "costume name" block, which reports the name of the current costume. 

### Reason for Changes

Compatibility with projects that use the block.

### Test Coverage

Added a test for the block, and manually tested with [this project](https://scratch.mit.edu/projects/228377453/). I also changed a variable named "number" to "name" in a related test, since that seems.. more right?