### PR TITLE
Add UserData ioDevice for setting and getting username from blocks

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -308,9 +308,8 @@ class Scratch3SensingBlocks {
         return 0;
     }
 
-    getUsername () {
-        // Logged out users get empty string. Return that for now.
-        return '';
+    getUsername (args, util) {
+        return util.ioQuery('userData', 'getUsername');
     }
 }
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -21,6 +21,7 @@ const DeviceManager = require('../io/deviceManager');
 const Keyboard = require('../io/keyboard');
 const Mouse = require('../io/mouse');
 const MouseWheel = require('../io/mouseWheel');
+const UserData = require('../io/userData');
 const Video = require('../io/video');
 
 const StringUtil = require('../util/string-util');
@@ -259,6 +260,7 @@ class Runtime extends EventEmitter {
             keyboard: new Keyboard(this),
             mouse: new Mouse(this),
             mouseWheel: new MouseWheel(this),
+            userData: new UserData(),
             video: new Video(this)
         };
 

--- a/src/io/userData.js
+++ b/src/io/userData.js
@@ -1,0 +1,24 @@
+class UserData {
+    constructor () {
+        this._username = '';
+    }
+
+    /**
+     * Handler for updating the username
+     * @param {object} data Data posted to this ioDevice.
+     * @property {!string} username The new username.
+     */
+    postData (data) {
+        this._username = data.username;
+    }
+
+    /**
+     * Getter for username. Initially empty string, until set via postData.
+     * @returns {!string} The current username
+     */
+    getUsername () {
+        return this._username;
+    }
+}
+
+module.exports = UserData;

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -3,6 +3,7 @@ const Sensing = require('../../src/blocks/scratch3_sensing');
 const Runtime = require('../../src/engine/runtime');
 const Sprite = require('../../src/sprites/sprite');
 const RenderedTarget = require('../../src/sprites/rendered-target');
+const BlockUtility = require('../../src/engine/block-utility');
 
 test('getPrimitives', t => {
     const rt = new Runtime();
@@ -147,7 +148,8 @@ test('loud? boolean', t => {
 test('username block', t => {
     const rt = new Runtime();
     const sensing = new Sensing(rt);
+    const util = new BlockUtility(rt.sequencer);
 
-    t.equal(sensing.getUsername(), '');
+    t.equal(sensing.getUsername({}, util), '');
     t.end();
 });

--- a/test/unit/io_userData.js
+++ b/test/unit/io_userData.js
@@ -1,0 +1,25 @@
+const test = require('tap').test;
+const UserData = require('../../src/io/userData');
+
+test('spec', t => {
+    const userData = new UserData();
+
+    t.type(userData, 'object');
+    t.type(userData.postData, 'function');
+    t.type(userData.getUsername, 'function');
+    t.end();
+});
+
+test('getUsername returns empty string initially', t => {
+    const userData = new UserData();
+
+    t.strictEquals(userData.getUsername(), '');
+    t.end();
+});
+
+test('postData sets the username', t => {
+    const userData = new UserData();
+    userData.postData({username: 'TEST'});
+    t.strictEquals(userData.getUsername(), 'TEST');
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Part of https://github.com/LLK/scratch-vm/issues/306, but finishing that will require sending the `postIOData` from the GUI when the username is available.

### Proposed Changes

_Describe what this Pull Request does_

Create a new "ioDevice" for holding UserData. There is only one property in there now (username) but this felt like a better approach than hardcoding username into the runtime or something. This also automatically provides an external API for setting the username, via `vm.postIOData('userData', {username: '...'})`

### Reason for Changes

_Explain why these changes should be made_

See linked issue.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test for the new `UserData` io device, and changed the block_sensing test to work with the io device.