### PR TITLE
Issue/1299 switch language

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -144,18 +144,21 @@ class ExtensionManager {
     }
 
     /**
-    * regenerate blockinfo for any loaded extensions
-    */
+     * Regenerate blockinfo for any loaded extensions
+     * @returns {Promise} resolved once all the extensions have been reinitialized
+     */
     refreshBlocks () {
-        this._loadedExtensions.forEach(serviceName => {
+        const allPromises = Array.from(this._loadedExtensions.values()).map(serviceName =>
             dispatch.call(serviceName, 'getInfo')
                 .then(info => {
+                    info = this._prepareExtensionInfo(serviceName, info);
                     dispatch.call('runtime', '_refreshExtensionPrimitives', info);
                 })
                 .catch(e => {
                     log.error(`Failed to refresh buildtin extension primitives: ${JSON.stringify(e)}`);
-                });
-        });
+                })
+        );
+        return Promise.all(allPromises);
     }
 
     allocateWorker () {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -907,12 +907,15 @@ class VirtualMachine extends EventEmitter {
      * set the current locale and builtin messages for the VM
      * @param {[type]} locale       current locale
      * @param {[type]} messages     builtin messages map for current locale
+     * @returns {Promise} Promise that resolves when all the blocks have been
+     *     updated for a new locale (or empty if locale hasn't changed.)
      */
     setLocale (locale, messages) {
-        if (locale !== formatMessage.setup().locale) {
-            formatMessage.setup({locale: locale, translations: {[locale]: messages}});
-            this.extensionManager.refreshBlocks();
+        if (locale === formatMessage.setup().locale) {
+            return Promise.resolve();
         }
+        formatMessage.setup({locale: locale, translations: {[locale]: messages}});
+        return this.extensionManager.refreshBlocks();
     }
 
     /**


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolves #1299 

### Proposed Changes

_Describe what this Pull Request does_
Converts setLocale to return a promise when all the blocks have updated. Then GUI can refresh the toolbox and workspace with the extension blocks in a new language. Also calls `_prepareExtensionInfo` for each extension loaded to make sure all the block functions are correctly initialized.

### Reason for Changes

_Explain why these changes should be made_
Allows extensions to keep working after switching language and renders the blocks in the new language.

### Testing

- [ ] Extension blocks (pen, music etc) in the toolbox render in a new language after switching language
- [ ] Extension blocks in the workspace render in a new language after switching language
- [ ] Extension blocks continue to work after switching language (e.g., pen `stamp` still stamps)