### PR TITLE
Add top-level `reorderTarget` API to VM

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -6,6 +6,7 @@ const Buffer = require('buffer').Buffer;
 const centralDispatch = require('./dispatch/central-dispatch');
 const ExtensionManager = require('./extension-support/extension-manager');
 const log = require('./util/log');
+const MathUtil = require('./util/math-util');
 const Runtime = require('./engine/runtime');
 const sb2 = require('./serialization/sb2');
 const sb3 = require('./serialization/sb3');
@@ -1031,6 +1032,25 @@ class VirtualMachine extends EventEmitter {
             return target.id;
         }
         return null;
+    }
+
+    /**
+     * Reorder target by index. Return whether a change was made.
+     * @param {!string} targetIndex Index of the target.
+     * @param {!number} newIndex index that the target should be moved to.
+     * @returns {boolean} Whether a target was reordered.
+     */
+    reorderTarget (targetIndex, newIndex) {
+        targetIndex = MathUtil.clamp(targetIndex, 0, this.runtime.targets.length - 1);
+        newIndex = MathUtil.clamp(newIndex, 0, this.runtime.targets.length - 1);
+        if (targetIndex === newIndex) return false;
+        const target = this.runtime.targets[targetIndex];
+        let targets = this.runtime.targets;
+        targets = targets.slice(0, targetIndex).concat(targets.slice(targetIndex + 1));
+        targets.splice(newIndex, 0, target);
+        this.runtime.targets = targets;
+        this.emitTargetsUpdate();
+        return true;
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1041,11 +1041,11 @@ class VirtualMachine extends EventEmitter {
      * @returns {boolean} Whether a target was reordered.
      */
     reorderTarget (targetIndex, newIndex) {
-        targetIndex = MathUtil.clamp(targetIndex, 0, this.runtime.targets.length - 1);
-        newIndex = MathUtil.clamp(newIndex, 0, this.runtime.targets.length - 1);
-        if (targetIndex === newIndex) return false;
-        const target = this.runtime.targets[targetIndex];
         let targets = this.runtime.targets;
+        targetIndex = MathUtil.clamp(targetIndex, 0, targets.length - 1);
+        newIndex = MathUtil.clamp(newIndex, 0, targets.length - 1);
+        if (targetIndex === newIndex) return false;
+        const target = targets[targetIndex];
         targets = targets.slice(0, targetIndex).concat(targets.slice(targetIndex + 1));
         targets.splice(newIndex, 0, target);
         this.runtime.targets = targets;

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -368,6 +368,30 @@ test('reorderSound', t => {
     t.end();
 });
 
+test('reorderTarget', t => {
+    const vm = new VirtualMachine();
+    vm.emitTargetsUpdate = () => {};
+
+    vm.runtime.targets = ['a', 'b', 'c', 'd'];
+
+    t.equal(vm.reorderTarget(2, 2), false);
+    t.deepEqual(vm.runtime.targets, ['a', 'b', 'c', 'd']);
+
+    // Make sure clamping works
+    t.equal(vm.reorderTarget(-100, -5), false);
+    t.deepEqual(vm.runtime.targets, ['a', 'b', 'c', 'd']);
+
+    // Reorder upwards
+    t.equal(vm.reorderTarget(0, 2), true);
+    t.deepEqual(vm.runtime.targets, ['b', 'c', 'a', 'd']);
+
+    // Reorder downwards
+    t.equal(vm.reorderTarget(3, 1), true);
+    t.deepEqual(vm.runtime.targets, ['b', 'd', 'c', 'a']);
+
+    t.end();
+});
+
 test('emitWorkspaceUpdate', t => {
     const vm = new VirtualMachine();
     const blocksToXML = comments => {


### PR DESCRIPTION
Allows reordering of the targets themselves. 

Add a unit test for this reordering, make it match the way the costume/sounds APIs work (i.e. consume an index to move and a new index, clamp the indices and return true/false based on whether a reorder occurs).

