### PR TITLE
Microbit write bails out if not connected

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -250,6 +250,7 @@ class MicroBit {
      * @private
      */
     _writeSessionData (command, message) {
+        if (!this.getPeripheralIsConnected()) return;
         const output = new Uint8Array(message.length + 1);
         output[0] = command; // attach command to beginning of message
         for (let i = 0; i < message.length; i++) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1310

### Proposed Changes

If no device is connected, bail out before attempting to send data to the microbit.

### Reason for Changes

This prevents errors that otherwise occur if you run any of the microbit display blocks while a microbit is not connected.