### PR TITLE
Trim text2speech string to 128 chars

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -331,7 +331,7 @@ class Scratch3SpeakBlocks {
         let path = `${SERVER_HOST}/synth`;
         path += `?locale=${locale}`;
         path += `&gender=${gender}`;
-        path += `&text=${encodeURI(words)}`;
+        path += `&text=${encodeURI(words.substring(0, 128))}`;
 
         // Perform HTTP request to get audio file
         return new Promise(resolve => {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1535

### Proposed Changes

Trim the string we send to the text2speech server to 128 characters max.

### Reason for Changes

Strings over 128 characters long are ignored by the server.