### PR TITLE
Sprite save load

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -348,8 +348,6 @@ class Target extends EventEmitter {
      * variable does exist in the target itself (e.g. it's a local variable in the sprite being uploaded),
      * then the variable is renamed to distinguish itself from the pre-existing variable.
      * All blocks that reference the local variable will be updated to use the new name.
-     // * @param {Target} target The new target being uploaded, with potential variable conflicts
-     // * @param {Runtime} runtime The runtime context with any pre-existing variables
      */
     fixUpVariableReferences () {
         if (!this.runtime) return; // There's no runtime context to conflict with

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -666,7 +666,6 @@ const sb2import = function (json, runtime, optForceSprite, zip) {
         extensionIDs: new Set(),
         extensionURLs: new Map()
     };
-
     return parseScratchObject(json, runtime, extensions, !optForceSprite, zip)
         .then(targets => ({
             targets,

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -668,13 +668,6 @@ const sb2import = function (json, runtime, optForceSprite, zip) {
     };
 
     return parseScratchObject(json, runtime, extensions, !optForceSprite, zip)
-        .then(targets => {
-            if (optForceSprite && targets.length === 1) {
-                const target = targets[0];
-                target.fixUpVariableReferences();
-            }
-            return targets;
-        })
         .then(targets => ({
             targets,
             extensions

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -671,7 +671,7 @@ const sb2import = function (json, runtime, optForceSprite, zip) {
         .then(targets => {
             if (optForceSprite && targets.length === 1) {
                 const target = targets[0];
-                target.blocks.fixUpVariableReferences(target, runtime);
+                target.fixUpVariableReferences();
             }
             return targets;
         })

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -937,13 +937,6 @@ const deserialize = function (json, runtime, zip, isSingleSprite) {
         ((isSingleSprite ? [json] : json.targets) || []).map(target =>
             parseScratchObject(target, runtime, extensions, zip))
     )
-        .then(targets => {
-            if (isSingleSprite && targets.length === 1) {
-                const target = targets[0];
-                target.fixUpVariableReferences();
-            }
-            return targets;
-        })
         .then(targets => ({
             targets,
             extensions

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -446,15 +446,25 @@ const serializeTarget = function (target) {
 
 /**
  * Serializes the specified VM runtime.
- * @param  {!Runtime} runtime VM runtime instance to be serialized.
+ * @param {!Runtime} runtime VM runtime instance to be serialized.
+ * @param {string=} targetId Optional target id if serializing only a single target
  * @return {object} Serialized runtime instance.
  */
-const serialize = function (runtime) {
+const serialize = function (runtime, targetId) {
     // Fetch targets
     const obj = Object.create(null);
-    const flattenedOriginalTargets = JSON.parse(JSON.stringify(
+    const flattenedOriginalTargets = JSON.parse(JSON.stringify(targetId ?
+        [runtime.getTargetById(targetId)] :
         runtime.targets.filter(target => target.isOriginal)));
-    obj.targets = flattenedOriginalTargets.map(t => serializeTarget(t, runtime));
+
+    const serializedTargets = flattenedOriginalTargets.map(t => serializeTarget(t, runtime));
+
+    if (targetId) {
+        return serializedTargets[0];
+    }
+
+    obj.targets = serializedTargets;
+
 
     // TODO Serialize monitors
 

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -940,7 +940,7 @@ const deserialize = function (json, runtime, zip, isSingleSprite) {
         .then(targets => {
             if (isSingleSprite && targets.length === 1) {
                 const target = targets[0];
-                target.blocks.fixUpVariableReferences(target, runtime);
+                target.fixUpVariableReferences();
             }
             return targets;
         })

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -936,10 +936,18 @@ const deserialize = function (json, runtime, zip, isSingleSprite) {
     return Promise.all(
         ((isSingleSprite ? [json] : json.targets) || []).map(target =>
             parseScratchObject(target, runtime, extensions, zip))
-    ).then(targets => ({
-        targets,
-        extensions
-    }));
+    )
+        .then(targets => {
+            if (isSingleSprite && targets.length === 1) {
+                const target = targets[0];
+                target.blocks.fixUpVariableReferences(target, runtime);
+            }
+            return targets;
+        })
+        .then(targets => ({
+            targets,
+            extensions
+        }));
 };
 
 module.exports = {

--- a/src/serialization/serialize-assets.js
+++ b/src/serialization/serialize-assets.js
@@ -5,10 +5,11 @@
  * to be written and the contents of the file, the serialized asset.
  * @param {Runtime} runtime The runtime with the assets to be serialized
  * @param {string} assetType The type of assets to be serialized: 'sounds' | 'costumes'
+ * @param {string=} optTargetId Optional target id to serialize assets for
  * @returns {Array<object>} An array of file descriptors for each asset
  */
-const serializeAssets = function (runtime, assetType) {
-    const targets = runtime.targets;
+const serializeAssets = function (runtime, assetType, optTargetId) {
+    const targets = optTargetId ? [runtime.getTargetById(optTargetId)] : runtime.targets;
     const assetDescs = [];
     for (let i = 0; i < targets.length; i++) {
         const currTarget = targets[i];
@@ -27,14 +28,16 @@ const serializeAssets = function (runtime, assetType) {
 };
 
 /**
- * Serialize all the sounds in the provided runtime into an array of file
- * descriptors. A file descriptor is an object containing the name of the file
+ * Serialize all the sounds in the provided runtime or, if a target id is provided,
+ * in the specified target into an array of file descriptors.
+ * A file descriptor is an object containing the name of the file
  * to be written and the contents of the file, the serialized sound.
  * @param {Runtime} runtime The runtime with the sounds to be serialized
+ * @param {string=} optTargetId Optional targetid for serializing sounds of a single target
  * @returns {Array<object>} An array of file descriptors for each sound
  */
-const serializeSounds = function (runtime) {
-    return serializeAssets(runtime, 'sounds');
+const serializeSounds = function (runtime, optTargetId) {
+    return serializeAssets(runtime, 'sounds', optTargetId);
 };
 
 /**
@@ -42,10 +45,11 @@ const serializeSounds = function (runtime) {
  * descriptors. A file descriptor is an object containing the name of the file
  * to be written and the contents of the file, the serialized costume.
  * @param {Runtime} runtime The runtime with the costumes to be serialized
+ * @param {string} optTargetId Optional targetid for serializing costumes of a single target
  * @returns {Array<object>} An array of file descriptors for each costume
  */
-const serializeCostumes = function (runtime) {
-    return serializeAssets(runtime, 'costumes');
+const serializeCostumes = function (runtime, optTargetId) {
+    return serializeAssets(runtime, 'costumes', optTargetId);
 };
 
 module.exports = {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -263,20 +263,38 @@ class VirtualMachine extends EventEmitter {
 
         // Put everything in a zip file
         zip.file('project.json', projectJson);
-        for (let i = 0; i < soundDescs.length; i++) {
-            const currSound = soundDescs[i];
-            zip.file(currSound.fileName, currSound.fileContent);
-        }
-        for (let i = 0; i < costumeDescs.length; i++) {
-            const currCostume = costumeDescs[i];
-            zip.file(currCostume.fileName, currCostume.fileContent);
-        }
+        this._addFileDescsToZip(soundDescs.concat(costumeDescs), zip);
 
         return zip.generateAsync({
             type: 'blob',
             compression: 'DEFLATE',
             compressionOptions: {
                 level: 6 // Tradeoff between best speed (1) and best compression (9)
+            }
+        });
+    }
+
+    _addFileDescsToZip (fileDescs, zip) {
+        for (let i = 0; i < fileDescs.length; i++) {
+            const currFileDesc = fileDescs[i];
+            zip.file(currFileDesc.fileName, currFileDesc.fileContent);
+        }
+    }
+
+    exportSprite (targetId) {
+        const soundDescs = serializeSounds(this.runtime, targetId);
+        const costumeDescs = serializeCostumes(this.runtime, targetId);
+        const spriteJson = JSON.stringify(sb3.serialize(this.runtime, targetId));
+
+        const zip = new JSZip();
+        zip.file('sprite.json', spriteJson);
+        this._addFileDescsToZip(soundDescs.concat(costumeDescs), zip);
+
+        return zip.generateAsync({
+            type: 'blob',
+            compression: 'DEFLATE',
+            compressionOptions: {
+                level: 6
             }
         });
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -386,6 +386,10 @@ class VirtualMachine extends EventEmitter {
                 this.editingTarget = targets[0];
             }
 
+            if (!wholeProject) {
+                this.editingTarget.fixUpVariableReferences();
+            }
+
             // Update the VM user's knowledge of targets and blocks on the workspace.
             this.emitTargetsUpdate();
             this.emitWorkspaceUpdate();

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -281,7 +281,19 @@ class VirtualMachine extends EventEmitter {
         }
     }
 
-    exportSprite (targetId) {
+    /**
+     * Exports a sprite in the sprite3 format.
+     * @param {string} targetId ID of the target to export
+     * @param {string=} optZipType Optional type that the resulting
+     * zip should be outputted in. Options are: base64, binarystring,
+     * array, uint8array, arraybuffer, blob, or nodebuffer. Defaults to
+     * blob if argument not provided.
+     * See https://stuk.github.io/jszip/documentation/api_jszip/generate_async.html#type-option
+     * for more information about these options.
+     * @return {object} A generated zip of the sprite and its assets in the format
+     * specified by optZipType or blob by default.
+     */
+    exportSprite (targetId, optZipType) {
         const soundDescs = serializeSounds(this.runtime, targetId);
         const costumeDescs = serializeCostumes(this.runtime, targetId);
         const spriteJson = JSON.stringify(sb3.serialize(this.runtime, targetId));
@@ -291,7 +303,7 @@ class VirtualMachine extends EventEmitter {
         this._addFileDescsToZip(soundDescs.concat(costumeDescs), zip);
 
         return zip.generateAsync({
-            type: 'blob',
+            type: typeof optZipType === 'string' ? optZipType : 'blob',
             compression: 'DEFLATE',
             compressionOptions: {
                 level: 6

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -90,5 +90,17 @@
         "type": "comment_create",
         "commentId": "a comment",
         "xy": {"x": 10, "y": 20}
+    },
+    "mockVariableBlock": {
+        "name": "block",
+        "xml": {
+            "outerHTML": "<block type='data_variable' id='a block' x='0' y='0'><field name='VARIABLE' id='mock var id' variabletype=''>a mock variable</field></block>"
+        }
+    },
+    "mockListBlock": {
+        "name": "block",
+        "xml": {
+            "outerHTML": "<block type='data_listcontents' id='another block' x='0' y='0'><field name='LIST' id='mock list id' variabletype=''>a mock list</field></block>"
+        }
     }
 }

--- a/test/unit/engine_blocks.js
+++ b/test/unit/engine_blocks.js
@@ -1,5 +1,8 @@
 const test = require('tap').test;
 const Blocks = require('../../src/engine/blocks');
+const Variable = require('../../src/engine/variable');
+const adapter = require('../../src/engine/adapter');
+const events = require('../fixtures/events.json');
 
 test('spec', t => {
     const b = new Blocks();
@@ -773,6 +776,35 @@ test('updateTargetSpecificBlocks changes sprite clicked hat to stage clicked for
     // originallyStageClicked does update when on a non-stage target
     b.updateTargetSpecificBlocks(false/* isStage */);
     t.equals(b.getBlock('originallyStageClicked').opcode, 'event_whenthisspriteclicked');
+
+    t.end();
+});
+
+test('getAllVariableAndListReferences returns an empty map references when variable blocks do not exist', t => {
+    const b = new Blocks();
+    t.equal(Object.keys(b.getAllVariableAndListReferences()).length, 0);
+    t.end();
+});
+
+test('getAllVariableAndListReferences returns references when variable blocks exist', t => {
+    const b = new Blocks();
+
+    let varListRefs = b.getAllVariableAndListReferences();
+    t.equal(Object.keys(varListRefs).length, 0);
+
+    b.createBlock(adapter(events.mockVariableBlock)[0]);
+    b.createBlock(adapter(events.mockListBlock)[0]);
+
+    varListRefs = b.getAllVariableAndListReferences();
+    t.equal(Object.keys(varListRefs).length, 2);
+    t.equal(Array.isArray(varListRefs['mock var id']), true);
+    t.equal(varListRefs['mock var id'].length, 1);
+    t.equal(varListRefs['mock var id'][0].type, Variable.SCALAR_TYPE);
+    t.equal(varListRefs['mock var id'][0].referencingField.value, 'a mock variable');
+    t.equal(Array.isArray(varListRefs['mock list id']), true);
+    t.equal(varListRefs['mock list id'].length, 1);
+    t.equal(varListRefs['mock list id'][0].type, Variable.LIST_TYPE);
+    t.equal(varListRefs['mock list id'][0].referencingField.value, 'a mock list');
 
     t.end();
 });

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -306,7 +306,7 @@ test('fixUpVariableReferences fixes sprite global var conflicting with project g
     t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
     t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
 
-    target.fixUpVariableReferences(target, runtime);
+    target.fixUpVariableReferences();
 
     t.equal(Object.keys(target.variables).length, 0);
     t.equal(Object.keys(stage.variables).length, 1);
@@ -344,7 +344,7 @@ test('fixUpVariableReferences fixes sprite local var conflicting with project gl
     t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
     t.equal(target.variables['mock var id'].name, 'a mock variable');
 
-    target.fixUpVariableReferences(target, runtime);
+    target.fixUpVariableReferences();
 
     t.equal(Object.keys(target.variables).length, 1);
     t.equal(Object.keys(stage.variables).length, 1);
@@ -378,7 +378,7 @@ test('fixUpVariableReferences fixes conflicting sprite local var without blocks 
     t.equal(Object.keys(stage.variables).length, 1);
     t.equal(target.variables['mock var id'].name, 'a mock variable');
 
-    target.fixUpVariableReferences(target, runtime);
+    target.fixUpVariableReferences();
 
     t.equal(Object.keys(target.variables).length, 1);
     t.equal(Object.keys(stage.variables).length, 1);
@@ -414,7 +414,7 @@ test('fixUpVariableReferences does not change variable name if there is no varia
     t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
     t.equal(target.variables['mock var id'].name, 'a mock variable');
 
-    target.fixUpVariableReferences(target, runtime);
+    target.fixUpVariableReferences();
 
     t.equal(Object.keys(target.variables).length, 1);
     t.equal(Object.keys(stage.variables).length, 2);

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -1,6 +1,9 @@
 const test = require('tap').test;
 const Target = require('../../src/engine/target');
 const Variable = require('../../src/engine/variable');
+const adapter = require('../../src/engine/adapter');
+const Runtime = require('../../src/engine/runtime');
+const events = require('../fixtures/events.json');
 
 test('spec', t => {
     const target = new Target();
@@ -145,7 +148,7 @@ test('deleteVariable2', t => {
     t.end();
 });
 
-test('lookupOrCreateList creates a list if var with given id does not exist', t => {
+test('lookupOrCreateList creates a list if var with given id or var with given name does not exist', t => {
     const target = new Target();
     const variables = target.variables;
 
@@ -167,6 +170,22 @@ test('lookupOrCreateList returns list if one with given id exists', t => {
     t.equal(Object.keys(variables).length, 1);
 
     const listVar = target.lookupOrCreateList('foo', 'bar');
+    t.equal(Object.keys(variables).length, 1);
+    t.equal(listVar.id, 'foo');
+    t.equal(listVar.name, 'bar');
+
+    t.end();
+});
+
+test('lookupOrCreateList succeeds in finding list if id is incorrect but name matches', t => {
+    const target = new Target();
+    const variables = target.variables;
+
+    t.equal(Object.keys(variables).length, 0);
+    target.createVariable('foo', 'bar', Variable.LIST_TYPE);
+    t.equal(Object.keys(variables).length, 1);
+
+    const listVar = target.lookupOrCreateList('not foo', 'bar');
     t.equal(Object.keys(variables).length, 1);
     t.equal(listVar.id, 'foo');
     t.equal(listVar.name, 'bar');
@@ -260,6 +279,150 @@ test('creating a comment with a blockId also updates the comment property on the
     const comment = comments['a comment'];
     t.equal(comment.blockId, 'a mock block');
     t.equal(target.blocks.getBlock('a mock block').comment, 'a comment');
+
+    t.end();
+});
+
+test('fixUpVariableReferences fixes sprite global var conflicting with project global var', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+
+    runtime.targets = [stage, target];
+
+    // Create a global variable
+    stage.createVariable('pre-existing global var id', 'a mock variable', Variable.SCALAR_TYPE);
+
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    t.equal(Object.keys(target.variables).length, 0);
+    t.equal(Object.keys(stage.variables).length, 1);
+    t.type(target.blocks.getBlock('a block'), 'object');
+    t.type(target.blocks.getBlock('a block').fields, 'object');
+    t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+
+    target.fixUpVariableReferences(target, runtime);
+
+    t.equal(Object.keys(target.variables).length, 0);
+    t.equal(Object.keys(stage.variables).length, 1);
+    t.type(target.blocks.getBlock('a block'), 'object');
+    t.type(target.blocks.getBlock('a block').fields, 'object');
+    t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'pre-existing global var id');
+
+    t.end();
+});
+
+test('fixUpVariableReferences fixes sprite local var conflicting with project global var', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    // Create a global variable
+    stage.createVariable('pre-existing global var id', 'a mock variable', Variable.SCALAR_TYPE);
+    target.createVariable('mock var id', 'a mock variable', Variable.SCALAR_TYPE);
+
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    t.equal(Object.keys(target.variables).length, 1);
+    t.equal(Object.keys(stage.variables).length, 1);
+    t.type(target.blocks.getBlock('a block'), 'object');
+    t.type(target.blocks.getBlock('a block').fields, 'object');
+    t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+    t.equal(target.variables['mock var id'].name, 'a mock variable');
+
+    target.fixUpVariableReferences(target, runtime);
+
+    t.equal(Object.keys(target.variables).length, 1);
+    t.equal(Object.keys(stage.variables).length, 1);
+    t.type(target.blocks.getBlock('a block'), 'object');
+    t.type(target.blocks.getBlock('a block').fields, 'object');
+    t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+    t.equal(target.variables['mock var id'].name, 'Target: a mock variable');
+
+    t.end();
+});
+
+test('fixUpVariableReferences fixes conflicting sprite local var without blocks referencing var', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    // Create a global variable
+    stage.createVariable('pre-existing global var id', 'a mock variable', Variable.SCALAR_TYPE);
+    target.createVariable('mock var id', 'a mock variable', Variable.SCALAR_TYPE);
+
+
+    t.equal(Object.keys(target.variables).length, 1);
+    t.equal(Object.keys(stage.variables).length, 1);
+    t.equal(target.variables['mock var id'].name, 'a mock variable');
+
+    target.fixUpVariableReferences(target, runtime);
+
+    t.equal(Object.keys(target.variables).length, 1);
+    t.equal(Object.keys(stage.variables).length, 1);
+    t.equal(target.variables['mock var id'].name, 'Target: a mock variable');
+
+    t.end();
+});
+
+test('fixUpVariableReferences does not change variable name if there is no variable conflict', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    // Create a global variable
+    stage.createVariable('pre-existing global var id', 'a variable', Variable.SCALAR_TYPE);
+    stage.createVariable('pre-existing global list id', 'a mock variable', Variable.LIST_TYPE);
+    target.createVariable('mock var id', 'a mock variable', Variable.SCALAR_TYPE);
+
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    t.equal(Object.keys(target.variables).length, 1);
+    t.equal(Object.keys(stage.variables).length, 2);
+    t.type(target.blocks.getBlock('a block'), 'object');
+    t.type(target.blocks.getBlock('a block').fields, 'object');
+    t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+    t.equal(target.variables['mock var id'].name, 'a mock variable');
+
+    target.fixUpVariableReferences(target, runtime);
+
+    t.equal(Object.keys(target.variables).length, 1);
+    t.equal(Object.keys(stage.variables).length, 2);
+    t.type(target.blocks.getBlock('a block'), 'object');
+    t.type(target.blocks.getBlock('a block').fields, 'object');
+    t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+    t.equal(target.variables['mock var id'].name, 'a mock variable');
 
     t.end();
 });


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#2030

### Proposed Changes

This pull request adds a top level API for exporting a sprite (in the .sprite3 format). This PR also makes provisions for uploading a sprite (.sprite2 or .sprite3) such that any variable conflicts with the existing project are resolved. Without these changes, uploading a .sprite2 (or .sprite3, but those didn't exist before this PR) into an existing project would fail to load the blocks in the sprite with an error in the console in the following scenarios:

#### Scenario 1 - Global Var Reference Conflicting with Project Global Var
- Create a project in Scratch 3 with a global variable named 'foo'
- Create a new project in Scratch 2 with a global variable named 'foo', and a block in a Sprite1's workspace referencing the variable 'foo'.
- Export 'Sprite1' from the Scratch 2 project
- Upload the exported .sprite2 file into the Scratch 3 project created in the first step.
- Observe errors in the console.

#### Scenario 2 - Local Var Reference Conflicting with Project Global Var
- Create a project in Scratch 3 with a global variable named 'foo'
- Create a new project in Scratch 2 with a local variable named 'foo', and [optionally] a block in a Sprite1's workspace referencing the variable 'foo'.
- Export 'Sprite1' from the Scratch 2 project
- Upload the exported .sprite2 file into the Scratch 3 project created in the first step.
- Observe errors in the console.

### Test Coverage

Added unit tests for the variable conflict resolving functionality.