### PR TITLE
Limit answer length

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -45,6 +45,14 @@ class Scratch3SensingBlocks {
     }
 
     /**
+     * The limit of askAndWait answer.
+     * @const {number}
+     */
+    static get ANSWER_LIMIT () {
+        return 400;
+    }
+
+    /**
      * Retrieve the block primitives implemented by this package.
      * @return {object.<string, Function>} Mapping of opcode to Function.
      */
@@ -94,7 +102,8 @@ class Scratch3SensingBlocks {
     }
 
     _onAnswer (answer) {
-        this._answer = answer;
+        const answerLimit = Scratch3SensingBlocks.ANSWER_LIMIT;
+        this._answer = answer.substr(0, answerLimit);
         const questionObj = this._questionList.shift();
         if (questionObj) {
             const [_question, resolve, target, wasVisible, wasStage] = questionObj;


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-gui#3112

### Proposed Changes
Clamp askAndWait answers to 400 letters

### Reason for Changes
Long string can make Scratch buggy

### Test Coverage
Tested manually on Windows 7 HomePremium 64bit SP1, Firefox 62 via
```
ask [foo] and wait
(answer "hello"*210 = 1050 letters)
say (length of (answer))
```
This returns 400 while current one returns 1050
