### PR TITLE
Ignore display command with blank string

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -536,7 +536,7 @@ class Scratch3MicroBitBlocks {
      */
     displayText (args) {
         const text = String(args.TEXT).substring(0, 19);
-        this._device.displayText(text);
+        if (text.length > 0) this._device.displayText(text);
         return Promise.resolve();
     }
 


### PR DESCRIPTION
### Resolves

If you run the `display [Hello!]` block with a blank string the micro:bit will sometimes lock up requiring a hard reset. 

To replicate, run the following stack a couple of times and the micro:bit will become unresponsive.

![screen shot 2018-07-17 at 11 11 10 am](https://user-images.githubusercontent.com/1169507/42826457-6de63e74-89b2-11e8-9112-e58afe7b3b3d.png)

### Proposed Changes

Only send the command to the micro:bit if the input string length is greater than 0.

### Reason for Changes

Fixes micro:bit device lockup.
