### PR TITLE
Fx ids and names for text2speech and speech2text extensions

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -14,7 +14,7 @@ const Scratch3MicroBitBlocks = require('../extensions/scratch3_microbit');
 const Scratch3Text2SpeechBlocks = require('../extensions/scratch3_text2speech');
 const Scratch3TranslateBlocks = require('../extensions/scratch3_translate');
 const Scratch3VideoSensingBlocks = require('../extensions/scratch3_video_sensing');
-const Scratch3SpeechBlocks = require('../extensions/scratch3_speech');
+const Scratch3Speech2TextBlocks = require('../extensions/scratch3_speech2text');
 const Scratch3Ev3Blocks = require('../extensions/scratch3_ev3');
 
 const builtinExtensions = {
@@ -25,7 +25,7 @@ const builtinExtensions = {
     text2speech: Scratch3Text2SpeechBlocks,
     translate: Scratch3TranslateBlocks,
     videoSensing: Scratch3VideoSensingBlocks,
-    speech: Scratch3SpeechBlocks,
+    speech2text: Scratch3Speech2TextBlocks,
     ev3: Scratch3Ev3Blocks
 };
 

--- a/src/extensions/scratch3_speech2text/index.js
+++ b/src/extensions/scratch3_speech2text/index.js
@@ -45,7 +45,7 @@ const finalResponseTimeoutDurationMs = 3000;
 const listenAndWaitBlockTimeoutMs = 10000;
 
 
-class Scratch3SpeechBlocks {
+class Scratch3Speech2TextBlocks {
     constructor (runtime) {
         /**
          * The runtime instantiating this block package.
@@ -278,7 +278,7 @@ class Scratch3SpeechBlocks {
         // Give it a couple seconds to response before giving up and assuming nothing else will come back.
         this._speechFinalResponseTimeout = setTimeout(this._resetListening, finalResponseTimeoutDurationMs);
     }
-    
+
     /**
      * Decides whether to keep a given transcirption result.
      * @param {number} fuzzyMatchIndex Index of the fuzzy match or -1 if there is no match.
@@ -369,7 +369,7 @@ class Scratch3SpeechBlocks {
     _processTranscriptionResult (result) {
         log.info(`Got result: ${JSON.stringify(result)}`);
         const transcriptionResult = this._normalizeText(result.alternatives[0].transcript);
-  
+
         // Waiting for an exact match is not satisfying.  It makes it hard to catch
         // things like homonyms or things that sound similar "let us" vs "lettuce".  Using the fuzzy matching helps
         // more aggressively match the phrases that are in the "When I hear" hat blocks.
@@ -387,7 +387,7 @@ class Scratch3SpeechBlocks {
 
         // We're done listening so resolove all the promises and reset everying so we're ready for next time.
         this._resetListening();
-        
+
         // We got results so clear out the timeouts.
         if (this._speechTimeoutId) {
             clearTimeout(this._speechTimeoutId);
@@ -416,7 +416,7 @@ class Scratch3SpeechBlocks {
         this._processTranscriptionResult(result);
     }
 
-  
+
     /**
      * Decide whether the pattern given matches the text. Uses fuzzy matching
      * @param {string} pattern The pattern to look for.  Usually this is the transcription result
@@ -598,10 +598,10 @@ class Scratch3SpeechBlocks {
      */
     getInfo () {
         return {
-            id: 'speech',
+            id: 'speech2text',
             name: formatMessage({
                 id: 'speech.extensionName',
-                default: 'Google Speech',
+                default: 'Speech to Text',
                 description: 'Name of extension that adds speech recognition blocks. Do Not translate Google.'
             }),
             menuIconURI: menuIconURI,
@@ -657,7 +657,7 @@ class Scratch3SpeechBlocks {
     listenAndWait () {
         this._phraseList = this._scanBlocksForPhraseList();
         this._resetEdgeTriggerUtterance();
-        
+
         const speechPromise = new Promise(resolve => {
             const listeningInProgress = this._speechPromises.length > 0;
             this._speechPromises.push(resolve);
@@ -685,4 +685,4 @@ class Scratch3SpeechBlocks {
         return this._currentUtterance;
     }
 }
-module.exports = Scratch3SpeechBlocks;
+module.exports = Scratch3Speech2TextBlocks;

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -54,7 +54,7 @@ const KITTEN_ID = 'KITTEN';
  * Class for the text2speech blocks.
  * @constructor
  */
-class Scratch3SpeakBlocks {
+class Scratch3Text2SpeechBlocks {
     constructor (runtime) {
         /**
          * The runtime instantiating this block package.
@@ -156,10 +156,10 @@ class Scratch3SpeakBlocks {
      * @private
      */
     _getState (target) {
-        let state = target.getCustomState(Scratch3SpeakBlocks.STATE_KEY);
+        let state = target.getCustomState(Scratch3Text2SpeechBlocks.STATE_KEY);
         if (!state) {
-            state = Clone.simple(Scratch3SpeakBlocks.DEFAULT_TEXT2SPEECH_STATE);
-            target.setCustomState(Scratch3SpeakBlocks.STATE_KEY, state);
+            state = Clone.simple(Scratch3Text2SpeechBlocks.DEFAULT_TEXT2SPEECH_STATE);
+            target.setCustomState(Scratch3Text2SpeechBlocks.STATE_KEY, state);
         }
         return state;
     }
@@ -173,9 +173,9 @@ class Scratch3SpeakBlocks {
      */
     _onTargetCreated (newTarget, sourceTarget) {
         if (sourceTarget) {
-            const state = sourceTarget.getCustomState(Scratch3SpeakBlocks.STATE_KEY);
+            const state = sourceTarget.getCustomState(Scratch3Text2SpeechBlocks.STATE_KEY);
             if (state) {
-                newTarget.setCustomState(Scratch3SpeakBlocks.STATE_KEY, Clone.simple(state));
+                newTarget.setCustomState(Scratch3Text2SpeechBlocks.STATE_KEY, Clone.simple(state));
             }
         }
     }
@@ -186,7 +186,7 @@ class Scratch3SpeakBlocks {
     getInfo () {
         return {
             id: 'text2speech',
-            name: 'Text-to-Speech',
+            name: 'Text to Speech',
             menuIconURI: '', // @todo Add the final icons.
             blockIconURI: '',
             blocks: [
@@ -352,4 +352,4 @@ class Scratch3SpeakBlocks {
         });
     }
 }
-module.exports = Scratch3SpeakBlocks;
+module.exports = Scratch3Text2SpeechBlocks;


### PR DESCRIPTION
For speech2text:
- Change extension object name to Scratch3Speech2TextBlocks
- Change extension ID to speech2text
- Change extension name to "Speech to Text"

For text2Speech:
- Change extension object name to Scratch3Text2SpeechBlocks
- Change extension name to "Text to Speech"