### PR TITLE
WeDo2 backwards compatibility update

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -508,11 +508,6 @@ class WeDo2 {
                 this.setLED(0x0000FF);
             })
             .then(() => {
-                // register for attached io notifications
-                // TODO: make backwards compatible with 'read':
-                // - try 'startNotifications'
-                // - then try 'read' with 'startNotifications' flag
-                // - then catch OSX and Windows errors
                 this._ble.startNotifications(UUID.DEVICE_SERVICE, UUID.ATTACHED_IO, this._onMessage);
             });
     }
@@ -622,10 +617,6 @@ class WeDo2 {
 
             this._send(UUID.INPUT_COMMAND, Base64Util.uint8ArrayToBase64(cmd))
                 .then(() => {
-                    // TODO: make backwards compatible with 'read':
-                    // - try 'startNotifications'
-                    // - then try 'read' with 'startNotifications' flag
-                    // - then catch OSX and Windows errors
                     this._ble.startNotifications(UUID.IO_SERVICE, UUID.INPUT_VALUES, this._onMessage);
                 });
         }

--- a/src/io/bleSession.js
+++ b/src/io/bleSession.js
@@ -135,12 +135,7 @@ class BLESession extends JSONRPCWebSocket {
             params.startNotifications = true;
         }
         this._characteristicDidChangeCallback = onCharacteristicChanged;
-        return this.sendRemoteRequest('read', params)
-            .catch(e => {
-                if (e.data !== 'Reading is not permitted.') { // TODO: move this error check to extension
-                    this._sendError(e);
-                }
-            });
+        return this.sendRemoteRequest('read', params);
     }
 
     /**

--- a/src/io/bleSession.js
+++ b/src/io/bleSession.js
@@ -115,7 +115,10 @@ class BLESession extends JSONRPCWebSocket {
             characteristicId
         };
         this._characteristicDidChangeCallback = onCharacteristicChanged;
-        return this.sendRemoteRequest('startNotifications', params);
+        return this.sendRemoteRequest('startNotifications', params)
+            .catch(e => {
+                this._sendError(e);
+            });
     }
 
     /**
@@ -135,7 +138,10 @@ class BLESession extends JSONRPCWebSocket {
             params.startNotifications = true;
         }
         this._characteristicDidChangeCallback = onCharacteristicChanged;
-        return this.sendRemoteRequest('read', params);
+        return this.sendRemoteRequest('read', params)
+            .catch(e => {
+                this._sendError(e);
+            });
     }
 
     /**
@@ -162,7 +168,7 @@ class BLESession extends JSONRPCWebSocket {
     }
 
     _sendError (/* e */) {
-        this._connected = false;
+        this.disconnectSession();
         // log.error(`BLESession error: ${JSON.stringify(e)}`);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR);
     }

--- a/src/io/btSession.js
+++ b/src/io/btSession.js
@@ -113,7 +113,7 @@ class BTSession extends JSONRPCWebSocket {
     }
 
     _sendError (/* e */) {
-        this._connected = false;
+        this.disconnectSession();
         // log.error(`BTSession error: ${JSON.stringify(e)}`);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR);
     }


### PR DESCRIPTION
Resolves #1492: WeDo2 use of `startNotifications` should be backwards compatible

- No longer going to try to make WeDo2 compatible with Scratch Link API 1.0
- **When using Scratch Link API 1.0**: shows an error modal and disconnects the BLE session
- **When using Scratch Link API 1.1**: works as expected