### PR TITLE
Add event to show and hide a mic indicator for Speech to Text

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -458,6 +458,15 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for requesting an update of the indicator that shows that the
+     * microphone is being used to stream audio.
+     * @const {string}
+     */
+    static get UPDATE_MIC_INDICATOR () {
+        return 'UPDATE_MIC_INDICATOR';
+    }
+
+    /**
      * Event name for reporting that blocksInfo was updated.
      * @const {string}
      */
@@ -987,6 +996,10 @@ class Runtime extends EventEmitter {
             isConnected = this.peripheralExtensions[extensionId].isConnected();
         }
         return isConnected;
+    }
+
+    requestMicIndicatorUpdate (visible) {
+        this.emit(Runtime.UPDATE_MIC_INDICATOR, visible);
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -458,12 +458,11 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Event name for requesting an update of the indicator that shows that the
-     * microphone is being used to stream audio.
+     * Event name to indicate that the microphone is being used to stream audio.
      * @const {string}
      */
-    static get UPDATE_MIC_INDICATOR () {
-        return 'UPDATE_MIC_INDICATOR';
+    static get MIC_LISTENING () {
+        return 'MIC_LISTENING';
     }
 
     /**
@@ -998,8 +997,12 @@ class Runtime extends EventEmitter {
         return isConnected;
     }
 
-    requestMicIndicatorUpdate (visible) {
-        this.emit(Runtime.UPDATE_MIC_INDICATOR, visible);
+    /**
+     * Emit an event to indicate that the microphone is being used to stream audio.
+     * @param {boolean} listening - true if the microphone is currently listening.
+     */
+    emitMicListening (listening) {
+        this.emit(Runtime.MIC_LISTENING, listening);
     }
 
     /**

--- a/src/extensions/scratch3_speech2text/index.js
+++ b/src/extensions/scratch3_speech2text/index.js
@@ -207,7 +207,7 @@ class Scratch3Speech2TextBlocks {
      * @private.
      */
     _resetListening () {
-        this.runtime.requestMicIndicatorUpdate(false);
+        this.runtime.emitMicListening(false);
         this._stopListening();
         this._closeWebsocket();
         this._resolveSpeechPromises();
@@ -437,7 +437,7 @@ class Scratch3Speech2TextBlocks {
      * @private
      */
     _startListening () {
-        this.runtime.requestMicIndicatorUpdate(true);
+        this.runtime.emitMicListening(true);
         this._initListening();
         // Force the block to timeout if we don't get any results back/the user didn't say anything.
         this._speechTimeoutId = setTimeout(this._stopTranscription, listenAndWaitBlockTimeoutMs);

--- a/src/extensions/scratch3_speech2text/index.js
+++ b/src/extensions/scratch3_speech2text/index.js
@@ -207,6 +207,7 @@ class Scratch3Speech2TextBlocks {
      * @private.
      */
     _resetListening () {
+        this.runtime.requestMicIndicatorUpdate(false);
         this._stopListening();
         this._closeWebsocket();
         this._resolveSpeechPromises();
@@ -236,8 +237,6 @@ class Scratch3Speech2TextBlocks {
      * @private
      */
     _stopListening () {
-        this.runtime.requestMicIndicatorUpdate(false);
-
         // Note that this can be called before any Listen And Wait block did setup,
         // so check that things exist before disconnecting them.
         if (this._context) {

--- a/src/extensions/scratch3_speech2text/index.js
+++ b/src/extensions/scratch3_speech2text/index.js
@@ -236,6 +236,8 @@ class Scratch3Speech2TextBlocks {
      * @private
      */
     _stopListening () {
+        this.runtime.requestMicIndicatorUpdate(false);
+
         // Note that this can be called before any Listen And Wait block did setup,
         // so check that things exist before disconnecting them.
         if (this._context) {
@@ -436,6 +438,7 @@ class Scratch3Speech2TextBlocks {
      * @private
      */
     _startListening () {
+        this.runtime.requestMicIndicatorUpdate(true);
         this._initListening();
         // Force the block to timeout if we don't get any results back/the user didn't say anything.
         this._speechTimeoutId = setTimeout(this._stopTranscription, listenAndWaitBlockTimeoutMs);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -117,6 +117,9 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.PERIPHERAL_SCAN_TIMEOUT, () =>
             this.emit(Runtime.PERIPHERAL_SCAN_TIMEOUT)
         );
+        this.runtime.on(Runtime.MIC_LISTENING, listening => {
+            this.emit(Runtime.MIC_LISTENING, listening);
+        });
 
         this.extensionManager = new ExtensionManager(this.runtime);
 


### PR DESCRIPTION
### Proposed Changes

- Add an event emitted by the runtime to indicate when an extension starts or stops streaming audio from the microphone to a server, so that the GUI can show or hide a microphone indicator icon.
- Use the event in the Speech to Text extension.