### PR TITLE
Add shareSound and shareCostume APIs with unit tests to the VM

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -936,6 +936,46 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * Called when costumes are dragged from editing target to another target.
+     * Sets the newly added costume as the current costume.
+     * @param {!number} costumeIndex Index of the costume of the editing target to share.
+     * @param {!string} targetId Id of target to add the costume.
+     * @return {Promise} Promise that resolves when the new costume has been loaded.
+     */
+    shareCostumeToTarget (costumeIndex, targetId) {
+        const originalCostume = this.editingTarget.getCostumes()[costumeIndex];
+        const clone = Object.assign({}, originalCostume);
+        const md5ext = `${clone.assetId}.${clone.dataFormat}`;
+        return loadCostume(md5ext, clone, this.runtime).then(() => {
+            const target = this.runtime.getTargetById(targetId);
+            if (target) {
+                target.addCostume(clone);
+                target.setCostume(
+                    target.getCostumes().length - 1
+                );
+            }
+        });
+    }
+
+    /**
+     * Called when sounds are dragged from editing target to another target.
+     * @param {!number} soundIndex Index of the sound of the editing target to share.
+     * @param {!string} targetId Id of target to add the sound.
+     * @return {Promise} Promise that resolves when the new sound has been loaded.
+     */
+    shareSoundToTarget (soundIndex, targetId) {
+        const originalSound = this.editingTarget.getSounds()[soundIndex];
+        const clone = Object.assign({}, originalSound);
+        return loadSound(clone, this.runtime).then(() => {
+            const target = this.runtime.getTargetById(targetId);
+            if (target) {
+                target.addSound(clone);
+                this.emitTargetsUpdate();
+            }
+        });
+    }
+
+    /**
      * Repopulate the workspace with the blocks of the current editingTarget. This
      * allows us to get around bugs like gui#413.
      */

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -369,6 +369,55 @@ test('reorderSound', t => {
     t.end();
 });
 
+test('shareCostumeToTarget', t => {
+    const vm = new VirtualMachine();
+    const spr1 = new Sprite(null, vm.runtime);
+    spr1.name = 'foo';
+    const target1 = spr1.createClone();
+    const costume1 = {name: 'costume1'};
+    target1.addCostume(costume1);
+
+    const spr2 = new Sprite(null, vm.runtime);
+    spr2.name = 'foo';
+    const target2 = spr2.createClone();
+    const costume2 = {name: 'another costume'};
+    target2.addCostume(costume2);
+
+    vm.runtime.targets = [target1, target2];
+    vm.editingTarget = vm.runtime.targets[0];
+    vm.emitWorkspaceUpdate = () => null;
+
+    vm.shareCostumeToTarget(0, target2.id).then(() => {
+        t.equal(target2.currentCostume, 1);
+        t.equal(target2.getCostumes()[1].name, 'costume1');
+        t.end();
+    });
+});
+
+test('shareSoundToTarget', t => {
+    const vm = new VirtualMachine();
+    const spr1 = new Sprite(null, vm.runtime);
+    spr1.name = 'foo';
+    const target1 = spr1.createClone();
+    const sound1 = {name: 'sound1'};
+    target1.addSound(sound1);
+
+    const spr2 = new Sprite(null, vm.runtime);
+    spr2.name = 'foo';
+    const target2 = spr2.createClone();
+    const sound2 = {name: 'another sound'};
+    target2.addSound(sound2);
+
+    vm.runtime.targets = [target1, target2];
+    vm.editingTarget = vm.runtime.targets[0];
+    vm.emitWorkspaceUpdate = () => null;
+
+    vm.shareSoundToTarget(0, target2.id).then(() => {
+        t.equal(target2.getSounds()[1].name, 'sound1');
+        t.end();
+    });
+});
+
 test('reorderTarget', t => {
     const vm = new VirtualMachine();
     vm.emitTargetsUpdate = () => {};


### PR DESCRIPTION
Another step towards drag and drop sharing of assets between sprites. 

The inner part of the duplication  follows the pattern from the `duplicateSound` and `duplicateCostume` methods. 

It is worth noting that the method for sharing costumes, like duplicating costumes, also enforces the feature where the new costume becomes the active costume. This is true in 2.0 as well, and gives a nice bit of feedback that a transfer has occurred.