### PR TITLE
Microbit display commands yield for a tick

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -522,7 +522,9 @@ class Scratch3MicroBitBlocks {
         this._device.ledMatrixState[2] = (hex >> 10) & 0x1F;
         this._device.ledMatrixState[3] = (hex >> 15) & 0x1F;
         this._device.ledMatrixState[4] = (hex >> 20) & 0x1F;
-        return this._device.displayMatrix(this._device.ledMatrixState);
+        this._device.displayMatrix(this._device.ledMatrixState);
+
+        return Promise.resolve();
     }
 
     /**
@@ -533,7 +535,8 @@ class Scratch3MicroBitBlocks {
      */
     displayText (args) {
         const text = String(args.TEXT).substring(0, 19);
-        return this._device.displayText(text);
+        this._device.displayText(text);
+        return Promise.resolve();
     }
 
     /**
@@ -544,7 +547,7 @@ class Scratch3MicroBitBlocks {
             this._device.ledMatrixState[i] = 0;
         }
         this._device.displayMatrix(this._device.ledMatrixState);
-        return;
+        return Promise.resolve();
     }
 
     /**

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -507,7 +507,7 @@ class Scratch3MicroBitBlocks {
     /**
      * Display a predefined symbol on the 5x5 LED matrix.
      * @param {object} args - the block's arguments.
-     * @return {Promise} - a Promise that resolves when writing to device.
+     * @return {Promise} - a Promise that resolves after a tick.
      */
     displaySymbol (args) {
         const symbol = cast.toString(args.MATRIX);
@@ -530,7 +530,7 @@ class Scratch3MicroBitBlocks {
     /**
      * Display text on the 5x5 LED matrix.
      * @param {object} args - the block's arguments.
-     * @return {Promise} - a Promise that resolves when writing to device.
+     * @return {Promise} - a Promise that resolves after a tick.
      * Note the limit is 19 characters
      */
     displayText (args) {
@@ -541,6 +541,7 @@ class Scratch3MicroBitBlocks {
 
     /**
      * Turn all 5x5 matrix LEDs off.
+     * @return {Promise} - a Promise that resolves after a tick.
      */
     displayClear () {
         for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1290

### Proposed Changes

Each opcode that updates the microbit display returns a promise that immediately resolves. This has the effect of yielding the stack for a tick.

### Reason for Changes

This rate-limits commands sent to the microbit to 30 per second.

You can now make a stack of animation frames with the new matrix field block, and it will play at 30fps.