### PR TITLE
Always glow threads that come from stack clicks

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1477,7 +1477,8 @@ class Runtime extends EventEmitter {
             const target = thread.target;
             if (target === this._editingTarget) {
                 const blockForThread = thread.blockGlowInFrame;
-                if (thread.requestScriptGlowInFrame) {
+                console.log(thread.blockGlowInFrame, thread.requestScriptGlowInFrame)
+                if (thread.requestScriptGlowInFrame || thread.stackClick) {
                     let script = target.blocks.getTopLevelScript(blockForThread);
                     if (!script) {
                         // Attempt to find in flyout blocks.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1477,7 +1477,6 @@ class Runtime extends EventEmitter {
             const target = thread.target;
             if (target === this._editingTarget) {
                 const blockForThread = thread.blockGlowInFrame;
-                console.log(thread.blockGlowInFrame, thread.requestScriptGlowInFrame)
                 if (thread.requestScriptGlowInFrame || thread.stackClick) {
                     let script = target.blocks.getTopLevelScript(blockForThread);
                     if (!script) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes a certain class of "non-glowing blocks"
Fixes  #993 
### Proposed Changes

_Describe what this Pull Request does_

Always make sure to glow when threads come from stack clicks

### Test Coverage

_Please show how you have added tests to cover your changes_

Previously 

![glows-not-working](https://user-images.githubusercontent.com/654102/42643222-9d2a9c88-85c6-11e8-88ef-c2c02ae0bc63.gif)


Now they always glow
![glows-working](https://user-images.githubusercontent.com/654102/42643232-a232ad9c-85c6-11e8-8262-9a2b3d947970.gif)

---

This does not fix the fact that promise based command blocks do not glow when triggered in another way (for example, "when sprite clicked -> play sound until done" does not glow when you click the sprite). But i does solve what seems to me to be the most obviously wrong issue.