### PR TITLE
Trim input to 128 chars

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -286,7 +286,7 @@ class Scratch3SpeakBlocks {
      */
     speakAndWait (args, util) {
         // Cast input to string
-        let words = Cast.toString(args.WORDS);
+        let words = Cast.toString(args.WORDS).substring(0, 128);
 
         const state = this._getState(util.target);
 


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/1535

### Proposed Changes

Trims text in text2speech blocks to be able to successfully be sent to the server

### Reason for Changes

It was an issue created by @ericrosenbaum 

### Test Coverage

Could not find any tests for text2speech blocks