### PR TITLE
Trim whitespace in "display [♡]" input field

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -783,7 +783,7 @@ class Scratch3MicroBitBlocks {
      * @return {Promise} - a Promise that resolves after a tick.
      */
     displaySymbol (args) {
-        const symbol = cast.toString(args.MATRIX);
+        const symbol = cast.toString(args.MATRIX).replace(/\s/g, '');
         const reducer = (accumulator, c, index) => {
             const value = (c === '0') ? accumulator : accumulator + Math.pow(2, index);
             return value;


### PR DESCRIPTION
### Resolves

Issue #1339, Trim whitespace in micro:bit display matrix block

### Proposed Changes

Use `.replace(/\s/g, '')` to remove all whitespace from the `display [♡]` input field.

### Reason for Changes

This change makes it easy to use a variable list for maintaining the state of the LED matrix. 

#### List of 5 items, 1 for each row:
![image](https://user-images.githubusercontent.com/1169507/45763842-63c96e00-bbff-11e8-88ec-a017b11abe0f.png)
![image](https://user-images.githubusercontent.com/1169507/45763870-7348b700-bbff-11e8-948b-c35c928c9604.png)

#### List of 25 items, 1 for each LED
![image](https://user-images.githubusercontent.com/1169507/45763890-7f347900-bbff-11e8-8725-b62b87b1adfd.png)
![image](https://user-images.githubusercontent.com/1169507/45763900-865b8700-bbff-11e8-8601-c87e9f4ff568.png)

