### PR TITLE
stop drum immediately if it is still starting

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -786,7 +786,7 @@ class Scratch3MusicBlocks {
 
         if (typeof player === 'undefined') return;
 
-        if (player.isPlaying) {
+        if (player.isPlaying && !player.isStarting) {
             // Take the internal player state and create a new player with it.
             // `.play` does this internally but then instructs the sound to
             // stop.
@@ -889,7 +889,7 @@ class Scratch3MusicBlocks {
 
         const player = this._instrumentPlayerNoteArrays[inst][note];
 
-        if (player.isPlaying) {
+        if (player.isPlaying && !player.isStarting) {
             // Take the internal player state and create a new player with it.
             // `.play` does this internally but then instructs the sound to
             // stop.


### PR DESCRIPTION
### Resolves

`[forever [playDrumForBeats "Snare Drum" 0]]` makes a loud noise.

### Proposed Changes

Stop a starting drum sound immediately.

I've included the same logic into `playNote` though note's behaviour means this will never be called. I've included the second change to have reading parity with playDrum.

### Reason for Changes

Without stopping immediately, `[forever [playDrumForBeats "Snare Drum" 0]]` makes a bad loud noise. With stopping immediately the drum will play normally.
