### PR TITLE
Remove some audio config safari can't handle.

### DIFF
--- a/src/extensions/scratch3_speech/index.js
+++ b/src/extensions/scratch3_speech/index.js
@@ -550,14 +550,7 @@ class Scratch3SpeechBlocks {
         // Safari still needs a webkit prefix for audio context
         this._context = new (window.AudioContext || window.webkitAudioContext)();
         this._audioPromise = navigator.mediaDevices.getUserMedia({
-            audio: {
-                echoCancellation: true,
-                channelCount: 1,
-                sampleRate: {
-                    ideal: 16000
-                },
-                sampleSize: 16
-            }
+            audio: true
         });
 
         const tempContext = this._context;


### PR DESCRIPTION
Note that this depends on PR https://github.com/LLK/scratch-vm/pull/1272 - I'd love a review on that so I can rebase appropriately once it is in.

### Resolves

Another step toward speech working in Safari. (https://github.com/LLK/scratch-vm/issues/1202) With this change it is now possible to get results back in safari the *first* time you click on a listen and wait block.  This extension still has problems related to bullet number 2 here: https://kaliatech.github.io/web-audio-recording-tests/dist/#/test1

There also seems to be some weirdness with the microphone - it *barely* hears me in safari.  Haven't figured out whether that is unique to my laptop settings or not yet. 

### Proposed Changes

removes some irrelevant config
### Reason for Changes
It makes safari work

