### PR TITLE
Fix microbit display matrix clear function

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -509,13 +509,14 @@ class Scratch3MicroBitBlocks {
             return value;
         };
         const hex = symbol.split('').reduce(reducer, 0);
-        if (!hex) return;
-        this._device.ledMatrixState[0] = hex & 0x1F;
-        this._device.ledMatrixState[1] = (hex >> 5) & 0x1F;
-        this._device.ledMatrixState[2] = (hex >> 10) & 0x1F;
-        this._device.ledMatrixState[3] = (hex >> 15) & 0x1F;
-        this._device.ledMatrixState[4] = (hex >> 20) & 0x1F;
-        this._device.displayMatrix(this._device.ledMatrixState);
+        if (hex !== null) {
+            this._device.ledMatrixState[0] = hex & 0x1F;
+            this._device.ledMatrixState[1] = (hex >> 5) & 0x1F;
+            this._device.ledMatrixState[2] = (hex >> 10) & 0x1F;
+            this._device.ledMatrixState[3] = (hex >> 15) & 0x1F;
+            this._device.ledMatrixState[4] = (hex >> 20) & 0x1F;
+            this._device.displayMatrix(this._device.ledMatrixState);
+        }
 
         return Promise.resolve();
     }


### PR DESCRIPTION
### Resolves

Resolves #1344 

### Proposed Changes

Only send matrix data to micro:bit if input does not equal `null`.

### Reason for Changes

`if (!hex)` returns if the input data is '0' which is valid input data. Passing '0' to the matrix field should clear the screen.

This also fixes the clear button not working.
