### PR TITLE
Fix locale-dependant string comparison operators to match 2.0

### DIFF
--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -118,7 +118,13 @@ class Cast {
             // Scratch compares strings as case insensitive.
             const s1 = String(v1).toLowerCase();
             const s2 = String(v2).toLowerCase();
-            return s1.localeCompare(s2);
+            if(s1 < s2) {
+                return -1
+            } else if (s1 > s2) {
+                return 1
+            } else {
+                return 0
+            }
         }
         // Compare as numbers.
         return n1 - n2;

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -118,13 +118,12 @@ class Cast {
             // Scratch compares strings as case insensitive.
             const s1 = String(v1).toLowerCase();
             const s2 = String(v2).toLowerCase();
-            if(s1 < s2) {
-                return -1
+            if (s1 < s2) {
+                return -1;
             } else if (s1 > s2) {
-                return 1
-            } else {
-                return 0
+                return 1;
             }
+            return 0;
         }
         // Compare as numbers.
         return n1 - n2;

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -37,6 +37,8 @@ test('lt', t => {
     t.strictEqual(blocks.lt({OPERAND1: '1', OPERAND2: '2'}), true);
     t.strictEqual(blocks.lt({OPERAND1: '2', OPERAND2: '1'}), false);
     t.strictEqual(blocks.lt({OPERAND1: '1', OPERAND2: '1'}), false);
+    t.strictEqual(blocks.lt({OPERAND1: '10', OPERAND2: '2'}), false);
+    t.strcitEqual(blocks.lt({OPERAND1: 'a', OPERAND2: 'z'}), true);
     t.end();
 });
 

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -38,7 +38,7 @@ test('lt', t => {
     t.strictEqual(blocks.lt({OPERAND1: '2', OPERAND2: '1'}), false);
     t.strictEqual(blocks.lt({OPERAND1: '1', OPERAND2: '1'}), false);
     t.strictEqual(blocks.lt({OPERAND1: '10', OPERAND2: '2'}), false);
-    t.strcitEqual(blocks.lt({OPERAND1: 'a', OPERAND2: 'z'}), true);
+    t.strictEqual(blocks.lt({OPERAND1: 'a', OPERAND2: 'z'}), true);
     t.end();
 });
 

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -46,6 +46,7 @@ test('equals', t => {
     t.strictEqual(blocks.equals({OPERAND1: '1', OPERAND2: '2'}), false);
     t.strictEqual(blocks.equals({OPERAND1: '2', OPERAND2: '1'}), false);
     t.strictEqual(blocks.equals({OPERAND1: '1', OPERAND2: '1'}), true);
+    t.strictEqual(blocks.equals({OPERAND1: 'あ', OPERAND2: 'ア'}), false);
     t.end();
 });
 


### PR DESCRIPTION
### Resolves

Resolves #1526

### Proposed Changes

Stop using the deceivingly similar `String.prototype.localeCompare`, as used in scratch-flash, because it behaves differently and inconsistently depending on the host environment, as specified by the ECMAScript specification.

Inconsistency is suboptimal -- it makes debugging for Scratchers hard. In addition, we cannot know what the Scratcher was trying to do: they might've _wanted_ to use a bitwise comparison (and if they didn't, we can't know which locale they wanted to use). Finally, locale-dependant outputs to blocks allows projects to selectively show harassing messages like 'I don't like people from country X'.

### Reason for Changes

scratch-flash used `s1.localeCompare(s2)`
scratch-vm was using `s1.localeCompare(s2)`

Despite them both being ECMAScript variants, the specification reads:

> The two Strings are compared in an implementation-defined fashion.

These implementations should take into account the locale.

> If no language-sensitive comparison at all is available from the host environment, this function may perform a bitwise comparison.

Browsers do take into account the user locale; but according to Adobe's documentation for ActionScript 3.0, it appears Flash always performs bit-wise comparisons.

> While this method is intended to handle the comparison in a locale-specific way, the ActionScript 3.0 implementation does not produce a different result from other string comparisons such as the equality (==) or inequality (!=) operators.

Since the two behave differently, serious backwards-compatibility issues were being filed, where equality wasn't working correctly. Therefore, the `compare()` function is modified such that it uses bitwise comparisons.

### Test Coverage

I added a couple of tests that passed before anyway, just to make sure in the future things don't change. **I wasn't sure how to test for this issue, because I need to set the locale of the host environment. Is this possible with the testing tool?** Manual tests were performed, these were:
- [X] a < z (true)
- [X] z < a (false)
- [X] b = b (true)
- [X] あ = ア (false) in the Japanese locale
- [X] "a" with an umlaut < "z" (same result in 2.0 and 3.0) -- adding to the case that they are bitwise comparisons
- [X] "abc" < "acb" (true) 

Resource for changing Firefox's language: https://support.mozilla.org/en-US/kb/use-firefox-interface-other-languages-language-pack