### PR TITLE
Make "display [Hello!] block yield until printing is done

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -812,16 +812,18 @@ class Scratch3MicroBitBlocks {
      * Note the limit is 19 characters
      * The print time is calculated by multiplying the number of horizontal pixels
      * by the default scroll delay of 120ms.
-     * # of horizontal pixels = 5 + 1 for each char with an additional 1px spacer.
+     * The number of horizontal pixels = 6px for each character in the string,
+     * 1px before the string, and 2px after the string.
      */
     displayText (args) {
         const text = String(args.TEXT).substring(0, 19);
         if (text.length > 0) this._peripheral.displayText(text);
+        const yieldDelay = 120 * ((6 * text.length) + 3);
 
         return new Promise(resolve => {
             setTimeout(() => {
                 resolve();
-            }, 120 * ((6 * text.length) + 1));
+            }, yieldDelay);
         });
     }
 

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -813,12 +813,12 @@ class Scratch3MicroBitBlocks {
      * The print time is calculated by multiplying the number of horizontal pixels
      * by the default scroll delay of 120ms.
      * The number of horizontal pixels = 6px for each character in the string,
-     * 1px before the string, and 2px after the string.
+     * 1px before the string, and 5px after the string.
      */
     displayText (args) {
         const text = String(args.TEXT).substring(0, 19);
         if (text.length > 0) this._peripheral.displayText(text);
-        const yieldDelay = 120 * ((6 * text.length) + 3);
+        const yieldDelay = 120 * ((6 * text.length) + 6);
 
         return new Promise(resolve => {
             setTimeout(() => {

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -808,8 +808,11 @@ class Scratch3MicroBitBlocks {
     /**
      * Display text on the 5x5 LED matrix.
      * @param {object} args - the block's arguments.
-     * @return {Promise} - a Promise that resolves after a tick.
+     * @return {Promise} - a Promise that resolves after the text is done printing.
      * Note the limit is 19 characters
+     * The print time is calculated by multiplying the number of horizontal pixels
+     * by the default scroll delay of 120ms.
+     * # of horizontal pixels = 5 + 1 for each char with an additional 1px spacer.
      */
     displayText (args) {
         const text = String(args.TEXT).substring(0, 19);
@@ -818,7 +821,7 @@ class Scratch3MicroBitBlocks {
         return new Promise(resolve => {
             setTimeout(() => {
                 resolve();
-            }, BLESendInterval);
+            }, 120 * ((6 * text.length) + 1));
         });
     }
 


### PR DESCRIPTION
### Resolves

Issue #1340, micro:bit display text block wait until finished

### Proposed Changes

Make the `display [Hello!]` block yield until the scrolling text has finished printing.

The delay time is calculated in the scratch-vm by multiplying the number of horizontal pixels by the default micro:bit scroll delay time (120ms). This eliminates the need for making a firmware level change.

Each char has a 5px width + a 1px spacer. The micro:bit DAL also adds a 1px spacer before printing the first character.

Delay time can be calculated with the following formula:
`DELAY_TIME = (120 * ((6 * TEXT_LENGTH) + 1)))`

If a second `display [TEXT]` block runs while another is printing, the new text will interrupt and begin printing immediately. The first block will still only yield when it originally expected to finish printing.
