### PR TITLE
ensure getTargetXY('_mouse_') is always whole numbers

### DIFF
--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -79,8 +79,8 @@ class Scratch3MotionBlocks {
         let targetX = 0;
         let targetY = 0;
         if (targetName === '_mouse_') {
-            targetX = util.ioQuery('mouse', 'getScratchX');
-            targetY = util.ioQuery('mouse', 'getScratchY');
+            targetX = Math.round(util.ioQuery('mouse', 'getScratchX'));
+            targetY = Math.round(util.ioQuery('mouse', 'getScratchY'));
         } else if (targetName === '_random_') {
             const stageWidth = this.runtime.constructor.STAGE_WIDTH;
             const stageHeight = this.runtime.constructor.STAGE_HEIGHT;


### PR DESCRIPTION
### Resolves

I'm not sure this is a bug or derivation from how Scratch 2 works but I think it may be. 

https://llk.github.io/scratch-gui/develop/#238096787 horizontal and vertical lines "fade" in and out because the x, y values the lines are drawing from are not whole numbers. They have fractional values that causes the line to be drawn inbetween pixels causing a fading line for some mouse positions.

### Proposed Changes

Round mouse position x and y.

### Reason for Changes

Mouse position might not be whole numbers.

### Test Coverage

https://llk.github.io/scratch-gui/develop/#238096787
