### PR TITLE
Add function to return the current VM/blocks locale

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -928,6 +928,14 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * get the current locale for the VM
+     * @returns {string} the current locale in the VM
+     */
+    getLocale () {
+        return formatMessage.setup().locale;
+    }
+
+    /**
      * Handle a Blockly event for the current editing target.
      * @param {!Blockly.Event} e Any Blockly event.
      */


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Needed for https://github.com/LLK/scratch-gui/issues/2530

### Proposed Changes

_Describe what this Pull Request does_
Adds a function that returns the current VM locale

### Reason for Changes

_Explain why these changes should be made_
GUI shouldn't update the toolbox locale when the blocks aren't visible. If the locale switches while the blocks are hidden (e.g. in sound editor), the gui needs a way to know to call setLocale when the visibility changes. This function is so that GUI can tell when the VM locale doesn't match the current locale, and call vm.setLocale to update the blocks.

