### PR TITLE
Remove webpack config from npm ignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@
 /.travis.yml
 /.tx
 /test
-/webpack.config.js
 
 # Build created files
 /playground


### PR DESCRIPTION
Custom branches that depend directly on the repo need this to work.
