### PR TITLE
Let wait, sayforsecs, thinkforsecs - handle big numbers

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -1,4 +1,5 @@
 const Cast = require('../util/cast');
+const MathUtil = require('../util/math-util.js');
 
 class Scratch3ControlBlocks {
     constructor (runtime) {
@@ -108,11 +109,11 @@ class Scratch3ControlBlocks {
     }
 
     wait (args) {
-        const duration = Math.max(0, 1000 * Cast.toNumber(args.DURATION));
+        const duration = 1000 * Cast.toNumber(args.DURATION);
         return new Promise(resolve => {
             setTimeout(() => {
                 resolve();
-            }, duration);
+            }, MathUtil.clamp(duration, 0, 2**31 - 1)); // setTimeout only supports up to 2**31 - 1
         });
     }
 

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -113,7 +113,7 @@ class Scratch3ControlBlocks {
         return new Promise(resolve => {
             setTimeout(() => {
                 resolve();
-            }, MathUtil.clamp(duration, 0, 2**31 - 1)); // setTimeout only supports up to 2**31 - 1
+            }, MathUtil.clamp(duration, 0, (2 ** 31) - 1)); // setTimeout only supports up to 2**31 - 1
         });
     }
 

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -113,7 +113,7 @@ class Scratch3ControlBlocks {
         return new Promise(resolve => {
             setTimeout(() => {
                 resolve();
-            }, MathUtil.clamp(duration, 0, (2 ** 31) - 1)); // setTimeout only supports up to 2**31 - 1
+            }, MathUtil.clamp(duration, 0, Math.pow(2, 31) - 1)); // setTimeout only supports up to 2^31 - 1
         });
     }
 

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -1,4 +1,5 @@
 const Cast = require('../util/cast');
+const MathUtil = require('../util/math-util.js');
 const Clone = require('../util/clone');
 const RenderedTarget = require('../sprites/rendered-target');
 const uid = require('../util/uid');
@@ -309,7 +310,7 @@ class Scratch3LooksBlocks {
                     this._updateBubble(target, 'say', '');
                 }
                 resolve();
-            }, 1000 * args.SECS);
+            }, MathUtil.clamp(1000 * args.SECS, 0, 2**31 - 1)); // setTimeout only supports up to 2**31 - 1
         });
     }
 
@@ -329,10 +330,10 @@ class Scratch3LooksBlocks {
                     this._updateBubble(target, 'think', '');
                 }
                 resolve();
-            }, 1000 * args.SECS);
+            }, MathUtil.clamp(1000 * args.SECS, 0, 2**31 - 1)); // setTimeout only supports up to 2**31 - 1
         });
     }
-
+	
     show (args, util) {
         util.target.setVisible(true);
         this._renderBubble(util.target);

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -310,7 +310,7 @@ class Scratch3LooksBlocks {
                     this._updateBubble(target, 'say', '');
                 }
                 resolve();
-            }, MathUtil.clamp(1000 * args.SECS, 0, 2**31 - 1)); // setTimeout only supports up to 2**31 - 1
+            }, MathUtil.clamp(1000 * args.SECS, 0, (2 ** 31) - 1)); // setTimeout only supports up to 2**31 - 1
         });
     }
 
@@ -330,10 +330,10 @@ class Scratch3LooksBlocks {
                     this._updateBubble(target, 'think', '');
                 }
                 resolve();
-            }, MathUtil.clamp(1000 * args.SECS, 0, 2**31 - 1)); // setTimeout only supports up to 2**31 - 1
+            }, MathUtil.clamp(1000 * args.SECS, 0, (2 ** 31) - 1)); // setTimeout only supports up to 2**31 - 1
         });
     }
-	
+
     show (args, util) {
         util.target.setVisible(true);
         this._renderBubble(util.target);

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -310,7 +310,7 @@ class Scratch3LooksBlocks {
                     this._updateBubble(target, 'say', '');
                 }
                 resolve();
-            }, MathUtil.clamp(1000 * args.SECS, 0, (2 ** 31) - 1)); // setTimeout only supports up to 2**31 - 1
+            }, MathUtil.clamp(1000 * args.SECS, 0, Math.pow(2, 31) - 1)); // setTimeout only supports up to 2^31 - 1
         });
     }
 
@@ -330,7 +330,7 @@ class Scratch3LooksBlocks {
                     this._updateBubble(target, 'think', '');
                 }
                 resolve();
-            }, MathUtil.clamp(1000 * args.SECS, 0, (2 ** 31) - 1)); // setTimeout only supports up to 2**31 - 1
+            }, MathUtil.clamp(1000 * args.SECS, 0, Math.pow(2, 31) - 1)); // setTimeout only supports up to 2^31 - 1
         });
     }
 


### PR DESCRIPTION
### Resolves

This PR resolves #1010

### Proposed Changes

For each block definition which uses `setTimeout`, ensure that the second argument passed to that function is no greater than the largest signed 32-bit integer.

As a result, the `wait` block in the Control category and the `thinkforsecs` and `sayforsecs` blocks in the Looks category will now do their action for a very long time when passed an unreasonably large argument -- rather than instantly completing the relevant action.

### Reason for Changes

This maintains compatibility with the way Scratch 2.0 behaved.

@ericrosenbaum stated that:
> We often see kids typing in very large numbers like this.

### Test Coverage

Manually tested through dragging out the aforementioned trio of blocks and verifying that they have a ring around them for more than a few seconds. Additionally, it was verified that when small numbers (like 5) were passed, the correct amount of time was taken.

On Windows 10,
- Chrome v68
- Microsoft Edge

`npm test` was run, only warnings appeared -- and these were regarding todo comments that existed pior to this pull request's filing.

`npm run coverage` was terminated half-way through, it was not enjoying that the sprite library was missing. This was not identified as an issue that this pull request created.