### PR TITLE
Update the category info name when the extension is refreshed.

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -565,6 +565,7 @@ class Runtime extends EventEmitter {
         let extensionBlocks = [];
         for (const categoryInfo of this._blockInfo) {
             if (extensionInfo.id === categoryInfo.id) {
+                categoryInfo.name = maybeFormatMessage(extensionInfo.name);
                 categoryInfo.blocks = [];
                 categoryInfo.menus = [];
                 this._fillExtensionCategory(categoryInfo, extensionInfo);


### PR DESCRIPTION
Fixes an issue where changing languages did not update the name in the category menu.

Fixes https://github.com/LLK/scratch-gui/issues/2600