### PR TITLE
Add opcode implementation for `data_deletealloflist`

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -23,6 +23,7 @@ class Scratch3DataBlocks {
             data_listcontents: this.getListContents,
             data_addtolist: this.addToList,
             data_deleteoflist: this.deleteOfList,
+            data_deletealloflist: this.deleteAllOfList,
             data_insertatlist: this.insertAtList,
             data_replaceitemoflist: this.replaceItemOfList,
             data_itemoflist: this.getItemOfList,
@@ -134,6 +135,13 @@ class Scratch3DataBlocks {
         }
         list.value.splice(index - 1, 1);
         list._monitorUpToDate = false;
+    }
+
+    deleteAllOfList (args, util) {
+        const list = util.target.lookupOrCreateList(
+            args.LIST.id, args.LIST.name);
+        list.value = [];
+        return;
     }
 
     insertAtList (args, util) {


### PR DESCRIPTION
### Blocked by
https://github.com/LLK/scratch-blocks/pull/1640

### Proposed Changes
Adds "delete all of [list]" block as per discussion.

### Reason for Changes
Maintaining and further exposing useful functionality from Scratch 2.0

### Reference
![load](https://user-images.githubusercontent.com/747641/42588731-a3933bee-850c-11e8-976b-57e6ec4b2853.gif)