### PR TITLE
Import current block menu as field not input

### DIFF
--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -1110,9 +1110,8 @@ const specMap = {
         opcode: 'sensing_current',
         argMap: [
             {
-                type: 'input',
-                inputOp: 'sensing_currentmenu',
-                inputName: 'CURRENTMENU'
+                type: 'field',
+                fieldName: 'CURRENTMENU'
             }
         ]
     },


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/1414

### Proposed Changes

_Describe what this Pull Request does_

Import current block menu as field not an input.

### Reason for Changes

_Explain why these changes should be made_

Because the current block has a field, not an input

### Test Coverage

_Please show how you have added tests to cover your changes_

On develop 

![image](https://user-images.githubusercontent.com/654102/43601155-99de7f64-965a-11e8-81f5-de6033b33b6a.png)

With this PR

![image](https://user-images.githubusercontent.com/654102/43601160-9df17dea-965a-11e8-8bb8-e9696e17891f.png)

