### PR TITLE
Change translate extension reporter block text to 'language'

### DIFF
--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -129,7 +129,7 @@ class Scratch3TranslateBlocks {
                     opcode: 'getViewerLanguage',
                     text: formatMessage({
                         id: 'translate.viewerLanguage',
-                        default: 'viewer language',
+                        default: 'language',
                         description: 'the languge of the project viewer'
                     }),
                     blockType: BlockType.REPORTER,


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1190

### Proposed Changes

Change the wording on the translate extension's reporter block for the language of the project viewer from 'viewer language' to just 'language'.

### Reason for Changes

Simplicity!