### PR TITLE
Add comment id to block when converting from XML to vm representation.

### DIFF
--- a/src/engine/adapter.js
+++ b/src/engine/adapter.js
@@ -86,6 +86,11 @@ const domToBlock = function (blockDOM, blocks, isTopBlock, parent) {
             }
             break;
         }
+        case 'comment':
+        {
+            block.comment = xmlChild.attribs.id;
+            break;
+        }
         case 'value':
         case 'statement':
         {

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -12,6 +12,19 @@
             "!6Ahqg4f}Ljl}X5Hws?Z"
         ]
     },
+    "createComment": {
+        "workspaceId": "7Luws3lyb*Z98~Kk+IG|",
+        "group": ";OswyM#@%`%,xOrhOXC=",
+        "recordUndo": true,
+        "name": "block",
+        "xml": {
+            "outerHTML": "<block type=\"wedo_motorclockwise\" id=\"z!+#Nqr,_(V=xz0y7a@d\"><comment id=\"aCommentId\">Some comment text</comment><value name=\"DURATION\"><shadow type=\"math_number\" id=\"!6Ahqg4f}Ljl}X5Hws?Z\"><field name=\"NUM\">10</field></shadow></value></block>"
+        },
+        "ids": [
+            "z!+#Nqr,_(V=xz0y7a@d",
+            "!6Ahqg4f}Ljl}X5Hws?Z"
+        ]
+    },
     "createbranch": {
         "name": "block",
         "xml": {

--- a/test/unit/engine_adapter.js
+++ b/test/unit/engine_adapter.js
@@ -24,6 +24,7 @@ test('create event', t => {
     // Outer block
     t.type(result[0].id, 'string');
     t.type(result[0].opcode, 'string');
+    t.type(result[0].comment, 'undefined');
     t.type(result[0].fields, 'object');
     t.type(result[0].inputs, 'object');
     t.type(result[0].inputs.DURATION, 'object');
@@ -39,6 +40,20 @@ test('create event', t => {
     t.type(result[1].fields.NUM.value, '10');
     t.type(result[1].topLevel, 'boolean');
     t.equal(result[1].topLevel, false);
+
+    t.end();
+});
+
+test('create with comment', t => {
+    const result = adapter(events.createComment);
+
+    // This test should be the same as above except that it also has a comment.
+
+    t.ok(Array.isArray(result));
+    t.equal(result.length, 2);
+
+    t.type(result[0].comment, 'string');
+    t.equal(result[0].comment, 'aCommentId');
 
     t.end();
 });


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#2366

### Proposed Changes

Add comment id to block when converting block xml (containing a block comment) to VM representation of block.

### Reason for Changes

LLK/scratch-gui#2366

### Test Coverage

Updated tests for block xml adapter.