### PR TITLE
Change 'video motion' to 'video sensing'. See LLK/scratch-gui#2621

### DIFF
--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -374,8 +374,8 @@ class Scratch3VideoSensingBlocks {
             id: 'videoSensing',
             name: formatMessage({
                 id: 'videoSensing.categoryName',
-                default: 'Video Motion',
-                description: 'Label for the video motion extension category'
+                default: 'Video Sensing',
+                description: 'Label for the video sensing extension category'
             }),
             blocks: [
                 {


### PR DESCRIPTION
### Resolves
Follow-up for LLK/scratch-gui#2621

### Proposed Changes
Change "Video Motion" to "Video Sensing" in the extension definition