### PR TITLE
Fix a few say bubble issues

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -107,6 +107,8 @@ class Scratch3LooksBlocks {
      */
     _onResetBubbles () {
         for (let n = 0; n < this.runtime.targets.length; n++) {
+            const bubbleState = this._getBubbleState(this.runtime.targets[n]);
+            bubbleState.text = '';
             this._onTargetWillExit(this.runtime.targets[n]);
         }
         clearTimeout(this._bubbleTimeout);

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -200,7 +200,13 @@ class Scratch3LooksBlocks {
 
             // TODO is there a way to figure out before rendering whether to default left or right?
             const targetBounds = target.getBounds();
-            const stageBounds = this.runtime.getTargetForStage().getBounds();
+            const stageSize = this.runtime.renderer.getNativeSize();
+            const stageBounds = {
+                left: -stageSize[0] / 2,
+                right: stageSize[0] / 2,
+                top: stageSize[1] / 2,
+                bottom: -stageSize[1] / 2
+            };
             if (targetBounds.right + 170 > stageBounds.right) {
                 bubbleState.onSpriteRight = false;
             }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/1205
Fixes https://github.com/LLK/scratch-vm/issues/1268

### Proposed Changes

_Describe what this Pull Request does_

Two separate fixes, but very nearby. Separated into two separate commits. One makes sure to reset the `text` in bubble state when resetting due to "stop" button, the other commit uses the bounds of the renderer instead of the bounds of the stage target to compare bubble size against.

Run the repros from the linked issues.