### PR TITLE
Set internal connected flag before emitting event

### DIFF
--- a/src/io/bleSession.js
+++ b/src/io/bleSession.js
@@ -51,8 +51,8 @@ class BLESession extends JSONRPCWebSocket {
         this.sendRemoteRequest('connect', {peripheralId: id})
             .then(() => {
                 log.info('should have connected');
-                this._runtime.emit(this._runtime.constructor.PERIPHERAL_CONNECTED);
                 this._connected = true;
+                this._runtime.emit(this._runtime.constructor.PERIPHERAL_CONNECTED);
                 this._connectCallback();
             })
             .catch(e => {

--- a/src/io/btSession.js
+++ b/src/io/btSession.js
@@ -53,8 +53,8 @@ class BTSession extends JSONRPCWebSocket {
         this.sendRemoteRequest('connect', {peripheralId: id})
             .then(() => {
                 log.info('should have connected');
-                this._runtime.emit(this._runtime.constructor.PERIPHERAL_CONNECTED);
                 this._connected = true;
+                this._runtime.emit(this._runtime.constructor.PERIPHERAL_CONNECTED);
                 this._connectCallback();
             })
             .catch(e => {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes an issue where asking if an extension was connected in a callback of the emitted event returned the wrong answer.

Thanks for helping me find this @cwillisf @ericrosenbaum 