### PR TITLE
Fix tick yielding threads

### DIFF
--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -221,6 +221,9 @@ class Sequencer {
                 // until the promise resolves. Promise resolution should reset
                 // thread.status to Thread.STATUS_RUNNING.
                 return;
+            } else if (thread.status === Thread.STATUS_YIELD_TICK) {
+                // stepThreads will reset the thread to Thread.STATUS_RUNNING
+                return;
             }
             // If no control flow has happened, switch to next block.
             if (thread.peekStack() === currentBlockId) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/2461

### Proposed Changes

_Describe what this Pull Request does_

Make sure to check for `STATUS_YIELD_TICK` in stepThread so that a block that turns its thread to this state does not move on to the next block. This is the cause of https://github.com/LLK/scratch-gui/issues/2461

### Reason for Changes

_Explain why these changes should be made_

This PR https://github.com/LLK/scratch-vm/pull/1211 introduced a way for blocks to induce the `Thread.STATUS_YIELD_TICK` status on their threads, which was not accounted for in the `stepThread` function of the sequencer, resulting in the thread moving on from that block instead of waiting. 

The `stepThreads` (note the "s") function already handles setting a "ranOnce" flag and toggling the running status of these threads, but it wasn't getting a chance to be used because the thread was continuing immediately and being marked as done. So just return when you hit a thread with this status, similar to what happens with promises, and allow the status to be toggled by the machinery one level up in stepThreads.

### Test Coverage

_Please show how you have added tests to cover your changes_

Ran the test example from the linked issue
