### PR TITLE
Use sprite’s soundbank to play text2speech sound

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -116,9 +116,10 @@ class Scratch3SpeakBlocks {
     /**
      * Convert the provided text into a sound file and then play the file.
      * @param  {object} args Block arguments
+     * @param {object} util - utility object provided by the runtime.
      * @return {Promise}     A promise that resolves after playing the sound
      */
-    speakAndWait (args) {
+    speakAndWait (args, util) {
         // Cast input to string
         args.WORDS = Cast.toString(args.WORDS);
 
@@ -154,8 +155,9 @@ class Scratch3SpeakBlocks {
                     }
                 };
                 this.runtime.audioEngine.decodeSoundPlayer(sound).then(soundPlayer => {
-                    soundPlayer.connect(this.runtime.audioEngine);
-                    soundPlayer.play();
+                    const soundBank = util.target.sprite.soundBank;
+                    soundBank.addSoundPlayer(soundPlayer);
+                    soundBank.playSound(util.target, soundPlayer.id);
                     soundPlayer.on('stop', resolve);
                 });
             });

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -155,6 +155,9 @@ class Scratch3SpeakBlocks {
                     }
                 };
                 this.runtime.audioEngine.decodeSoundPlayer(sound).then(soundPlayer => {
+                    // @todo this code should not go to production as is because it leaks
+                    // soundplayers. We may not want to use the soundbank for this purpose
+                    // at all.
                     const soundBank = util.target.sprite.soundBank;
                     soundBank.addSoundPlayer(soundPlayer);
                     soundBank.playSound(util.target, soundPlayer.id);


### PR DESCRIPTION
This change hooks up the speech synthesis sound to the sprite's soundbank to play it. This lets us run the speech synthesis sound through:

- Pitch effect
- Pan effect
- Volume
- Stop button

Note that this code is "leaky", because it adds a new soundplayer to the soundbank with each playback, and does not remove them. We can use this code for testing but it should be revisited (probably we will use a menu of voices that apply a fixed set of effects, rather than using the sprite's soundbank effect chain).