### PR TITLE
Remove the word "test" from 'when pin connected' block

### DIFF
--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -703,7 +703,7 @@ class Scratch3MicroBitBlocks {
                     opcode: 'whenPinConnected',
                     text: formatMessage({
                         id: 'microbit.whenPinConnected',
-                        default: 'when pin [PIN] connected test',
+                        default: 'when pin [PIN] connected',
                         description: 'when the pin detects a connection to Earth/Ground'
 
                     }),


### PR DESCRIPTION
### Resolves

Issue #1559, Fix name of micro:bit block "when pin connected"

### Proposed Changes

Delete the word "test" from the `when pin connected` block.

### Reason for Changes

It shouldn't say test 😜
