### PR TITLE
Update position for comments imported from 2.0 projects after auto-positioning.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -362,6 +362,18 @@ class Blocks {
                 const currTarget = optRuntime.getEditingTarget();
                 currTarget.createComment(e.commentId, e.blockId, e.text,
                     e.xy.x, e.xy.y, e.width, e.height, e.minimized);
+
+                if (currTarget.comments[e.commentId].x === null &&
+                    currTarget.comments[e.commentId].y === null) {
+                    // Block comments imported from 2.0 projects are imported with their
+                    // x and y coordinates set to null so that scratch-blocks can
+                    // auto-position them. If we are receiving a create event for these
+                    // comments, then the auto positioning should have taken place.
+                    // Update the x and y position of these comments to match the
+                    // one from the event.
+                    currTarget.comments[e.commentId].x = e.xy.x;
+                    currTarget.comments[e.commentId].y = e.xy.y;
+                }
             }
             break;
         case 'comment_change':

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -71,5 +71,11 @@
         "xml": {
             "outerHTML": "<block type='operator_add' id='D;MqidqmaN}Dft)y#Bf`' x='80' y='98'><value name='NUM1'><shadow type='math_number' id='F[IFAdLbq8!q25+Nio@i'><field name='NUM'></field></shadow><block type='sensing_answer' id='D~ZQ|BYb1)xw4)8ziI%.'></block</value><value name='NUM2'><shadow type='math_number' id='|Sjv4!*X6;wj?QaCE{-9'><field name='NUM'></field></shadow></value></block>"
         }
+    },
+    "createcommentUpdatePosition": {
+        "name": "comment",
+        "type": "comment_create",
+        "commentId": "a comment",
+        "xy": {"x": 10, "y": 20}
     }
 }

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -189,3 +189,77 @@ test('lookupBroadcastMsg returns the var with given id if exists', t => {
 
     t.end();
 });
+
+test('createComment adds a comment to the target', t => {
+    const target = new Target();
+    const comments = target.comments;
+
+    t.equal(Object.keys(comments).length, 0);
+    target.createComment('a comment', null, 'some comment text',
+        10, 20, 200, 300, true);
+    t.equal(Object.keys(comments).length, 1);
+
+    const comment = comments['a comment'];
+    t.notEqual(comment, null);
+    t.equal(comment.blockId, null);
+    t.equal(comment.text, 'some comment text');
+    t.equal(comment.x, 10);
+    t.equal(comment.y, 20);
+    t.equal(comment.width, 200);
+    t.equal(comment.height, 300);
+    t.equal(comment.minimized, true);
+
+    t.end();
+});
+
+test('creating comment with id that already exists does not change existing comment', t => {
+    const target = new Target();
+    const comments = target.comments;
+
+    t.equal(Object.keys(comments).length, 0);
+    target.createComment('a comment', null, 'some comment text',
+        10, 20, 200, 300, true);
+    t.equal(Object.keys(comments).length, 1);
+
+    target.createComment('a comment', null,
+        'some new comment text', 40, 50, 300, 400, false);
+
+    const comment = comments['a comment'];
+    t.notEqual(comment, null);
+    // All of the comment properties should remain unchanged from the first
+    // time createComment was called
+    t.equal(comment.blockId, null);
+    t.equal(comment.text, 'some comment text');
+    t.equal(comment.x, 10);
+    t.equal(comment.y, 20);
+    t.equal(comment.width, 200);
+    t.equal(comment.height, 300);
+    t.equal(comment.minimized, true);
+
+    t.end();
+});
+
+test('creating a comment with a blockId also updates the comment property on the block', t => {
+    const target = new Target();
+    const comments = target.comments;
+    // Create a mock block on the target
+    target.blocks = {
+        'a mock block': {
+            id: 'a mock block'
+        }
+    };
+
+    // Mock the getBlock function that's used in commentCreate
+    target.blocks.getBlock = id => target.blocks[id];
+
+    t.equal(Object.keys(comments).length, 0);
+    target.createComment('a comment', 'a mock block', 'some comment text',
+        10, 20, 200, 300, true);
+    t.equal(Object.keys(comments).length, 1);
+
+    const comment = comments['a comment'];
+    t.equal(comment.blockId, 'a mock block');
+    t.equal(target.blocks.getBlock('a mock block').comment, 'a comment');
+
+    t.end();
+});

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -2,6 +2,7 @@ const test = require('tap').test;
 const VirtualMachine = require('../../src/virtual-machine.js');
 const Sprite = require('../../src/sprites/sprite.js');
 const Variable = require('../../src/engine/variable.js');
+const events = require('../fixtures/events.json');
 
 test('addSprite throws on invalid string', t => {
     const vm = new VirtualMachine();
@@ -555,6 +556,30 @@ test('getVariableValue', t => {
     t.equal(vm.getVariableValue(target.id, 'a-variable'), 0);
     vm.setVariableValue(target.id, 'a-variable', 'string');
     t.equal(vm.getVariableValue(target.id, 'a-variable'), 'string');
+
+    t.end();
+});
+
+// Block Listener tests for comment
+test('comment_create event updates comment with null position', t => {
+    const vm = new VirtualMachine();
+    const spr = new Sprite(null, vm.runtime);
+    const target = spr.createClone();
+
+    target.createComment('a comment', null, 'some text',
+        null, null, 200, 300, false);
+    vm.runtime.targets = [target];
+    vm.editingTarget = target;
+    vm.runtime.setEditingTarget(target);
+
+    const comment = target.comments['a comment'];
+    t.equal(comment.x, null);
+    t.equal(comment.y, null);
+
+    vm.blockListener(events.createcommentUpdatePosition);
+
+    t.equal(comment.x, 10);
+    t.equal(comment.y, 20);
 
     t.end();
 });


### PR DESCRIPTION
### Proposed Changes

Update the position of block comments imported from 2.0 when scratch-blocks emits a comment_create event.

### Reason for Changes

Block comments imported from 2.0 projects have their position coordinates initially set to `null` so that they can be auto positioned by scratch-blocks. However, because of this, the position does not get updated on the block when scratch-blocks emits a create events. Thus, every time the workspace is reloaded, the comments are auto-positioned again. This looks fine for the most part, except for when changing the minimized state of a block comment before moving it. See GIFs below for before and after.

Before:

![block_comment_positioning_before](https://user-images.githubusercontent.com/1786240/41318262-b0e8422a-6e65-11e8-9060-a36f51dd78b5.gif)

After: 

![block_comment_positioning_after](https://user-images.githubusercontent.com/1786240/41318268-b6f53740-6e65-11e8-8151-99b2a3ff771b.gif)

### Test Coverage

Added unit tests for commentCreate function and added a unit test for testing this particular change.
This latter test was added to test/unit/virtual-machine, which might be a weird place for it because it's not necessarily testing functionality for that specific file/module. The reason I put it there was because other tests in virtual machine already have some of the boiler plate needed for this test as well (e.g access to the runtime and the target).