### PR TITLE
round x and y like Scratch 2 does

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -272,8 +272,8 @@ class RenderedTarget extends Target {
         const oldY = this.y;
         if (this.renderer) {
             const position = this.renderer.getFencedPositionOfDrawable(this.drawableID, [x, y]);
-            position[0] = this._roundCoord(position[0], 8);
-            position[1] = this._roundCoord(position[1], 8);
+            position[0] = Math.round(position[0]);
+            position[1] = Math.round(position[1]);
             this.x = position[0];
             this.y = position[1];
 
@@ -285,8 +285,8 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         } else {
-            this.x = this._roundCoord(x, 8);
-            this.y = this._roundCoord(y, 8);
+            this.x = Math.round(x);
+            this.y = Math.round(y);
         }
         this.emit(RenderedTarget.EVENT_TARGET_MOVED, this, oldX, oldY, force);
         this.runtime.requestTargetsUpdate(this);


### PR DESCRIPTION
### Proposed Changes

Use Math.round instead of this._roundCoord.

### Reason for Changes

https://github.com/LLK/scratch-flash/blob/develop/src/scratch/ScratchSprite.as#L180-L186

Scratch 2 rounds the X and Y to the nearest whole number.

### Test Coverage

Projects like https://llk.github.io/scratch-gui/develop/#238746871 with fine lines and fractional positions needs rounded x and y values so that their lines are not offset from whole numbers. Offset lines from whole numbers in Scratch 3 render "inbetween pixels" and come out faded out or with striations.

https://scratch.mit.edu/projects/238746871/
https://llk.github.io/scratch-gui/develop/#238746871
