### PR TITLE
Add support for "midiInstrument:" block

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -778,7 +778,7 @@ class Scratch3MusicBlocks {
                     text: formatMessage({
                         id: 'music.midiSetInstrument',
                         default: 'set instrument to [INSTRUMENT]',
-                        description: 'set the instrument for notes played according to a mapping of MIDI codes to Scratch instrument numbers'
+                        description: 'set the instrument for notes played according to a mapping of MIDI codes'
                     }),
                     arguments: {
                         INSTRUMENT: {

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -785,7 +785,8 @@ class Scratch3MusicBlocks {
                             type: ArgumentType.NUMBER,
                             defaultValue: 1
                         }
-                    }
+                    },
+                    hideFromPalette: true
                 },
                 {
                     opcode: 'setTempo',

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -536,6 +536,79 @@ class Scratch3MusicBlocks {
     }
 
     /**
+     * An array that is a mapping from MIDI instrument numbers to Scratch instrument numbers.
+     * @type {number[]} an array of Scratch instrument numbers.
+     */
+    get MIDI_INSTRUMENTS () {
+        return [
+            // Acoustic Grand, Bright Acoustic, Electric Grand, Honky-Tonk
+            1, 1, 1, 1,
+            // Electric Piano 1, Electric Piano 2, Harpsichord, Clavinet
+            2, 2, 4, 4,
+            // Celesta, Glockenspiel, Music Box, Vibraphone
+            17, 17, 17, 16,
+            // Marimba, Xylophone, Tubular Bells, Dulcimer
+            19, 16, 17, 17,
+            // Drawbar Organ, Percussive Organ, Rock Organ, Church Organ
+            3, 3, 3, 3,
+            // Reed Organ, Accordion, Harmonica, Tango Accordion
+            3, 3, 3, 3,
+            // Nylon String Guitar, Steel String Guitar, Electric Jazz Guitar, Electric Clean Guitar
+            4, 4, 5, 5,
+            // Electric Muted Guitar, Overdriven Guitar,Distortion Guitar, Guitar Harmonics
+            5, 5, 5, 5,
+            // Acoustic Bass, Electric Bass (finger), Electric Bass (pick), Fretless Bass
+            6, 6, 6, 6,
+            // Slap Bass 1, Slap Bass 2, Synth Bass 1, Synth Bass 2
+            6, 6, 6, 6,
+            // Violin, Viola, Cello, Contrabass
+            8, 8, 8, 8,
+            // Tremolo Strings, Pizzicato Strings, Orchestral Strings, Timpani
+            8, 7, 8, 19,
+            // String Ensemble 1, String Ensemble 2, SynthStrings 1, SynthStrings 2
+            8, 8, 8, 8,
+            // Choir Aahs, Voice Oohs, Synth Voice, Orchestra Hit
+            15, 15, 15, 19,
+            // Trumpet, Trombone, Tuba, Muted Trumpet
+            9, 9, 9, 9,
+            // French Horn, Brass Section, SynthBrass 1, SynthBrass 2
+            9, 9, 9, 9,
+            // Soprano Sax, Alto Sax, Tenor Sax, Baritone Sax
+            11, 11, 11, 11,
+            // Oboe, English Horn, Bassoon, Clarinet
+            14, 14, 14, 10,
+            // Piccolo, Flute, Recorder, Pan Flute
+            12, 12, 13, 13,
+            // Blown Bottle, Shakuhachi, Whistle, Ocarina
+            13, 13, 12, 12,
+            // Lead 1 (square), Lead 2 (sawtooth), Lead 3 (calliope), Lead 4 (chiff)
+            20, 20, 20, 20,
+            // Lead 5 (charang), Lead 6 (voice), Lead 7 (fifths), Lead 8 (bass+lead)
+            20, 20, 20, 20,
+            // Pad 1 (new age), Pad 2 (warm), Pad 3 (polysynth), Pad 4 (choir)
+            21, 21, 21, 21,
+            // Pad 5 (bowed), Pad 6 (metallic), Pad 7 (halo), Pad 8 (sweep)
+            21, 21, 21, 21,
+            // FX 1 (rain), FX 2 (soundtrack), FX 3 (crystal), FX 4 (atmosphere)
+            21, 21, 21, 21,
+            // FX 5 (brightness), FX 6 (goblins), FX 7 (echoes), FX 8 (sci-fi)
+            21, 21, 21, 21,
+            // Sitar, Banjo, Shamisen, Koto
+            4, 4, 4, 4,
+            // Kalimba, Bagpipe, Fiddle, Shanai
+            17, 14, 8, 10,
+            // Tinkle Bell, Agogo, Steel Drums, Woodblock
+            17, 17, 18, 19,
+            // Taiko Drum, Melodic Tom, Synth Drum, Reverse Cymbal
+            1, 1, 1, 1,
+            // Guitar Fret Noise, Breath Noise, Seashore, Bird Tweet
+            21, 21, 21, 21,
+            // Telephone Ring, Helicopter, Applause, Gunshot
+            21, 21, 21, 21
+        ]
+    }
+
+    /**
      * The key to load & store a target's music-related state.
      * @type {string}
      */
@@ -695,6 +768,21 @@ class Scratch3MusicBlocks {
                         INSTRUMENT: {
                             type: ArgumentType.NUMBER,
                             menu: 'INSTRUMENT',
+                            defaultValue: 1
+                        }
+                    }
+                },
+                {
+                    opcode: 'midiSetInstrument',
+                    blockType: BlockType.COMMAND,
+                    text: formatMessage({
+                        id: 'music.midiSetInstrument',
+                        default: 'set instrument to [INSTRUMENT]',
+                        description: 'set the instrument for notes played according to a mapping of MIDI codes to Scratch instrument numbers'
+                    }),
+                    arguments: {
+                        INSTRUMENT: {
+                            type: ArgumentType.NUMBER,
                             defaultValue: 1
                         }
                     }
@@ -1029,10 +1117,35 @@ class Scratch3MusicBlocks {
      * @property {int} INSTRUMENT - the number of the instrument to select.
      */
     setInstrument (args, util) {
+        this._setInstrument(args.INSTRUMENT, util, false);
+    }
+
+    /**
+     * Select an instrument for playing notes according to a mapping of MIDI codes to Scratch instrument numbers.
+     * This block is implemented for compatibility with old Scratch projects that use the 'midiInstrument:' block.
+     * @param {object} args - the block arguments.
+     * @param {object} util - utility object provided by the runtime.
+     * @property {int} INSTRUMENT - the MIDI number of the instrument to select.
+     */
+    midiSetInstrument (args, util) {
+        this._setInstrument(args.INSTRUMENT, util, true);
+    }
+
+    /**
+     * Internal code to select an instrument for playing notes. If mapMidi is true, set the instrument according to
+     * the MIDI to Scratch instrument mapping.
+     * @param {number} instNum - the instrument number.
+     * @param {object} util - utility object provided by the runtime.
+     * @param {boolean} mapMidi - whether or not instNum is a MIDI instrument number.
+     */
+    _setInstrument (instNum, util, mapMidi) {
         const musicState = this._getMusicState(util.target);
-        let instNum = Cast.toNumber(args.INSTRUMENT);
+        instNum = Cast.toNumber(instNum);
         instNum = Math.round(instNum);
         instNum -= 1; // instruments are one-indexed
+        if (mapMidi) {
+            instNum = (this.MIDI_INSTRUMENTS[instNum] || 0) - 1;
+        }
         instNum = MathUtil.wrapClamp(instNum, 0, this.INSTRUMENT_INFO.length - 1);
         musicState.currentInstrument = instNum;
     }

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -605,7 +605,7 @@ class Scratch3MusicBlocks {
             21, 21, 21, 21,
             // Telephone Ring, Helicopter, Applause, Gunshot
             21, 21, 21, 21
-        ]
+        ];
     }
 
     /**

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -538,6 +538,16 @@ const specMap = {
             }
         ]
     },
+    'midiInstrument:': {
+        opcode: 'music_midiSetInstrument',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'INSTRUMENT'
+            }
+        ]
+    },
     'changeVolumeBy:': {
         opcode: 'sound_changevolumeby',
         argMap: [


### PR DESCRIPTION
### Resolves

Resolves #861. Closes #883 (since that PR also resolves the issue - but it doesn't use the MIDI mapping, so it's not a solution that makes the block's behavior compatible with 2.0).

### Proposed Changes

Adds support for the old Scratch block "midiInstrument:". This block behaves basically the same as the ordinary "set instrument to" block, but refers to a (hard-coded) mapping of MIDI instrument numbers (from Scratch 1.4 and earlier) to Scratch 2.0+ instrument numbers.

Support exists by way of adding a new block to the Music extension (and keeping it hidden from the block palette, since it's an obsolete/compatibility block). Since `setInstrument` and `midiSetInstrument` behave so similarly, I created a helper function `_setInstrument`. 2.0 just uses a single `primSetInstrument` function, and [directly checks the block's opcode](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/primitives/SoundPrims.as#L162-L165) to decide whether or not to use the MIDI mapping, but I didn't see any way to do something exactly like that in scratch-vm.

### Reason for Changes

Compatibility with old Scratch projects. The mapping is taken from [here, in scratch-flash](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/primitives/SoundPrims.as#L191-L257).

### Test Coverage

Manually tested with [this project](https://scratch.mit.edu/projects/138256836/).
