### PR TITLE
Bubble string length limit

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -59,6 +59,14 @@ class Scratch3LooksBlocks {
     }
 
     /**
+     * Limit for say bubble string.
+     * @const {string}
+     */
+    static get SAY_BUBBLE_LIMIT () {
+        return 330;
+    }
+
+    /**
      * @param {Target} target - collect bubble state for this target. Probably, but not necessarily, a RenderedTarget.
      * @returns {BubbleState} the mutable bubble state associated with that target. This will be created if necessary.
      * @private
@@ -278,7 +286,7 @@ class Scratch3LooksBlocks {
         if (typeof message === 'number') {
             message = parseFloat(message.toFixed(2));
         }
-        message = String(message);
+        message = String(message).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT);
         this.runtime.emit('SAY', util.target, 'say', message);
     }
 
@@ -299,7 +307,7 @@ class Scratch3LooksBlocks {
     }
 
     think (args, util) {
-        this._updateBubble(util.target, 'think', String(args.MESSAGE));
+        this._updateBubble(util.target, 'think', String(args.MESSAGE).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT));
     }
 
     thinkforsecs (args, util) {


### PR DESCRIPTION
### Resolves
Fixes LLK/scratch-gui#3112

### Proposed Changes
Strings passed to say or think blocks have length limit now.

### Reason for Changes
Not to show long strings and make the screen ugly.

In Scratch 2, normal stage mode, strings with more than 330 charactors will always overflow, so I choose 330. However, you can make it lower.
