### PR TITLE
Extension monitors

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -745,6 +745,9 @@ class Runtime extends EventEmitter {
         case BlockType.REPORTER:
             blockJSON.output = 'String'; // TODO: distinguish number & string here?
             blockJSON.outputShape = ScratchBlocksConstants.OUTPUT_SHAPE_ROUND;
+            if (!blockInfo.disableMonitor) {
+                blockJSON.checkboxInFlyout = true;
+            }
             break;
         case BlockType.BOOLEAN:
             blockJSON.output = 'Boolean';

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1828,6 +1828,31 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Get the label or label function for an opcode
+     * @param {string} extendedOpcode - the opcode you want a label for
+     * @return {object} - object with label and category
+     * @property {string} category - the category for this opcode
+     * @property {Function} [labelFn] - function to generate the label for this opcode
+     * @property {string} [label] - the label for this opcode if `labelFn` is absent
+     */
+    getLabelForOpcode (extendedOpcode) {
+        const [category, opcode] = extendedOpcode.split('_');
+        if (!(category && opcode)) return;
+
+        const categoryInfo = this._blockInfo.find(ci => ci.id === category);
+        if (!categoryInfo) return;
+
+        const block = categoryInfo.blocks.find(b => b.info.opcode === opcode);
+        if (!block) return;
+
+        // TODO: should this use some other category? Also, we may want to format the label in a locale-specific way.
+        return {
+            category: 'data',
+            label: `${categoryInfo.name}: ${block.info.text}`
+        };
+    }
+
+    /**
      * Create a new global variable avoiding conflicts with other variable names.
      * @param {string} variableName The desired variable name for the new global variable.
      * This can be turned into a fresh name as necessary.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -745,9 +745,6 @@ class Runtime extends EventEmitter {
         case BlockType.REPORTER:
             blockJSON.output = 'String'; // TODO: distinguish number & string here?
             blockJSON.outputShape = ScratchBlocksConstants.OUTPUT_SHAPE_ROUND;
-            if (!blockInfo.disableMonitor) {
-                blockJSON.checkboxInFlyout = true;
-            }
             break;
         case BlockType.BOOLEAN:
             blockJSON.output = 'Boolean';
@@ -805,8 +802,12 @@ class Runtime extends EventEmitter {
             }
         }
 
-        // Add icon to the bottom right of a loop block
-        if (blockInfo.blockType === BlockType.LOOP) {
+        if (blockInfo.blockType === BlockType.REPORTER) {
+            if (!blockInfo.disableMonitor && context.inputList.length === 0) {
+                blockJSON.checkboxInFlyout = true;
+            }
+        } else if (blockInfo.blockType === BlockType.LOOP) {
+            // Add icon to the bottom right of a loop block
             blockJSON[`lastDummyAlign${outLineNum}`] = 'RIGHT';
             blockJSON[`message${outLineNum}`] = '%1';
             blockJSON[`args${outLineNum}`] = [{

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1837,7 +1837,7 @@ class Runtime extends EventEmitter {
      * @property {string} [label] - the label for this opcode if `labelFn` is absent
      */
     getLabelForOpcode (extendedOpcode) {
-        const [category, opcode] = extendedOpcode.split('_');
+        const [category, opcode] = StringUtil.splitFirst(extendedOpcode, '_');
         if (!(category && opcode)) return;
 
         const categoryInfo = this._blockInfo.find(ci => ci.id === category);

--- a/src/extension-support/extension-metadata.js
+++ b/src/extension-support/extension-metadata.js
@@ -19,6 +19,7 @@
  * @property {string} text - the text on the block, with [PLACEHOLDERS] for arguments.
  * @property {Boolean} [hideFromPalette] - true if this block should not appear in the block palette.
  * @property {Boolean} [isTerminal] - true if the block ends a stack - no blocks can be connected after it.
+ * @property {Boolean} [disableMonitor] - true if this block is a reporter but should not allow a monitor.
  * @property {ReporterScope} [reporterScope] - if this block is a reporter, this is the scope/context for its value.
  * @property {Boolean} [isEdgeActivated] - sets whether a hat block is edge-activated.
  * @property {Boolean} [shouldRestartExistingThreads] - sets whether a hat/event block should restart existing threads.

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -50,7 +50,7 @@ test('monitorStateDoesNotEqual', t => {
     });
     r.requestAddMonitor(prevMonitorState);
     r.requestUpdateMonitor(newMonitorDelta);
-    
+
     t.equals(false, prevMonitorState.equals(r._monitorState.get(id)));
     t.equals(String(24), r._monitorState.get(id).get('value'));
 
@@ -64,6 +64,47 @@ test('monitorStateDoesNotEqual', t => {
     t.equals(false, prevMonitorState.equals(r._monitorState.get(id)));
     t.equals(String(24), r._monitorState.get(id).value);
     t.equals(params, r._monitorState.get(id).params);
+
+    t.end();
+});
+
+test('getLabelForOpcode', t => {
+    const r = new Runtime();
+
+    const fakeExtension = {
+        id: 'fakeExtension',
+        name: 'Fake Extension',
+        blocks: [
+            {
+                info: {
+                    opcode: 'foo',
+                    json: {},
+                    text: 'Foo',
+                    xml: ''
+                }
+            },
+            {
+                info: {
+                    opcode: 'foo_2',
+                    json: {},
+                    text: 'Foo 2',
+                    xml: ''
+                }
+            }
+        ]
+    };
+
+    r._blockInfo.push(fakeExtension);
+
+    const result1 = r.getLabelForOpcode('fakeExtension_foo');
+    t.type(result1.category, 'string');
+    t.type(result1.label, 'string');
+    t.equals(result1.label, 'Fake Extension: Foo');
+
+    const result2 = r.getLabelForOpcode('fakeExtension_foo_2');
+    t.type(result2.category, 'string');
+    t.type(result2.label, 'string');
+    t.equals(result2.label, 'Fake Extension: Foo 2');
 
     t.end();
 });


### PR DESCRIPTION
### Resolves

Along with LLK/scratch-gui#3099, this resolves #693 

### Proposed Changes

1. Extension reporters which have no block arguments will get a checkbox in the flyout so the user may enable monitoring of that reporter, unless the extension sets the `disableMonitor` flag for the block.
2. The runtime now has a helper method to determine a user-friendly label for any block registered through the extension system. This is similar to the `OpcodeLabels` function in the `scratch-gui`.

### Reason for Changes

The `OpcodeLabels` function in the GUI currently hard-codes all non-trivial cases. We can't do that for extensions, and the GUI ~doesn't~ shouldn't have direct access to extension block metadata anyway, so instead it delegates calculation of the label to the VM's runtime.
