### PR TITLE
Make click hats trigger on mouse down instead of up

### DIFF
--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -14,40 +14,42 @@ class Mouse {
     }
 
     /**
-     * Activate "event_whenthisspriteclicked" hats if needed.
-     * @param  {number} x X position to be sent to the renderer.
-     * @param  {number} y Y position to be sent to the renderer.
-     * @param  {?bool} wasDragged Whether the click event was the result of
-     * a drag end.
+     * Activate "event_whenthisspriteclicked" hats.
+     * @param  {Target} target to trigger hats on.
      * @private
      */
-    _activateClickHats (x, y) {
+    _activateClickHats (target) {
+        // Activate both "this sprite clicked" and "stage clicked"
+        // They were separated into two opcodes for labeling,
+        // but should act the same way.
+        // Intentionally not checking isStage to make it work when sharing blocks.
+        // @todo the blocks should be converted from one to another when shared
+        this.runtime.startHats('event_whenthisspriteclicked',
+            null, target);
+        this.runtime.startHats('event_whenstageclicked',
+            null, target);
+    }
+
+    /**
+     * Find a target by XY location
+     * @param  {number} x X position to be sent to the renderer.
+     * @param  {number} y Y position to be sent to the renderer.
+     * @return {Target} the target at that location
+     * @private
+     */
+    _pickTarget (x, y) {
         if (this.runtime.renderer) {
             const drawableID = this.runtime.renderer.pick(x, y);
             for (let i = 0; i < this.runtime.targets.length; i++) {
                 const target = this.runtime.targets[i];
                 if (target.hasOwnProperty('drawableID') &&
                     target.drawableID === drawableID) {
-                    // only activate click hat if the mouse up event wasn't
-                    // Activate both "this sprite clicked" and "stage clicked"
-                    // They were separated into two opcodes for labeling,
-                    // but should act the same way.
-                    // Intentionally not checking isStage to make it work when sharing blocks.
-                    // @todo the blocks should be converted from one to another when shared
-                    this.runtime.startHats('event_whenthisspriteclicked',
-                        null, target);
-                    this.runtime.startHats('event_whenstageclicked',
-                        null, target);
-                    return;
+                    return target;
                 }
             }
-            // If haven't returned, activate click hats for stage.
-            // Still using both blocks for sharing compatibility.
-            this.runtime.startHats('event_whenthisspriteclicked',
-                null, this.runtime.getTargetForStage());
-            this.runtime.startHats('event_whenstageclicked',
-                null, this.runtime.getTargetForStage());
         }
+        // Return the stage if no target was found
+        return this.runtime.getTargetForStage();
     }
 
     /**
@@ -74,12 +76,27 @@ class Mouse {
         if (typeof data.isDown !== 'undefined') {
             const previousDownState = this._isDown;
             this._isDown = data.isDown;
+
+            // Do not trigger if down state has not changed
+            if (previousDownState === this._isDown) return;
+
+            // Never trigger click hats at the end of a drag
+            if (data.wasDragged) return;
+
+            // Do not activate click hats for clicks outside canvas bounds
+            if (!(data.x > 0 && data.x < data.canvasWidth &&
+                data.y > 0 && data.y < data.canvasHeight)) return;
+
+            const target = this._pickTarget(data.x, data.y);
             const isNewMouseDown = !previousDownState && this._isDown;
-            // Make sure click is within the canvas bounds to activate click hats
-            if (isNewMouseDown &&
-                data.x > 0 && data.x < data.canvasWidth &&
-                data.y > 0 && data.y < data.canvasHeight) {
-                this._activateClickHats(data.x, data.y);
+            const isNewMouseUp = previousDownState && !this._isDown;
+
+            // Draggable targets start click hats on mouse up.
+            // Non-draggable targets start click hats on mouse down.
+            if (target.draggable && isNewMouseUp) {
+                this._activateClickHats(target);
+            } else if (!target.draggable && isNewMouseDown) {
+                this._activateClickHats(target);
             }
         }
     }

--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -21,7 +21,7 @@ class Mouse {
      * a drag end.
      * @private
      */
-    _activateClickHats (x, y, wasDragged) {
+    _activateClickHats (x, y) {
         if (this.runtime.renderer) {
             const drawableID = this.runtime.renderer.pick(x, y);
             for (let i = 0; i < this.runtime.targets.length; i++) {
@@ -29,18 +29,15 @@ class Mouse {
                 if (target.hasOwnProperty('drawableID') &&
                     target.drawableID === drawableID) {
                     // only activate click hat if the mouse up event wasn't
-                    // the result of a drag ending
-                    if (!wasDragged) {
-                        // Activate both "this sprite clicked" and "stage clicked"
-                        // They were separated into two opcodes for labeling,
-                        // but should act the same way.
-                        // Intentionally not checking isStage to make it work when sharing blocks.
-                        // @todo the blocks should be converted from one to another when shared
-                        this.runtime.startHats('event_whenthisspriteclicked',
-                            null, target);
-                        this.runtime.startHats('event_whenstageclicked',
-                            null, target);
-                    }
+                    // Activate both "this sprite clicked" and "stage clicked"
+                    // They were separated into two opcodes for labeling,
+                    // but should act the same way.
+                    // Intentionally not checking isStage to make it work when sharing blocks.
+                    // @todo the blocks should be converted from one to another when shared
+                    this.runtime.startHats('event_whenthisspriteclicked',
+                        null, target);
+                    this.runtime.startHats('event_whenstageclicked',
+                        null, target);
                     return;
                 }
             }
@@ -75,12 +72,14 @@ class Mouse {
             );
         }
         if (typeof data.isDown !== 'undefined') {
+            const previousDownState = this._isDown;
             this._isDown = data.isDown;
+            const isNewMouseDown = !previousDownState && this._isDown;
             // Make sure click is within the canvas bounds to activate click hats
-            if (!this._isDown &&
+            if (isNewMouseDown &&
                 data.x > 0 && data.x < data.canvasWidth &&
                 data.y > 0 && data.y < data.canvasHeight) {
-                this._activateClickHats(data.x, data.y, data.wasDragged);
+                this._activateClickHats(data.x, data.y);
             }
         }
     }

--- a/test/unit/io_mouse.js
+++ b/test/unit/io_mouse.js
@@ -70,3 +70,57 @@ test('at zoomed scale', t => {
     t.strictEquals(m.getScratchY(), -90);
     t.end();
 });
+
+test('mousedown activating click hats', t => {
+    const rt = new Runtime();
+    const m = new Mouse(rt);
+
+    const mouseMoveEvent = {
+        x: 10,
+        y: 100,
+        canvasWidth: 480,
+        canvasHeight: 360
+    };
+
+    const mouseDownEvent = Object.assign({}, mouseMoveEvent, {
+        isDown: true
+    });
+
+    const mouseUpEvent = Object.assign({}, mouseMoveEvent, {
+        isDown: false
+    });
+
+    // Stub activateClickHats function for testing
+    let ranClickHats = false;
+    m._activateClickHats = () => {
+        ranClickHats = true;
+    };
+
+    // Mouse move without mousedown
+    m.postData(mouseMoveEvent);
+    t.strictEquals(ranClickHats, false);
+
+    // Mouse down event triggers the hats
+    m.postData(mouseDownEvent);
+    t.strictEquals(ranClickHats, true);
+
+    // But another mouse move while down doesn't trigger
+    ranClickHats = false;
+    m.postData(mouseDownEvent);
+    t.strictEquals(ranClickHats, false);
+
+    // And it doesn't trigger on mouse up
+    ranClickHats = false;
+    m.postData(mouseUpEvent);
+    t.strictEquals(ranClickHats, false);
+
+    // And hats don't trigger if mouse down is outside canvas
+    ranClickHats = false;
+    m.postData(Object.assign({}, mouseDownEvent, {
+        x: 50000,
+        y: 50
+    }));
+    t.strictEquals(ranClickHats, false);
+
+    t.end();
+});

--- a/test/unit/io_mouse.js
+++ b/test/unit/io_mouse.js
@@ -82,6 +82,10 @@ test('mousedown activating click hats', t => {
         canvasHeight: 360
     };
 
+    const dummyTarget = {
+        draggable: false
+    };
+
     const mouseDownEvent = Object.assign({}, mouseMoveEvent, {
         isDown: true
     });
@@ -90,17 +94,19 @@ test('mousedown activating click hats', t => {
         isDown: false
     });
 
-    // Stub activateClickHats function for testing
+    // Stub activateClickHats and pick function for testing
     let ranClickHats = false;
     m._activateClickHats = () => {
         ranClickHats = true;
     };
+    m._pickTarget = () => dummyTarget;
 
     // Mouse move without mousedown
     m.postData(mouseMoveEvent);
     t.strictEquals(ranClickHats, false);
 
-    // Mouse down event triggers the hats
+    // Mouse down event triggers the hats if target is not draggable
+    dummyTarget.draggable = false;
     m.postData(mouseDownEvent);
     t.strictEquals(ranClickHats, true);
 
@@ -109,10 +115,11 @@ test('mousedown activating click hats', t => {
     m.postData(mouseDownEvent);
     t.strictEquals(ranClickHats, false);
 
-    // And it doesn't trigger on mouse up
+    // And it does trigger on mouse up if target is draggable
     ranClickHats = false;
+    dummyTarget.draggable = true;
     m.postData(mouseUpEvent);
-    t.strictEquals(ranClickHats, false);
+    t.strictEquals(ranClickHats, true);
 
     // And hats don't trigger if mouse down is outside canvas
     ranClickHats = false;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/1249

### Proposed Changes

_Describe what this Pull Request does_

Make the click hats activate on mousedown instead of mouse up

### Reason for Changes

_Explain why these changes should be made_

We already had all the needed info, we just were explicitly triggering on mouse up. Understandable, since that is the technical way the word "click" is used, but it turns out that click in scratch 2 specifically means "on mouse down", and projects depended on that behavior. 

I do not think this impacts any dragging behavior, which is handled totally separately. But I want to be cautious because I don't fully understand the comment from @thisandagain in the linked issue.


### Test Coverage

_Please show how you have added tests to cover your changes_

I added a pretty long unit test to make sure:
1. hats are triggered on the "leading edge" of the mouse up -> mousedown transition.
2. mouse ups do not trigger the hats.
3. hats are triggered only for clicks within the canvas window, which was implemented previously but was not tested until this.