### PR TITLE
Change “monster” to “giant” and raise pitch

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -43,7 +43,7 @@ const SQUEAK_ID = 'SQUEAK';
 /**
  * An id for one of the voices.
  */
-const MONSTER_ID = 'MONSTER';
+const GIANT_ID = 'GIANT';
 
 /**
  * An id for one of the voices.
@@ -111,14 +111,14 @@ class Scratch3Text2SpeechBlocks {
                 gender: 'female',
                 playbackRate: 1.4
             },
-            [MONSTER_ID]: {
+            [GIANT_ID]: {
                 name: formatMessage({
-                    id: 'text2speech.monster',
-                    default: 'monster',
+                    id: 'text2speech.giant',
+                    default: 'giant',
                     description: 'Name for a funny voice with a low pitch.'
                 }),
                 gender: 'male',
-                playbackRate: 0.7
+                playbackRate: 0.84
             },
             [KITTEN_ID]: {
                 name: formatMessage({


### PR DESCRIPTION
### Resolves

resolves https://github.com/LLK/scratch-vm/issues/1605

### Proposed Changes

- Change the name of the "monster" voice to "giant"
- Use a less extreme pitch shift so that it is less distorted. I decided on a ratio of 0.84, which works out to lowering the pitch by a minor third.

### Reason for Changes

There were moderation concerns about the name "monster". 

The previous pitch ratio was a bit too extreme, resulting in some creepy distortion in the voice.
