### PR TITLE
Fix duplicating sounds not working

### DIFF
--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -155,7 +155,7 @@ class Sprite {
         newSprite.sounds = this.sounds.map(sound => {
             const newSound = Object.assign({}, sound);
             const soundAsset = this.runtime.storage.get(sound.assetId);
-            assetPromises.push(loadSoundFromAsset(newSound, soundAsset, this.runtime, this));
+            assetPromises.push(loadSoundFromAsset(newSound, soundAsset, this.runtime, newSprite));
             return newSound;
         });
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2629, which was a simple typo that was causing the duplicated sounds to be copied into the original sprite instead of the new sprite. Introduced in https://github.com/paulkaplan/scratch-vm/commit/4431b43e45744e07c7d16bfd0749a4b0816debf8

### Proposed Changes

_Describe what this Pull Request does_

Make sure to copy the new sound into the new sprite instead of the duplicating sprite.
