### PR TITLE
Do not send coast if another motor command has been sent

### DIFF
--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -342,7 +342,7 @@ class EV3 {
         });
     }
 
-    coastAfter(port, time) {
+    coastAfter (port, time) {
         // Set the motor command id to check before starting coast
         const commandId = uid();
         this._motors.commandId[port] = commandId;

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -1,6 +1,7 @@
 const ArgumentType = require('../../extension-support/argument-type');
 const BlockType = require('../../extension-support/block-type');
 const Cast = require('../../util/cast');
+const uid = require('../../util/uid');
 // const log = require('../../util/log');
 const Base64Util = require('../../util/base64-util');
 const BTSession = require('../../io/btSession');
@@ -135,7 +136,8 @@ class EV3 {
         this._motors = {
             speeds: [50, 50, 50, 50],
             positions: [0, 0, 0, 0],
-            busy: [0, 0, 0, 0]
+            busy: [0, 0, 0, 0],
+            commandId: [null, null, null, null]
         };
         this._pollingIntervalID = null;
         this._pollingCounter = 0;
@@ -186,7 +188,8 @@ class EV3 {
         this._motors = {
             speeds: [50, 50, 50, 50],
             positions: [0, 0, 0, 0],
-            busy: [0, 0, 0, 0]
+            busy: [0, 0, 0, 0],
+            commandId: [null, null, null, null]
         };
         this._pollingIntervalID = null;
     }
@@ -296,10 +299,7 @@ class EV3 {
         // Set motor to busy
         // this._motors.busy[port] = 1;
 
-        // Send coast message
-        setTimeout(() => {
-            this.motorCoast(port);
-        }, time);
+        this.coastAfter(port, time);
 
         // Yield for turn time + brake time
         const coastTime = 100; // TODO: calculate coasting or set flag
@@ -331,10 +331,7 @@ class EV3 {
         // Set motor to busy
         // this._motors.busy[port] = 1;
 
-        // Send coast message
-        setTimeout(() => {
-            this.motorCoast(port);
-        }, time);
+        this.coastAfter(port, time);
 
         // Yield for time
         const coastTime = 100; // TODO: calculate coasting or set flag
@@ -343,6 +340,21 @@ class EV3 {
                 resolve();
             }, time + coastTime);
         });
+    }
+
+    coastAfter(port, time) {
+        // Set the motor command id to check before starting coast
+        const commandId = uid();
+        this._motors.commandId[port] = commandId;
+
+        // Send coast message
+        setTimeout(() => {
+            // Do not send coast if another motor command changed the command id.
+            if (this._motors.commandId[port] === commandId) {
+                this.motorCoast(port);
+                this._motors.commandId[port] = null;
+            }
+        }, time);
     }
 
     motorCoast (port) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes an issue where sending another second motor command while another is running causes the second command to get interrupted by the first commands "coast" command.

Diagrammatically:
- 0s: Motor command (1) is sent to rotate motor for 5 seconds
- 2s: Motor command (2) is sent to rotate motor for 10 seconds
- 5s: Motor command (1) finishes, and the "coast" command is sent, interrupting motor command 2
- 12s: Motor command (2) should still be running, but it isn't. Sends a coast command anyway.

This changes that sequence to this:
- 0s: Motor command (1) is sent to rotate motor for 5 seconds, sets motor command id to X
- 2s: Motor command (2) is sent to rotate motor for 10 seconds, sets motor command id to Y
- 5s: Motor command (1) finishes, checks to see if motor command id is X. It isn't (it is now Y), so it does not send a coast command.
- 12s: Motor command (2) finishes running, checks if the current motor command is Y (it is), so it sends coast. 


### Proposed Changes

_Describe what this Pull Request does_

Store a map of command IDs, and refactor the coast timeout logic into a `coastAfter(port, time)` function that sets the command ID and creates the timeout for checking if the coast command should be sent. 

### Reason for Changes

_Explain why these changes should be made_

Sending rotate for time commands in moderately quick succession leads to the motors moving for short and seemingly random amounts of time, because the "coast"  from out-of-date commands starts interrupting the current commands.
