### PR TITLE
Add extension status button

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -546,6 +546,16 @@ class Runtime extends EventEmitter {
                 categoryInfo.menus.push(convertedMenu);
             }
         }
+
+        // Add extension status button
+        if (extensionInfo.showStatusButton) {
+            categoryInfo.blocks.push({
+                info: {},
+                json: null,
+                xml: `<button type="status" extensionId="${categoryInfo.id}"></button>`
+            });
+        }
+
         for (const blockInfo of extensionInfo.blocks) {
             if (blockInfo === '---') {
                 categoryInfo.blocks.push(ConvertedSeparator);

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -318,6 +318,7 @@ class Scratch3MicroBitBlocks {
             name: Scratch3MicroBitBlocks.EXTENSION_NAME,
             menuIconURI: menuIconURI,
             blockIconURI: blockIconURI,
+            showStatusButton: true,
             blocks: [
                 {
                     opcode: 'whenButtonPressed',


### PR DESCRIPTION
### Proposed Changes

Add support for extensions to optionally show a status button, to be used by hardware extensions. Also add the relevant flag to the microbit extension for testing.

Depends on https://github.com/LLK/scratch-blocks/pull/1586

### Reason for Changes

Work in progress on supporting hardware extensions, where the user needs to be able to initiate a bluetooth connection workflow.