### PR TITLE
Decode at-mark and backslash ( #1307 )

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -1061,7 +1061,8 @@ const parseBlock = function (sb2block, addBroadcastMsg, getVariableId, extension
             children: [],
             mutation: {
                 tagName: 'mutation',
-                proccode: procData[0].replace(/\\@/g, '@').replace(/\\\\/g, '\\'), // e.g., "abc %n %b %s"
+                proccode: procData[0].replace(/\\@/g, '@').replace(/\\\\/g, '\\')
+                    .replace(/\\%/g, '％'), // e.g., "abc %n %b %s" @todo: It uses fullwidth percent!
                 argumentnames: JSON.stringify(procData[1]), // e.g. ['arg1', 'arg2']
                 argumentids: JSON.stringify(parseProcedureArgIds(procData[0])),
                 argumentdefaults: JSON.stringify(procData[2]), // e.g., [1, 'abc']

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -1061,7 +1061,7 @@ const parseBlock = function (sb2block, addBroadcastMsg, getVariableId, extension
             children: [],
             mutation: {
                 tagName: 'mutation',
-                proccode: procData[0], // e.g., "abc %n %b %s"
+                proccode: procData[0].replace(/\\@/g, '@').replace(/\\\\/g, '\\'), // e.g., "abc %n %b %s"
                 argumentnames: JSON.stringify(procData[1]), // e.g. ['arg1', 'arg2']
                 argumentids: JSON.stringify(parseProcedureArgIds(procData[0])),
                 argumentdefaults: JSON.stringify(procData[2]), // e.g., [1, 'abc']

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -1061,8 +1061,8 @@ const parseBlock = function (sb2block, addBroadcastMsg, getVariableId, extension
             children: [],
             mutation: {
                 tagName: 'mutation',
-                proccode: procData[0].replace(/\\@/g, '@').replace(/\\\\/g, '\\')
-                    .replace(/\\%/g, '％'), // e.g., "abc %n %b %s" @todo: It uses fullwidth percent!
+                proccode: procData[0].replace(/\\%/g, '％').replace(/\\(.)/g, '$1'),
+                // e.g., "abc %n %b %s" @todo: It uses fullwidth percent!
                 argumentnames: JSON.stringify(procData[1]), // e.g. ['arg1', 'arg2']
                 argumentids: JSON.stringify(parseProcedureArgIds(procData[0])),
                 argumentdefaults: JSON.stringify(procData[2]), // e.g., [1, 'abc']


### PR DESCRIPTION
### Resolves
Fixes #1307 

### Proposed Changes
Decode `\\@` and `\\\\` using regex and replace. The issue didn't contain the backslash one, but I also found that, so it contains fix for that.

### Reason for Changes
Not to change custom block name.

### Test Coverage
https://scratch.mit.edu/projects/246543955/
This project has 2 custom blocks named `@atmark@` and `\backslash\`

Tested using above with Windows 7, Firefox 62 and Chrome 68