### PR TITLE
Fix benchmark suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "scratch-blocks": "latest",
     "scratch-render": "latest",
     "scratch-storage": "^0.4.0",
+    "scratch-svg-renderer": "latest",
     "script-loader": "0.7.2",
     "stats.js": "^0.17.0",
     "tap": "^11.0.1",

--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -481,6 +481,8 @@ const runBenchmark = function () {
     vm.attachRenderer(renderer);
     const audioEngine = new window.AudioEngine();
     vm.attachAudioEngine(audioEngine);
+    vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
+    vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
 
     // Feed mouse events as VM I/O events.
     document.addEventListener('mousemove', e => {

--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -481,6 +481,7 @@ const runBenchmark = function () {
     vm.attachRenderer(renderer);
     const audioEngine = new window.AudioEngine();
     vm.attachAudioEngine(audioEngine);
+    /* global ScratchSVGRenderer */
     vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
     vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
 

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -85,6 +85,8 @@
   <script src="./scratch-storage.js"></script>
   <!-- Stage rendering -->
   <script src="./scratch-render.js"></script>
+  <!-- SVG rendering -->
+  <script src="./scratch-svg-renderer.js"></script>
   <!-- VM -->
   <script src="./scratch-vm.js"></script>
   <!-- Playground -->

--- a/src/playground/suite.js
+++ b/src/playground/suite.js
@@ -577,6 +577,7 @@ window.onload = function () {
         recordingTime: 5000
     }));
 
+    // TODO: #1322
     // Error: Cannot create monitor for target that cannot be found by name
     // suite.add(new BenchFixture({
     //     projectId: 187694931,

--- a/src/playground/suite.js
+++ b/src/playground/suite.js
@@ -577,17 +577,18 @@ window.onload = function () {
         recordingTime: 5000
     }));
 
-    suite.add(new BenchFixture({
-        projectId: 187694931,
-        warmUpTime: 0,
-        recordingTime: 5000
-    }));
-
-    suite.add(new BenchFixture({
-        projectId: 187694931,
-        warmUpTime: 5000,
-        recordingTime: 5000
-    }));
+    // Error: Cannot create monitor for target that cannot be found by name
+    // suite.add(new BenchFixture({
+    //     projectId: 187694931,
+    //     warmUpTime: 0,
+    //     recordingTime: 5000
+    // }));
+    //
+    // suite.add(new BenchFixture({
+    //     projectId: 187694931,
+    //     warmUpTime: 5000,
+    //     recordingTime: 5000
+    // }));
 
     suite.add(new BenchFixture({
         projectId: 219313833,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,6 +151,8 @@ module.exports = [
             }, {
                 from: 'node_modules/scratch-render/dist/web'
             }, {
+                from: 'node_modules/scratch-svg-renderer/dist/web'
+            }, {
                 from: 'src/playground'
             }])
         ])


### PR DESCRIPTION
### Proposed Changes

Add SVG and Bitmap adapters to scratch vm in benchmark suite.

### Reason for Changes

Benchmark is broken without the adapters.
