### PR TITLE
EV3/Microbit critical fixes for code freeze

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -429,6 +429,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for reporting that a peripheral has not been discovered.
+     * @const {string}
+     */
+    static get PERIPHERAL_SCAN_TIMEOUT () {
+        return 'PERIPHERAL_SCAN_TIMEOUT';
+    }
+
+    /**
      * Event name for reporting that blocksInfo was updated.
      * @const {string}
      */

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -125,7 +125,6 @@ class EV3 {
         /**
          * State
          */
-        this.connected = false;
         this._sensorPorts = [];
         this._motorPorts = [];
         this._sensors = {
@@ -206,7 +205,7 @@ class EV3 {
     }
 
     get distance () {
-        if (!this.connected) return 0;
+        if (!this.getPeripheralIsConnected()) return 0;
 
         // https://shop.lego.com/en-US/EV3-Ultrasonic-Sensor-45504
         // Measures distances between one and 250 cm (one to 100 in.)
@@ -219,13 +218,13 @@ class EV3 {
     }
 
     get brightness () {
-        if (!this.connected) return 0;
+        if (!this.getPeripheralIsConnected()) return 0;
 
         return this._sensors.brightness;
     }
 
     getMotorPosition (port) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         let value = this._motors.positions[port];
         value = value % 360;
@@ -235,13 +234,13 @@ class EV3 {
     }
 
     isButtonPressed (port) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         return this._sensors.buttons[port];
     }
 
     beep (freq, time) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         const cmd = [];
         cmd[0] = 15; // length
@@ -277,7 +276,7 @@ class EV3 {
     }
 
     motorTurnClockwise (port, time) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         // Build up motor command
         const cmd = this._applyPrefix(0, this._motorCommand(
@@ -312,7 +311,7 @@ class EV3 {
     }
 
     motorTurnCounterClockwise (port, time) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         // Build up motor command
         const cmd = this._applyPrefix(0, this._motorCommand(
@@ -368,7 +367,7 @@ class EV3 {
     }
 
     motorRotate (port, degrees) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         // Build up motor command
         const cmd = this._applyPrefix(0, this._motorCommand(
@@ -400,7 +399,7 @@ class EV3 {
     }
 
     motorSetPosition (port, degrees) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         // Calculate degrees to turn
         let previousPos = this._motors.positions[port];
@@ -446,7 +445,7 @@ class EV3 {
     }
 
     motorSetPower (port, power) {
-        if (!this.connected) return;
+        if (!this.getPeripheralIsConnected()) return;
 
         this._motors.speeds[port] = power;
     }
@@ -557,8 +556,6 @@ class EV3 {
 
     // TODO: keep here? / refactor
     _onSessionConnect () {
-        this.connected = true;
-
         // start polling
         // TODO: window?
         this._pollingIntervalID = window.setInterval(this._getSessionData.bind(this), 150);
@@ -566,7 +563,7 @@ class EV3 {
 
     // TODO: keep here? / refactor
     _getSessionData () {
-        if (!this.connected) {
+        if (!this.getPeripheralIsConnected()) {
             window.clearInterval(this._pollingIntervalID);
             return;
         }

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -1,7 +1,7 @@
 const ArgumentType = require('../../extension-support/argument-type');
 const BlockType = require('../../extension-support/block-type');
 const Cast = require('../../util/cast');
-const log = require('../../util/log');
+// const log = require('../../util/log');
 const Base64Util = require('../../util/base64-util');
 const BTSession = require('../../io/btSession');
 const MathUtil = require('../../util/math-util');

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -112,7 +112,6 @@ class MicroBit {
      * Called by the runtime when user wants to scan for a device.
      */
     startDeviceScan () {
-        log.info('making a new BLE session');
         this._ble = new BLESession(this._runtime, {
             filters: [
                 {services: [BLEUUID.service]}

--- a/src/io/bleSession.js
+++ b/src/io/bleSession.js
@@ -35,8 +35,8 @@ class BLESession extends JSONRPCWebSocket {
      */
     requestDevice () {
         if (this._ws.readyState === 1) { // is this needed since it's only called on ws.onopen?
-            // TODO: window?
-            this.discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
+            this._availablePeripherals = {};
+            this._discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
             this.sendRemoteRequest('discover', this._deviceOptions)
                 .catch(e => this._sendError(e)); // never reached?
         }
@@ -89,7 +89,8 @@ class BLESession extends JSONRPCWebSocket {
                 this._runtime.constructor.PERIPHERAL_LIST_UPDATE,
                 this._availablePeripherals
             );
-            if (this._discoverTimeoutID) { // cancel discover timeout
+            if (this._discoverTimeoutID) {
+                // TODO: window?
                 window.clearTimeout(this._discoverTimeoutID);
             }
             break;

--- a/src/io/bleSession.js
+++ b/src/io/bleSession.js
@@ -118,8 +118,10 @@ class BLESession extends JSONRPCWebSocket {
             params.startNotifications = true;
         }
         this._characteristicDidChangeCallback = onCharacteristicChanged;
-        return this.sendRemoteRequest('read', params);
-        // TODO: handle error here
+        return this.sendRemoteRequest('read', params)
+            .catch(e => {
+                this._sendError(e);
+            });
     }
 
     /**
@@ -135,7 +137,10 @@ class BLESession extends JSONRPCWebSocket {
         if (encoding) {
             params.encoding = encoding;
         }
-        return this.sendRemoteRequest('write', params);
+        return this.sendRemoteRequest('write', params)
+            .catch(e => {
+                this._sendError(e);
+            });
     }
 
     _sendError (e) {

--- a/src/io/btSession.js
+++ b/src/io/btSession.js
@@ -77,9 +77,11 @@ class BTSession extends JSONRPCWebSocket {
         return this._connected;
     }
 
-
     sendMessage (options) {
-        return this.sendRemoteRequest('send', options);
+        return this.sendRemoteRequest('send', options)
+            .catch(e => {
+                this._sendError(e);
+            });
     }
 
     /**
@@ -110,6 +112,7 @@ class BTSession extends JSONRPCWebSocket {
     }
 
     _sendError (e) {
+        this._connected = false;
         log.error(`BTSession error: ${JSON.stringify(e)}`);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR);
     }

--- a/src/io/btSession.js
+++ b/src/io/btSession.js
@@ -37,8 +37,8 @@ class BTSession extends JSONRPCWebSocket {
      */
     requestDevice () {
         if (this._ws.readyState === 1) { // is this needed since it's only called on ws.onopen?
-            // TODO: window?
-            this.discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
+            this._availablePeripherals = {};
+            this._discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
             this.sendRemoteRequest('discover', this._deviceOptions)
                 .catch(e => this._sendError(e)); // never reached?
         }
@@ -99,7 +99,8 @@ class BTSession extends JSONRPCWebSocket {
                 this._runtime.constructor.PERIPHERAL_LIST_UPDATE,
                 this._availablePeripherals
             );
-            if (this._discoverTimeoutID) { // cancel discover timeout
+            if (this._discoverTimeoutID) {
+                // TODO: window?
                 window.clearTimeout(this._discoverTimeoutID);
             }
             break;

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -115,6 +115,9 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.PERIPHERAL_ERROR, () =>
             this.emit(Runtime.PERIPHERAL_ERROR)
         );
+        this.runtime.on(Runtime.PERIPHERAL_SCAN_TIMEOUT, () =>
+            this.emit(Runtime.PERIPHERAL_SCAN_TIMEOUT)
+        );
 
         this.extensionManager = new ExtensionManager(this.runtime);
 


### PR DESCRIPTION
### Resolves

[Device scan can display devices of the wrong type #2636](https://github.com/LLK/scratch-gui/issues/2636)
[EV3 distance sensor should not report NaN after being unplugged #1312](https://github.com/LLK/scratch-vm/issues/1312)
[BLESession and BTSession should emit PERIPHERAL_SCAN_TIMEOUT #1348](https://github.com/LLK/scratch-vm/issues/1348)
[BLESession should handle "could not find service" error #1350](https://github.com/LLK/scratch-vm/issues/1350)
[BTSession should handle 'no peripheral connected' error #1351](https://github.com/LLK/scratch-vm/issues/1351)
[Add casting and clamping throughout the EV3 extension #1352](https://github.com/LLK/scratch-vm/issues/1352)

### Notes
- Device scan timeout requires a change in `scratch-gui`: [https://github.com/LLK/scratch-gui/pull/2651](https://github.com/LLK/scratch-gui/pull/2651)
- Device scan timeout is **15 seconds**
- EV3 beep block notes run from **47 to 99**
- EV3 beep block time capped to **3 seconds**
- EV3 motor block turn this way / that way times capped to **15 seconds**