### PR TITLE
Sprite Layer Ordering Save/Load

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -879,6 +879,13 @@ class RenderedTarget extends Target {
         return false;
     }
 
+    getLayerOrder () {
+        if (this.renderer) {
+            return this.renderer.getDrawableOrder(this.drawableID);
+        }
+        return null;
+    }
+
     /**
      * Move to the front layer.
      */

--- a/src/util/math-util.js
+++ b/src/util/math-util.js
@@ -63,6 +63,20 @@ class MathUtil {
             return parseFloat(Math.tan((Math.PI * angle) / 180).toFixed(10));
         }
     }
+
+    /**
+     * Given an array of unique numbers,
+     * returns a reduced array such that each element of the reduced array
+     * represents the position of that element in a sorted version of the
+     * original array.
+     * E.g. [5, 19. 13, 1] => [1, 3, 2, 0]
+     * @param {Array<number>} elts The elements to sort and reduce
+     * @return {Array<number>} The array of reduced orderings
+     */
+    static reducedSortOrdering (elts) {
+        const sorted = elts.slice(0).sort((a, b) => a - b);
+        return elts.map(e => sorted.indexOf(e));
+    }
 }
 
 module.exports = MathUtil;

--- a/test/fixtures/fake-renderer.js
+++ b/test/fixtures/fake-renderer.js
@@ -34,10 +34,6 @@ FakeRenderer.prototype.isTouchingColor = function (d, c) { // eslint-disable-lin
     return true;
 };
 
-FakeRenderer.prototype.setDrawableOrder = function (d, l, optA, optB) { // eslint-disable-line no-unused-vars
-    return true;
-};
-
 FakeRenderer.prototype.getBounds = function (d) { // eslint-disable-line no-unused-vars
     return {left: this.x, right: this.x, top: this.y, bottom: this.y};
 };
@@ -53,6 +49,10 @@ FakeRenderer.prototype.setDrawableOrder = function (d, a, optG, optA, optB) { //
     a = Math.max(a, 0);
     this.order = Math.min(a, this.spriteCount);
     return this.order;
+};
+
+FakeRenderer.prototype.getDrawableOrder = function (d) { // eslint-disable-line no-unused-vars
+    return 'stub';
 };
 
 FakeRenderer.prototype.pick = function (x, y, a, b, c) { // eslint-disable-line no-unused-vars

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -326,6 +326,23 @@ test('layers', t => { // TODO this tests fake functionality. Move layering tests
     t.end();
 });
 
+test('getLayerOrder returns result of renderer getDrawableOrder or null if renderer is not attached', t => {
+    const s = new Sprite();
+    const r = new Runtime();
+    const a = new RenderedTarget(s, r);
+
+    // getLayerOrder should return null if there is no renderer attached to the runtime
+    t.equal(a.getLayerOrder(), null);
+
+    const renderer = new FakeRenderer();
+    r.attachRenderer(renderer);
+    const b = new RenderedTarget(s, r);
+
+    t.equal(b.getLayerOrder(), 'stub');
+
+    t.end();
+});
+
 test('keepInFence', t => {
     const s = new Sprite();
     const r = new Runtime();

--- a/test/unit/util_math.js
+++ b/test/unit/util_math.js
@@ -42,3 +42,9 @@ test('tan', t => {
     t.strictEqual(math.tan(33), 0.6494075932);
     t.end();
 });
+
+test('reducedSortOrdering', t => {
+    t.deepEqual(math.reducedSortOrdering([5, 18, 6, 3]), [1, 3, 2, 0]);
+    t.deepEqual(math.reducedSortOrdering([5, 1, 56, 19]), [1, 0, 3, 2]);
+    t.end();
+});


### PR DESCRIPTION
### Proposed Changes

Preserve sprite layer order information across saving and loading an sb3.

### Reason for Changes

Feature exists in Scratch 2.

### Test Coverage

Added unit tests for new functionality.

### Related PRs
This PR depends on LLK/scratch-render#320