### PR TITLE
Fix issue with deleting sprite with local variables

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -852,7 +852,14 @@ class VirtualMachine extends EventEmitter {
             }
             const spritePromise = this.exportSprite(targetId, 'uint8array');
             const restoreSprite = () => spritePromise.then(spriteBuffer => this.addSprite(spriteBuffer));
+            // Remove monitors from the runtime state and remove the
+            // target-specific monitored blocks (e.g. local variables)
             this.runtime.requestRemoveMonitorByTargetId(targetId);
+            const targetSpecificMonitorBlockIds = Object.keys(this.runtime.monitorBlocks._blocks)
+                .filter(key => this.runtime.monitorBlocks._blocks[key].targetId === targetId);
+            for (const blockId of targetSpecificMonitorBlockIds) {
+                this.runtime.monitorBlocks.deleteBlock(blockId);
+            }
             const currentEditingTarget = this.editingTarget;
             for (let i = 0; i < sprite.clones.length; i++) {
                 const clone = sprite.clones[i];


### PR DESCRIPTION
### Resolves

Resolves #1470 

### Proposed Changes

Fix issue where deleting a sprite with a monitored local variable creates that local variable on all other sprites after switching sprites twice or more.

### Test Coverage

Manually tested the bug in #1470. Also tested with restoring (local variable blocks are restored correctly).