### PR TITLE
Rename block "display [Hello!]" to "display text [Hello!]"

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -620,7 +620,7 @@ class Scratch3MicroBitBlocks {
                     opcode: 'displayText',
                     text: formatMessage({
                         id: 'microbit.displayText',
-                        default: 'display [TEXT]',
+                        default: 'display text [TEXT]',
                         description: 'display text on the micro:bit display'
                     }),
                     blockType: BlockType.COMMAND,


### PR DESCRIPTION
### Resolves

Issue #1338, micro:bit extension identical display blocks

### Proposed Changes

Rename `display [Hello!]` block to `display text [Hello!]`

![image](https://user-images.githubusercontent.com/1169507/45761923-3ed2fc00-bbfb-11e8-8335-738cfde4a72d.png)


### Reason for Changes

Avoids potential confusion when a block is dropped onto the input field of the `display [♡]` and `display [Hello!]` blocks.

![image](https://user-images.githubusercontent.com/1169507/45761764-de43bf00-bbfa-11e8-9ba5-a69ca2b56d39.png)
