### PR TITLE
Change variable toXML function to a static function that acts on vari…

### DIFF
--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -33,9 +33,15 @@ class Variable {
         }
     }
 
-    toXML (isLocal) {
+    /**
+     * Serialize a variable object to XML.
+     * @param {Variable | object} variable The Variable or Variable-like object to serialize.
+     * @param {boolean=} isLocal Whether the variable being serialized is local or not.
+     * @return {!string} The serialized variable in XML format.
+     */
+    static toXML (variable, isLocal) {
         isLocal = (isLocal === true);
-        return `<variable type="${this.type}" id="${this.id}" islocal="${isLocal}">${this.name}</variable>`;
+        return `<variable type="${variable.type}" id="${variable.id}" islocal="${isLocal}">${variable.name}</variable>`;
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1147,8 +1147,8 @@ class VirtualMachine extends EventEmitter {
 
         const xmlString = `<xml xmlns="http://www.w3.org/1999/xhtml">
                             <variables>
-                                ${globalVariables.map(v => v.toXML()).join()}
-                                ${localVariables.map(v => v.toXML(true)).join()}
+                                ${globalVariables.map(v => Variable.toXML(v)).join()}
+                                ${localVariables.map(v => Variable.toXML(v, true)).join()}
                             </variables>
                             ${workspaceComments.map(c => c.toXML()).join()}
                             ${this.editingTarget.blocks.toXML(this.editingTarget.comments)}

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -456,12 +456,13 @@ test('emitWorkspaceUpdate', t => {
         }
         return blockString;
     };
+    Variable.toXML = variable => variable.name;
     vm.runtime.targets = [
         {
             isStage: true,
             variables: {
                 global: {
-                    toXML: () => 'global'
+                    name: 'global'
                 }
             },
             blocks: {
@@ -476,7 +477,7 @@ test('emitWorkspaceUpdate', t => {
         }, {
             variables: {
                 unused: {
-                    toXML: () => 'unused'
+                    name: 'unused'
                 }
             },
             blocks: {
@@ -491,7 +492,7 @@ test('emitWorkspaceUpdate', t => {
         }, {
             variables: {
                 local: {
-                    toXML: () => 'local'
+                    name: 'local'
                 }
             },
             blocks: {


### PR DESCRIPTION
### Resolves

Resolves #895

### Proposed Changes

Replace `Variable.prototype.toXML` with a static function that can act on both variable instances as well as flattened objects (via `JSON.parse(JSON.stringify...)`). These flattened objects were creating issues with serializing the blocks workspace to XML whenever a sprite with local variables was duplicated or cloned. These workspace issues can eventually lead to a workspace crash.
