### PR TITLE
Localize category labels

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -623,7 +623,11 @@ class Scratch3MusicBlocks {
     getInfo () {
         return {
             id: 'music',
-            name: 'Music',
+            name: formatMessage({
+                id: 'music.categoryName',
+                default: 'Music',
+                description: 'Label for the Music extension category'
+            }),
             menuIconURI: menuIconURI,
             blockIconURI: blockIconURI,
             blocks: [

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -282,7 +282,11 @@ class Scratch3PenBlocks {
     getInfo () {
         return {
             id: 'pen',
-            name: 'Pen',
+            name: formatMessage({
+                id: 'pen.categoryName',
+                default: 'Pen',
+                description: 'Label for the pen extension category'
+            }),
             blockIconURI: blockIconURI,
             blocks: [
                 {

--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -86,7 +86,11 @@ class Scratch3TranslateBlocks {
     getInfo () {
         return {
             id: 'translate',
-            name: 'Translate',
+            name: formatMessage({
+                id: 'translate.categoryName',
+                default: 'Translate',
+                description: 'Label for the translate extension category'
+            }),
             menuIconURI: '', // TODO: Add the final icons.
             blockIconURI: '',
             blocks: [

--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -372,7 +372,11 @@ class Scratch3VideoSensingBlocks {
         // Return extension definition
         return {
             id: 'videoSensing',
-            name: 'Video Motion',
+            name: formatMessage({
+                id: 'videoSensing.categoryName',
+                default: 'Video Motion',
+                description: 'Label for the video motion extension category'
+            }),
             blocks: [
                 {
                     // @todo this hat needs to be set itself to restart existing


### PR DESCRIPTION
Added formatMessage to the name attribute for:
* music
* pen
* translate
* video motion

Skipped speak extension - trademarked name
Skipped extensions that are not yet localized at all.

### Resolves

_What Github issue does this resolve (please include link)?_
Fixes #1245 

### Proposed Changes

_Describe what this Pull Request does_
Adds `formatMessage` calls to the `name` attribute in `getInfo`

### Reason for Changes

_Explain why these changes should be made_

### Testing
[Note: there are issues with extensions related to switching languages after loading an extension]

- [ ] Start with or switch to French, add the 'Pen' Extension - make sure the category label is translated
- [ ] Start or switch into a non-latin language (Japanese, Chinese, Thai), add all extensions
