### PR TITLE
Don't serialize layerOrder when exporting a sprite.

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -485,7 +485,9 @@ const serialize = function (runtime, targetId) {
 
     const flattenedOriginalTargets = JSON.parse(JSON.stringify(originalTargetsToSerialize));
 
-    if (runtime.renderer) {
+    // If the renderer is attached, and we're serializing a whole project (not a sprite)
+    // add a temporary layerOrder property to each target.
+    if (runtime.renderer && !targetId) {
         flattenedOriginalTargets.forEach((t, index) => {
             t.layerOrder = layerOrdering[index];
         });


### PR DESCRIPTION
### Proposed Changes

Title says it all.

### Reason for Changes

Will help more concrete validation down the line.

### Related PRs
This PR is a dependency of the following PR and should be merged first.
LLK/scratch-parser#44