### PR TITLE
Add turbo mode events

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -323,6 +323,22 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for turning on turbo mode.
+     * @const {string}
+     */
+    static get TURBO_MODE_ON () {
+        return 'TURBO_MODE_ON';
+    }
+
+    /**
+     * Event name for turning off turbo mode.
+     * @const {string}
+     */
+    static get TURBO_MODE_OFF () {
+        return 'TURBO_MODE_OFF';
+    }
+
+    /**
      * Event name when the project is started (threads may not necessarily be
      * running).
      * @const {string}

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -148,6 +148,11 @@ class VirtualMachine extends EventEmitter {
      */
     setTurboMode (turboModeOn) {
         this.runtime.turboMode = !!turboModeOn;
+        if (this.runtime.turboMode) {
+            this.emit(Runtime.TURBO_MODE_ON);
+        } else {
+            this.emit(Runtime.TURBO_MODE_OFF);
+        }
     }
 
     /**

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -857,3 +857,24 @@ test('shareBlocksToTarget chooses a fresh name for a new global variable checkin
 
     t.end();
 });
+
+test('Setting turbo mode emits events', t => {
+    let turboMode = null;
+
+    const vm = new VirtualMachine();
+
+    vm.addListener('TURBO_MODE_ON', () => {
+        turboMode = true;
+    });
+    vm.addListener('TURBO_MODE_OFF', () => {
+        turboMode = false;
+    });
+
+    vm.setTurboMode(true);
+    t.equal(turboMode, true);
+
+    vm.setTurboMode(false);
+    t.equal(turboMode, false);
+
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Required step to https://github.com/LLK/scratch-gui/issues/1966

### Proposed Changes

_Describe what this Pull Request does_

Add TURBO_MODE_ON and TURBO_MODE_OFF events, emit when turbo mode is set.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test on vm for making sure these events are being emitted when toggling the turbo mode state.