### PR TITLE
XML escape comment text.

### DIFF
--- a/src/engine/comment.js
+++ b/src/engine/comment.js
@@ -5,6 +5,7 @@
 
 const uid = require('../util/uid');
 const Cast = require('../util/cast');
+const xmlEscape = require('../util/xml-escape');
 
 class Comment {
     /**
@@ -31,7 +32,7 @@ class Comment {
     toXML () {
         return `<comment id="${this.id}" x="${this.x}" y="${
             this.y}" w="${this.width}" h="${this.height}" pinned="${
-            this.blockId !== null}" minimized="${this.minimized}">${this.text}</comment>`;
+            this.blockId !== null}" minimized="${this.minimized}">${xmlEscape(this.text)}</comment>`;
     }
 
     // TODO choose min and defaults for width and height


### PR DESCRIPTION
### Resolves

Resolves #1234 

### Proposed Changes

XML escape comment text.

### Reason for Changes

Blocks break if comment text has xml characters in it like `<`

### Test Coverage

Tested with project 229156463.