### PR TITLE
delete clone should not stop sound

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1044,7 +1044,7 @@ class RenderedTarget extends Target {
     onStopAll () {
         this.clearEffects();
         if (this.sprite.soundBank) {
-            this.sprite.soundBank.stopAllSounds(this);
+            this.sprite.soundBank.stopAllSounds();
         }
     }
 
@@ -1130,9 +1130,6 @@ class RenderedTarget extends Target {
     dispose () {
         this.runtime.changeCloneCounter(-1);
         this.runtime.stopForTarget(this);
-        if (this.sprite.soundBank) {
-            this.sprite.soundBank.stopAllSounds(this);
-        }
         this.sprite.removeClone(this);
         if (this.renderer && this.drawableID !== null) {
             this.renderer.destroyDrawable(this.drawableID, this.isStage ?


### PR DESCRIPTION
### Resolves
Deleting a clone **SHOULD NOT** stop it's sounds from playing

### Proposed Changes

Remove stop sounds hook from `dispose()` method, and update `onStopAll` to stop all sounds on the sprite (so deleted clone sounds still stop)
