### PR TITLE
Add "set voice" block to text2speech extension

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -255,7 +255,7 @@ class Scratch3SpeakBlocks {
      */
     speakAndWait (args, util) {
         // Cast input to string
-        args.WORDS = Cast.toString(args.WORDS);
+        let words = Cast.toString(args.WORDS);
 
         const state = this._getState(util.target);
 
@@ -263,14 +263,14 @@ class Scratch3SpeakBlocks {
         const playbackRate = this.VOICE_INFO[state.voiceId].playbackRate;
 
         if (state.voiceId === this.VOICE_INFO.KITTEN.id) {
-            args.WORDS = args.WORDS.replace(/\w+/g, 'meow');
+            words = words.replace(/\w+/g, 'meow');
         }
 
         // Build up URL
         let path = `${SERVER_HOST}/synth`;
         path += `?locale=${this.getViewerLanguageCode()}`;
         path += `&gender=${gender}`;
-        path += `&text=${encodeURI(args.WORDS)}`;
+        path += `&text=${encodeURI(words)}`;
 
         // Perform HTTP request to get audio file
         return new Promise(resolve => {

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -228,15 +228,8 @@ class Scratch3SpeakBlocks {
             playbackRate = 1.4;
         }
 
-        if (this.voice === Voices.KITTEN) {
-            const wordList = args.WORDS.split(' ');
-            args.WORDS = wordList.reduce((acc, curr) => {
-                let next = '';
-                if (curr.length > 0) {
-                    next = 'meow ';
-                }
-                return acc + next;
-            }, '');
+        if (state.voice === Voices.KITTEN) {
+            args.WORDS = args.WORDS.replace(/\w+/g, 'meow');
         }
 
         // Build up URL

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -62,6 +62,7 @@ class Scratch3SpeakBlocks {
         this.runtime = runtime;
 
         // @todo stop all speech sounds currently playing
+        // https://github.com/LLK/scratch-vm/issues/1405
         // this._stopAllSpeech = this._stopAllSpeech.bind(this);
         // if (this.runtime) {
         //      this.runtime.on('PROJECT_STOP_ALL', this._stopAllSpeech);

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -209,6 +209,8 @@ class Scratch3SpeakBlocks {
     getViewerLanguageCode () {
         // @todo This should be the language code of the project *creator*
         // rather than the project viewer.
+        // @todo Amazon Polly needs the locale in a two part form (e.g. ja-JP),
+        // so we probably need to create a lookup table.
         return formatMessage.setup().locale || navigator.language || navigator.userLanguage || 'en-US';
     }
 

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -189,7 +189,7 @@ class Scratch3SpeakBlocks {
     getInfo () {
         return {
             id: 'text2speech',
-            name: 'Speech Synthesis',
+            name: 'Text-to-Speech',
             menuIconURI: '', // @todo Add the final icons.
             blockIconURI: '',
             blocks: [


### PR DESCRIPTION
This adds a block to the text2speech extension to set the voice for speech synthesis to:

- quinn (female voice)
- max (male voice)
- squeak (female voice pitched up)
- monster (male voice pitched down)
- kitten (same as squeak, with all words replaced by "meow")
- puppy (same as max, with british locale and words randomly replaced by bark/woof/ruff)

It also reverts back to use soundPlayers without connecting to the sprite's soundbank, since we're using the pitch effect to create the voices. 