### PR TITLE
Serialize extensions used in a project

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -466,11 +466,16 @@ const serializeTarget = function (target, extensions) {
 const serialize = function (runtime) {
     // Fetch targets
     const obj = Object.create(null);
+    // Create extension set to hold extension ids found while serializing targets
+    const extensions = new Set();
     const flattenedOriginalTargets = JSON.parse(JSON.stringify(
         runtime.targets.filter(target => target.isOriginal)));
-    obj.targets = flattenedOriginalTargets.map(t => serializeTarget(t, runtime));
+    obj.targets = flattenedOriginalTargets.map(t => serializeTarget(t, extensions));
 
     // TODO Serialize monitors
+
+    // Assemble extension list
+    obj.extensions = Array.from(extensions);
 
     // Assemble metadata
     const meta = Object.create(null);

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -909,9 +909,6 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     if (object.hasOwnProperty('isStage')) {
         target.isStage = object.isStage;
     }
-    if (object.hasOwnProperty('extensions')) {
-        target.extensions = object.extensions;
-    }
     Promise.all(costumePromises).then(costumes => {
         sprite.costumes = costumes;
     });

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -419,17 +419,19 @@ const serializeComments = function (comments) {
  * Serialize the given target. Only serialize properties that are necessary
  * for saving and loading this target.
  * @param {object} target The target to be serialized.
+ * @param {Set} extensions A set of extensions to add extension IDs to
  * @return {object} A serialized representation of the given target.
  */
-const serializeTarget = function (target) {
+const serializeTarget = function (target, extensions) {
     const obj = Object.create(null);
+    let targetExtensions = [];
     obj.isStage = target.isStage;
     obj.name = obj.isStage ? 'Stage' : target.name;
     const vars = serializeVariables(target.variables);
     obj.variables = vars.variables;
     obj.lists = vars.lists;
     obj.broadcasts = vars.broadcasts;
-    [obj.blocks, obj.extensions] = serializeBlocks(target.blocks);
+    [obj.blocks, targetExtensions] = serializeBlocks(target.blocks);
     obj.comments = serializeComments(target.comments);
     obj.currentCostume = target.currentCostume;
     obj.costumes = target.costumes.map(serializeCostume);
@@ -448,6 +450,11 @@ const serializeTarget = function (target) {
         obj.draggable = target.draggable;
         obj.rotationStyle = target.rotationStyle;
     }
+
+    // Add found extensions to the extensions object
+    targetExtensions.forEach(extensionId => {
+        extensions.add(extensionId);
+    });
     return obj;
 };
 

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -272,12 +272,13 @@ const compressInputTree = function (block, blocks) {
  * Serialize the given blocks object (representing all the blocks for the target
  * currently being serialized.)
  * @param {object} blocks The blocks to be serialized
- * @param {Set} extensionIDs Set of extension ids
- * @return {object} The serialized blocks with compressed inputs and compressed
- * primitives.
+ * @return {Array} An array of the serialized blocks with compressed inputs and
+ * compressed primitives and the list of all extension IDs present
+ * in the serialized blocks.
  */
-const serializeBlocks = function (blocks, extensionIDs) {
+const serializeBlocks = function (blocks) {
     const obj = Object.create(null);
+    const extensionIDs = new Set();
     for (const blockID in blocks) {
         if (!blocks.hasOwnProperty(blockID)) continue;
         obj[blockID] = serializeBlock(blocks[blockID], blocks);
@@ -314,7 +315,7 @@ const serializeBlocks = function (blocks, extensionIDs) {
             delete obj[blockID];
         }
     }
-    return obj;
+    return [obj, Array.from(extensionIDs)];
 };
 
 /**
@@ -422,15 +423,13 @@ const serializeComments = function (comments) {
  */
 const serializeTarget = function (target) {
     const obj = Object.create(null);
-    const extensionIDs = new Set();
     obj.isStage = target.isStage;
     obj.name = obj.isStage ? 'Stage' : target.name;
     const vars = serializeVariables(target.variables);
     obj.variables = vars.variables;
     obj.lists = vars.lists;
     obj.broadcasts = vars.broadcasts;
-    obj.blocks = serializeBlocks(target.blocks, extensionIDs);
-    obj.extensions = Array.from(extensionIDs);
+    [obj.blocks, obj.extensions] = serializeBlocks(target.blocks);
     obj.comments = serializeComments(target.comments);
     obj.currentCostume = target.currentCostume;
     obj.costumes = target.costumes.map(serializeCostume);


### PR DESCRIPTION
### Proposed Changes
This PR adds an additional section to target objects in an sb3 file to hold a list of extension IDs used by blocks in that target. This list of IDs is generated in the `serializeBlocks` function, which has been modified to include an opcode parsing step in the first `for (const blockID in blocks)` loop.

### Reason for Changes
This change is necessary so the project page can easily find the extensions used in a project and display them to a user.