### PR TITLE
Rate-limiting with a token bucket for the WeDo extension

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -364,7 +364,7 @@ class WeDo2 {
          * @type {RateLimiter}
          * @private
          */
-        this._rateLimiter = new RateLimiter(30);
+        this._rateLimiter = new RateLimiter(20);
     }
 
     /**

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -358,6 +358,12 @@ class WeDo2 {
         this._onConnect = this._onConnect.bind(this);
         this._onMessage = this._onMessage.bind(this);
 
+        /**
+         * A rate limiter utility, to help limit the rate at which we send BLE messages
+         * over the socket to Scratch Link to a maximum number of sends per second.
+         * @type {RateLimiter}
+         * @private
+         */
         this._rateLimiter = new RateLimiter(30);
     }
 

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -32,6 +32,12 @@ const UUID = {
 const BLESendInterval = 100;
 
 /**
+ * A maximum number of BLE message sends per second, to be enforced by the rate limiter.
+ * @type {number}
+ */
+const BLESendRateMax = 20;
+
+/**
  * Enum for WeDo2 sensor and output types.
  * @readonly
  * @enum {number}
@@ -364,7 +370,7 @@ class WeDo2 {
          * @type {RateLimiter}
          * @private
          */
-        this._rateLimiter = new RateLimiter(20);
+        this._rateLimiter = new RateLimiter(BLESendRateMax);
     }
 
     /**

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -396,7 +396,7 @@ class WeDo2 {
      */
     stopAllMotors () {
         this._motors.forEach(motor => {
-            if (motor && motor.isOn) {
+            if (motor) {
                 motor.setMotorOff();
             }
         });

--- a/src/util/rateLimiter.js
+++ b/src/util/rateLimiter.js
@@ -1,0 +1,74 @@
+const Timer = require('../util/timer');
+
+class RateLimiter {
+    /**
+     * A utility for limiting the rate of repetitive send operations, such as
+     * bluetooth messages being sent to hardware devices. It uses the token bucket
+     * strategy: a counter accumulates tokens at a steady rate, and each send costs
+     * a token. If no tokens remain, it's not okay to send.
+     * @param {number} maxRate the maximum number of sends allowed per second
+     * @constructor
+     */
+    constructor (maxRate) {
+        /**
+         * The maximum number of tokens.
+         * @type {number}
+         */
+        this._maxTokens = maxRate;
+
+        /**
+         * The interval in milliseconds for refilling one token. It is calculated
+         * so that the tokens will be filled to maximum in one second.
+         * @type {number}
+         */
+        this._refillInterval = 1000 / maxRate;
+
+        /**
+         * The current number of tokens in the bucket.
+         * @type {number}
+         */
+        this._count = this._maxTokens;
+
+
+        this._timer = new Timer();
+        this._timer.start();
+
+        /**
+         * The last time in milliseconds when the token count was updated.
+         * @type {number}
+         */
+        this._lastUpdateTime = this._timer.timeElapsed();
+    }
+
+    /**
+     * Check if it is okay to send a message, by updating the token count,
+     * taking a token and then checking if we are still under the rate limit.
+     * @return {boolean} true if we are under the rate limit
+     */
+    okayToSend () {
+        // Calculate the number of tokens to refill the bucket with, based on the
+        // amount of time since the last refill.
+        const now = this._timer.timeElapsed();
+        const timeSinceRefill = now - this._lastUpdateTime;
+        const refillCount = Math.floor(timeSinceRefill / this._refillInterval);
+
+        // If we're adding at least one token, reset _lastUpdateTime to now.
+        // Otherwise, don't reset it so that we can continue measuring time until
+        // the next refill.
+        if (refillCount > 0) {
+            this._lastUpdateTime = now;
+        }
+
+        // Refill the tokens up to the maximum
+        this._count = Math.min(this._maxTokens, this._count + refillCount);
+
+        // If we have at least one token, use one, and it's okay to send.
+        if (this._count > 0) {
+            this._count--;
+            return true;
+        }
+        return false;
+    }
+}
+
+module.exports = RateLimiter;

--- a/src/util/rateLimiter.js
+++ b/src/util/rateLimiter.js
@@ -29,7 +29,6 @@ class RateLimiter {
          */
         this._count = this._maxTokens;
 
-
         this._timer = new Timer();
         this._timer.start();
 

--- a/test/unit/util_rateLimiter.js
+++ b/test/unit/util_rateLimiter.js
@@ -2,24 +2,31 @@ const test = require('tap').test;
 const RateLimiter = require('../../src/util/rateLimiter.js');
 
 test('rate limiter', t => {
+    // Create a rate limiter with maximum of 30 sends per second
     const rate = 30;
     const limiter = new RateLimiter(rate);
+
+    // Simulate time passing with a stubbed timer
+    let simulatedTime = Date.now();
+    limiter._timer = {timeElapsed: () => simulatedTime};
 
     // The rate limiter starts with a number of tokens equal to the max rate
     t.equal(limiter._count, rate);
 
-    // Running okayToSend rate times uses up all of the tokens
+    // Running okayToSend a number of times equal to the max rate
+    // uses up all of the tokens
     for (let i = 0; i < rate; i++) {
         t.true(limiter.okayToSend());
+        // Tokens are counting down
         t.equal(limiter._count, rate - (i + 1));
     }
     t.false(limiter.okayToSend());
 
-    // After a delay of one second divided by the max rate, we should have exactly
-    // one more token to use.
-    setTimeout(() => {
-        t.true(limiter.okayToSend());
-        t.false(limiter.okayToSend());
-        t.end();
-    }, 1000 / rate);
+    // Advance the timer enough so we get exactly one more token
+    // One extra millisecond is required to get over the threshold
+    simulatedTime += (1000 / rate) + 1;
+    t.true(limiter.okayToSend());
+    t.false(limiter.okayToSend());
+
+    t.end();
 });

--- a/test/unit/util_rateLimiter.js
+++ b/test/unit/util_rateLimiter.js
@@ -2,8 +2,8 @@ const test = require('tap').test;
 const RateLimiter = require('../../src/util/rateLimiter.js');
 
 test('rate limiter', t => {
-    // Create a rate limiter with maximum of 30 sends per second
-    const rate = 30;
+    // Create a rate limiter with maximum of 20 sends per second
+    const rate = 20;
     const limiter = new RateLimiter(rate);
 
     // Simulate time passing with a stubbed timer

--- a/test/unit/util_rateLimiter.js
+++ b/test/unit/util_rateLimiter.js
@@ -1,0 +1,18 @@
+const test = require('tap').test;
+const RateLimiter = require('../../src/util/rateLimiter.js');
+
+test('limit', t => {
+    const rate = 30;
+    const limiter = new RateLimiter(rate);
+    t.equal(limiter.getCount(), rate);
+    for (let i = 0; i < rate; i++) {
+        t.true(limiter.check());
+        t.equal(limiter.getCount(), rate - (i + 1));
+    }
+    t.false(limiter.check());
+    setTimeout(() => {
+        t.true(limiter.check());
+        t.false(limiter.check());
+        t.end();
+    }, 1000 / rate);
+});

--- a/test/unit/util_rateLimiter.js
+++ b/test/unit/util_rateLimiter.js
@@ -1,18 +1,25 @@
 const test = require('tap').test;
 const RateLimiter = require('../../src/util/rateLimiter.js');
 
-test('limit', t => {
+test('rate limiter', t => {
     const rate = 30;
     const limiter = new RateLimiter(rate);
-    t.equal(limiter.getCount(), rate);
+
+    // The rate limiter starts with a number of tokens equal to the max rate
+    t.equal(limiter._count, rate);
+
+    // Running okayToSend rate times uses up all of the tokens
     for (let i = 0; i < rate; i++) {
-        t.true(limiter.check());
-        t.equal(limiter.getCount(), rate - (i + 1));
+        t.true(limiter.okayToSend());
+        t.equal(limiter._count, rate - (i + 1));
     }
-    t.false(limiter.check());
+    t.false(limiter.okayToSend());
+
+    // After a delay of one second divided by the max rate, we should have exactly
+    // one more token to use.
     setTimeout(() => {
-        t.true(limiter.check());
-        t.false(limiter.check());
+        t.true(limiter.okayToSend());
+        t.false(limiter.okayToSend());
         t.end();
     }, 1000 / rate);
 });


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-vm/issues/1531
Resolves https://github.com/LLK/scratch-vm/issues/1523

Previously, the WeDo extension used a simple rate limiting strategy that would drop any messages while it was currently sending. This approach caused the bugs in the issues above. 

This PR adds a rateLimiter utility that uses the [token bucket](https://en.wikipedia.org/wiki/Token_bucket) strategy. It limits sends to 30 per second. A counter accumulates tokens at the rate of 30 per second, and each send costs a token. If no tokens remain, the message is dropped.

The WeDo blocks that send messages all yield for 100ms, so a forever loop with a "set light color" in it for example is sending about 10 messages per second. With three or more such loops running in parallel, we will start to drop messages. Because of the limitations of the WeDo, this seems like enough bandwidth. 

It's possible to create lots of clones that all have forever loops with sending blocks, resulting in thousands of sends per second:

![screen shot 2018-08-28 at 6 13 37 pm](https://user-images.githubusercontent.com/567844/44754205-ed00ef80-aaee-11e8-8eeb-292fdaa3537f.png)

This change protects against problems caused by this clone-sending-apocalypse situation (such as messages queuing up and running on the WeDo for a tens of seconds after the Scratch code has stopped). 

This PR also fixes an issue that was revealed by these changes: When you run fast-sending code with clones as shown above, and also turn on a motor, pressing the stop button would result in the code stopping, but the motor never getting turned off. Pressing the stop button additional times would still not stop it. This is because the initial stop button press, during the fast-sends, tried to send a motor off command that was dropped, but it nonetheless updated the internal motor state to off; later stop button presses would check the motor state, and not send the motor off command... So I just removed the check for motor.isOn, since we can safely send a motor off command to a motor that is off.

**Testing**
- [x] Mac Chrome
- [x] Mac Firefox
- [x] Mac Safari
- [x] Windows Chrome
- [x] Windows Edge
- [x] Windows Firefox