### PR TITLE
Remove heuristic for bubble positioning that was not accurate.

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -197,23 +197,8 @@ class Scratch3LooksBlocks {
             this.runtime.renderer.updateTextSkin(bubbleState.skinId, type, text, onSpriteRight, [0, 0]);
         } else {
             target.addListener(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this._onTargetChanged);
-
-            // TODO is there a way to figure out before rendering whether to default left or right?
-            const targetBounds = target.getBounds();
-            const stageSize = this.runtime.renderer.getNativeSize();
-            const stageBounds = {
-                left: -stageSize[0] / 2,
-                right: stageSize[0] / 2,
-                top: stageSize[1] / 2,
-                bottom: -stageSize[1] / 2
-            };
-            if (targetBounds.right + 170 > stageBounds.right) {
-                bubbleState.onSpriteRight = false;
-            }
-
             bubbleState.drawableId = this.runtime.renderer.createDrawable(StageLayering.SPRITE_LAYER);
             bubbleState.skinId = this.runtime.renderer.createTextSkin(type, text, bubbleState.onSpriteRight, [0, 0]);
-
             this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {
                 skinId: bubbleState.skinId
             });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2789

### Proposed Changes

_Describe what this Pull Request does_

"guessing" the bubble positioning before rendering is no longer needed because the positioning logic has changed, bubbles that don't fit during the positioning stage get flipped.


### Test Coverage

_Please show how you have added tests to cover your changes_

Tested by making a project that would definitely need to display the bubble on the left and noting that there was no glitching

Also tested the project from the linked issue and seeing it worked.