### PR TITLE
Use the newer date format for vm versions, to get greenkeeper working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       node_js: 8
       env: NPM_SCRIPT=build
       before_deploy:
-      - npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
+      - npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%Y%m%d%H%M%S)
       - git config --global user.email "$(git log --pretty=format:"%ae" -n1)"
       - git config --global user.name "$(git log --pretty=format:"%an" -n1)"
       deploy:


### PR DESCRIPTION
Fixes an issue where the last version in the npm version list was not the most recent version. Hopefully this fixes greenkeeper. It also brings the version tag more in line with the audio/rest of the repos