### PR TITLE
Use round() instead of floor() in repeat

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -49,7 +49,7 @@ class Scratch3ControlBlocks {
     }
 
     repeat (args, util) {
-        const times = Math.floor(Cast.toNumber(args.TIMES));
+        const times = Math.round(Cast.toNumber(args.TIMES));
         // Initialize loop
         if (typeof util.stackFrame.loopCounter === 'undefined') {
             util.stackFrame.loopCounter = times;

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -31,6 +31,33 @@ test('repeat', t => {
     t.end();
 });
 
+test('repeat rounds with round()', t => {
+    const rt = new Runtime();
+    const c = new Control(rt);
+
+    const roundingTest = (inputForRepeat, expectedTimes) => {
+        // Test harness (mocks `util`)
+        let i = 0;
+        const util = {
+            stackFrame: Object.create(null),
+            startBranch: function () {
+                i++;
+                c.repeat({TIMES: inputForRepeat}, util);
+            }
+        };
+
+        // Execute test
+        c.repeat({TIMES: inputForRepeat}, util);
+        t.strictEqual(i, expectedTimes);
+    };
+
+    // Execute tests
+    roundingTest(3.2, 3);
+    roundingTest(3.7, 4);
+    roundingTest(3.5, 4);
+    t.end();
+});
+
 test('repeatUntil', t => {
     const rt = new Runtime();
     const c = new Control(rt);


### PR DESCRIPTION
### Resolves

Fixes #1083.

### Proposed Changes

Make the "repeat" control block round the given number of times according to `round()` (down if decimal is less than 0.5, otherwise up) instead of `floor()` (always down).

### Reason for Changes

Compatibility with Scratch 2.0.

### Test Coverage

A new unit test is added which verifies that the "repeat" block is behaving the right way. It passes, and did not pass before the `Math.floor` to `Math.round` change.