### PR TITLE
Fix local var rename/delete

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -354,7 +354,7 @@ class Blocks {
             }
             break;
         case 'var_rename':
-            if (editingTarget && editingTarget.hasOwnProperty(e.varId)) {
+            if (editingTarget && editingTarget.variables.hasOwnProperty(e.varId)) {
                 // This is a local variable, rename on the current target
                 editingTarget.renameVariable(e.varId, e.newName);
                 // Update all the blocks on the current target that use

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -372,7 +372,7 @@ class Blocks {
             }
             break;
         case 'var_delete': {
-            const target = (editingTarget && editingTarget.hasOwnProperty(e.varId)) ?
+            const target = (editingTarget && editingTarget.variables.hasOwnProperty(e.varId)) ?
                 editingTarget : stage;
             target.deleteVariable(e.varId);
             break;


### PR DESCRIPTION
### Resolves

Resolves #1343

### Proposed Changes

Fixes the issue where local variable renaming or deletion was getting undone after switching sprites. Also fixes the issue where the monitor name wasn't getting updated after renaming a local variable.
