### PR TITLE
Fix new sprites only showing up in the top-right quadrant

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1004,8 +1004,8 @@ class RenderedTarget extends Target {
             const newTarget = newSprite.createClone();
             // Copy all properties.
             // @todo refactor with clone methods
-            newTarget.x = Math.random() * 400 / 2;
-            newTarget.y = Math.random() * 300 / 2;
+            newTarget.x = (Math.random() - 0.5) * 400 / 2;
+            newTarget.y = (Math.random() - 0.5) * 300 / 2;
             newTarget.direction = this.direction;
             newTarget.draggable = this.draggable;
             newTarget.visible = this.visible;


### PR DESCRIPTION
### Resolves

Fixes LLK/scratch-gui#2340.

### Proposed Changes

Makes sprites show up in all four quadrants of the stage.

### Reason for Changes

It just doesn't make sense for them to only show up in the top-right quadrant!

### Test Coverage

Tested manually.

Here are 25 sprites created **without** this PR:

![25 sprites, totally covering the top-right quadrant](https://user-images.githubusercontent.com/9948030/41560017-37008f38-731c-11e8-9dfd-230dd6614c94.png)

Here are 25 sprites created **with** this PR:

![25 sprites, generally centered around the middle of the stage, showing up in all four quadrants](https://user-images.githubusercontent.com/9948030/41560036-490886fe-731c-11e8-8eec-177a8bedc110.png)

Sprites appear in range (-100, -75) to (100, 75). I think it might be intended that they show up in range (-200, -150) to (200, 150)? If so, a simple fix for that is getting rid of the `/ 2`s at the end of each formula.

(The greatest X-distance from the center is ((1 - 0.5) * 400 / 2) = 0.5 * 200 = 100. The greatest Y-distance from the center is ((1 - 0.5) * 300 / 2) = 0.5 * 150 = 75.)

(/cc @paulkaplan)