### PR TITLE
Fix variable xml

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -269,7 +269,7 @@ class Target extends EventEmitter {
 
     /**
      * Renames the variable with the given id to newName.
-     * @param {string} id Id of renamed variable.
+     * @param {string} id Id of variable to rename.
      * @param {string} newName New name for the variable.
      */
     renameVariable (id, newName) {
@@ -301,7 +301,7 @@ class Target extends EventEmitter {
 
     /**
      * Removes the variable with the given id from the dictionary of variables.
-     * @param {string} id Id of renamed variable.
+     * @param {string} id Id of variable to delete.
      */
     deleteVariable (id) {
         if (this.variables.hasOwnProperty(id)) {
@@ -311,6 +311,48 @@ class Target extends EventEmitter {
                 this.runtime.requestRemoveMonitor(id);
             }
         }
+    }
+
+    /**
+     * Create a clone of the variable with the given id from the dictionary of
+     * this target's variables.
+     * @param {string} id Id of variable to duplicate.
+     * @return {?Variable} The duplicated variable, or null if
+     * the original variable was not found.
+     */
+    duplicateVariable (id) {
+        if (this.variables.hasOwnProperty(id)) {
+            const originalVariable = this.variables[id];
+            const newVariable = new Variable(
+                null, // generate a new uid
+                originalVariable.name,
+                originalVariable.type,
+                originalVariable.isCloud
+            );
+            newVariable.value = originalVariable.value;
+            return newVariable;
+        }
+        return null;
+    }
+
+    /**
+     * Duplicate the dictionary of this target's variables as part of duplicating.
+     * this target or making a clone.
+     * @param {object} blocks Block container for the target being duplicated
+     * @return {object} The duplicated dictionary of variables
+     */
+    duplicateVariables (blocks) {
+        const allVarRefs = blocks.getAllVariableAndListReferences();
+        return Object.keys(this.variables).reduce((accum, varId) => {
+            const newVariable = this.duplicateVariable(varId);
+            accum[newVariable.id] = newVariable;
+            const currVarRefs = allVarRefs[varId];
+            if (currVarRefs) {
+                this.mergeVariables(varId, newVariable.id, currVarRefs);
+            }
+
+            return accum;
+        }, {});
     }
 
     /**

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1003,7 +1003,7 @@ class RenderedTarget extends Target {
         newClone.currentCostume = this.currentCostume;
         newClone.rotationStyle = this.rotationStyle;
         newClone.effects = JSON.parse(JSON.stringify(this.effects));
-        newClone.variables = JSON.parse(JSON.stringify(this.variables));
+        newClone.variables = this.duplicateVariables();
         newClone.initDrawable(StageLayering.SPRITE_LAYER);
         newClone.updateAllDrawableProperties();
         // Place behind the current target.
@@ -1029,7 +1029,7 @@ class RenderedTarget extends Target {
             newTarget.currentCostume = this.currentCostume;
             newTarget.rotationStyle = this.rotationStyle;
             newTarget.effects = JSON.parse(JSON.stringify(this.effects));
-            newTarget.variables = JSON.parse(JSON.stringify(this.variables));
+            newTarget.variables = this.duplicateVariables(newTarget.blocks);
             newTarget.updateAllDrawableProperties();
             newTarget.goBehindOther(this);
             return newTarget;


### PR DESCRIPTION
### Resolves

Resolves #895 and is a replacement for #1409.

### Proposed Changes

Fix variable duplication during making a clone of a sprite or duplicating a sprite.
There are now functions for duplicating variables (and actually creating real variable objects from them so that they get serialized to XML correctly) in one of two ways:

1) The duplicated variable gets a new ID and all block fields that reference that variable in the provided blocks container get updated to use the new variable ID. This is necessary for duplicating a sprite, in which we want local variables of different sprites to have different IDs (which is necessary for those variables to have their own monitors).

2) The duplicated variable keeps the original variable's ID, and no block field update is necessary. This is required for making a clone of a sprite because sprite clones use the same blocks container as their parent sprite. Sprite clone variables cannot be monitored separately and thus do not need to have an ID separate from the original variable.

### Reason for Changes

Fixing issues where duplicating a sprite with local variables causes errors that can eventually cause the editor to crash.

### Test Coverage

Added unit tests for the new duplicate functions.