### PR TITLE
Regulate micro:bit send timing

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -308,7 +308,7 @@ class MicroBit {
         }
         const data = Base64Util.uint8ArrayToBase64(output);
 
-        this._ble.write(BLEUUID.service, BLEUUID.txChar, data, 'base64').then(
+        this._ble.write(BLEUUID.service, BLEUUID.txChar, data, 'base64', true).then(
             () => {
                 if (this._cachedDataToSend) {
                     // If the cache was updated while we were busy sending,

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -27,6 +27,8 @@ const BLECommand = {
 
 const BLETimeout = 4500; // TODO: might need tweaking based on how long the device takes to start sending data
 
+const BLESendInterval = 50;
+
 /**
  * Enum for micro:bit protocol.
  * https://github.com/LLK/scratch-microbit-firmware/blob/master/protocol.md
@@ -750,7 +752,11 @@ class Scratch3MicroBitBlocks {
             this._device.displayMatrix(this._device.ledMatrixState);
         }
 
-        return Promise.resolve();
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, BLESendInterval);
+        });
     }
 
     /**
@@ -762,7 +768,12 @@ class Scratch3MicroBitBlocks {
     displayText (args) {
         const text = String(args.TEXT).substring(0, 19);
         if (text.length > 0) this._device.displayText(text);
-        return Promise.resolve();
+
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, BLESendInterval);
+        });
     }
 
     /**
@@ -774,7 +785,12 @@ class Scratch3MicroBitBlocks {
             this._device.ledMatrixState[i] = 0;
         }
         this._device.displayMatrix(this._device.ledMatrixState);
-        return Promise.resolve();
+
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, BLESendInterval);
+        });
     }
 
     /**

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -27,7 +27,7 @@ const BLECommand = {
 
 const BLETimeout = 4500; // TODO: might need tweaking based on how long the device takes to start sending data
 
-const BLESendInterval = 1000;
+const BLESendInterval = 100;
 
 /**
  * Enum for micro:bit protocol.
@@ -113,7 +113,6 @@ class MicroBit {
 
         this._busy = false;
         this._cachedDataToSend = null;
-        // window.setInterval(this._sendSessionData.bind(this), BLESendInterval);
     }
 
     // TODO: keep here?
@@ -280,8 +279,11 @@ class MicroBit {
     _sendSessionData () {
         if (!this.getPeripheralIsConnected()) return;
         if (this._cachedDataToSend === null) return;
+
+        this._busy = true;
         const command = this._cachedDataToSend.command;
         const message = this._cachedDataToSend.message;
+
         const output = new Uint8Array(message.length + 1);
         output[0] = command; // attach command to beginning of message
         for (let i = 0; i < message.length; i++) {
@@ -290,7 +292,6 @@ class MicroBit {
         const data = Base64Util.uint8ArrayToBase64(output);
 
         this._cachedDataToSend = null;
-        this._busy = true;
         this._ble.write(BLEUUID.service, BLEUUID.txChar, data, 'base64').then(
             () => {
                 if (this._cachedDataToSend) {
@@ -783,12 +784,11 @@ class Scratch3MicroBitBlocks {
             this._device.displayMatrix(this._device.ledMatrixState);
         }
 
-        // return new Promise(resolve => {
-        //     setTimeout(() => {
-        //         resolve();
-        //     }, BLESendInterval);
-        // });
-        return Promise.resolve();
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, BLESendInterval);
+        });
     }
 
     /**
@@ -801,12 +801,11 @@ class Scratch3MicroBitBlocks {
         const text = String(args.TEXT).substring(0, 19);
         if (text.length > 0) this._device.displayText(text);
 
-        // return new Promise(resolve => {
-        //     setTimeout(() => {
-        //         resolve();
-        //     }, BLESendInterval);
-        // });
-        return Promise.resolve();
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, BLESendInterval);
+        });
     }
 
     /**
@@ -819,12 +818,11 @@ class Scratch3MicroBitBlocks {
         }
         this._device.displayMatrix(this._device.ledMatrixState);
 
-        // return new Promise(resolve => {
-        //     setTimeout(() => {
-        //         resolve();
-        //     }, BLESendInterval);
-        // });
-        return Promise.resolve();
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, BLESendInterval);
+        });
     }
 
     /**

--- a/src/io/bleSession.js
+++ b/src/io/bleSession.js
@@ -133,12 +133,16 @@ class BLESession extends JSONRPCWebSocket {
      * @param {number} characteristicId - the ble characteristic to write.
      * @param {string} message - the message to send.
      * @param {string} encoding - the message encoding type.
+     * @param {boolean} withResponse - if true, resolve after peripheral's response.
      * @return {Promise} - a promise from the remote send request.
      */
-    write (serviceId, characteristicId, message, encoding = null) {
+    write (serviceId, characteristicId, message, encoding = null, withResponse = null) {
         const params = {serviceId, characteristicId, message};
         if (encoding) {
             params.encoding = encoding;
+        }
+        if (withResponse) {
+            params.withResponse = withResponse;
         }
         return this.sendRemoteRequest('write', params)
             .catch(e => {


### PR DESCRIPTION
In order to prevent sending data too rapidly to the micro:bit over BLE:

- Make all display blocks yield for 100ms
- Add a "busy" flag that is set when we start sending data, and cleared when we finish
- Add a timeout to clear the busy flag if it has been true for too long (which may have occurred if a write response never came back, e.g. because the device was powered off)

Also, update BLESession with an optional `withResponse` param for Scratch Link that we set to true for micro:bit. See https://github.com/LLK/scratch-link/pull/71

- ~~Add a cache for data to send, which gets updated if a display block runs while we are busy sending. The cache gets overwritten with new data, so if it is updated multiple times, we will send only the latest data.~~
- ~~If we finish sending and the cache has been updated while we were busy, immediately send again. This prevents the need for additional timers.~~