### PR TITLE
Show customized alerts on hardware extension peripheral errors.

### DIFF
--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -409,6 +409,11 @@ class EV3 {
         this._runtime.on('PROJECT_STOP_ALL', this.stopAll.bind(this));
 
         /**
+         * The id of the extension this peripheral belongs to.
+         */
+        this._extensionId = extensionId;
+
+        /**
          * A list of the names of the sensors connected in ports 1,2,3,4.
          * @type {string[]}
          * @private
@@ -548,7 +553,7 @@ class EV3 {
      * Called by the runtime when user wants to scan for an EV3 peripheral.
      */
     scan () {
-        this._bt = new BT(this._runtime, 'EV3', {
+        this._bt = new BT(this._runtime, this._extensionId, {
             majorDeviceClass: 8,
             minorDeviceClass: 1
         }, this._onConnect, this._onMessage);

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -548,7 +548,7 @@ class EV3 {
      * Called by the runtime when user wants to scan for an EV3 peripheral.
      */
     scan () {
-        this._bt = new BT(this._runtime, {
+        this._bt = new BT(this._runtime, 'EV3', {
             majorDeviceClass: 8,
             minorDeviceClass: 1
         }, this._onConnect, this._onMessage);

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -200,7 +200,7 @@ class MicroBit {
      * Called by the runtime when user wants to scan for a peripheral.
      */
     scan () {
-        this._ble = new BLE(this._runtime, {
+        this._ble = new BLE(this._runtime, 'micro:bit', {
             filters: [
                 {services: [BLEUUID.service]}
             ]

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -73,6 +73,8 @@ class MicroBit {
         this._ble = null;
         this._runtime.registerPeripheralExtension(extensionId, this);
 
+        this._extensionId = extensionId;
+
         /**
          * The most recently received value for each sensor.
          * @type {Object.<string, number>}
@@ -132,6 +134,15 @@ class MicroBit {
         this.disconnect = this.disconnect.bind(this);
         this._onConnect = this._onConnect.bind(this);
         this._onMessage = this._onMessage.bind(this);
+
+        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
+            message: `Scratch lost connection to peripheral.`,
+            extensionId: this._extensionId
+        });
+        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
+            message: `Scratch lost connection to peripheral.`,
+            extensionId: 2
+        });
     }
 
     /**
@@ -200,7 +211,7 @@ class MicroBit {
      * Called by the runtime when user wants to scan for a peripheral.
      */
     scan () {
-        this._ble = new BLE(this._runtime, 'micro:bit', {
+        this._ble = new BLE(this._runtime, this._extensionId, {
             filters: [
                 {services: [BLEUUID.service]}
             ]

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -73,6 +73,9 @@ class MicroBit {
         this._ble = null;
         this._runtime.registerPeripheralExtension(extensionId, this);
 
+        /**
+         * The id of the extension this peripheral belongs to.
+         */
         this._extensionId = extensionId;
 
         /**
@@ -134,15 +137,6 @@ class MicroBit {
         this.disconnect = this.disconnect.bind(this);
         this._onConnect = this._onConnect.bind(this);
         this._onMessage = this._onMessage.bind(this);
-
-        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
-            message: `Scratch lost connection to peripheral.`,
-            extensionId: this._extensionId
-        });
-        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
-            message: `Scratch lost connection to peripheral.`,
-            extensionId: 2
-        });
     }
 
     /**

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -549,7 +549,7 @@ class WeDo2 {
      * Called by the runtime when user wants to scan for a WeDo 2.0 peripheral.
      */
     scan () {
-        this._ble = new BLE(this._runtime, {
+        this._ble = new BLE(this._runtime, 'WeDo 2', {
             filters: [{
                 services: [BLEService.DEVICE_SERVICE]
             }],

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -358,6 +358,11 @@ class WeDo2 {
         this._runtime.on('PROJECT_STOP_ALL', this.stopAll.bind(this));
 
         /**
+         * The id of the extension this peripheral belongs to.
+         */
+        this._extensionId = extensionId;
+
+        /**
          * A list of the ids of the motors or sensors in ports 1 and 2.
          * @type {string[]}
          * @private
@@ -549,7 +554,7 @@ class WeDo2 {
      * Called by the runtime when user wants to scan for a WeDo 2.0 peripheral.
      */
     scan () {
-        this._ble = new BLE(this._runtime, 'WeDo 2', {
+        this._ble = new BLE(this._runtime, this._extensionId, {
             filters: [{
                 services: [BLEService.DEVICE_SERVICE]
             }],

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -174,8 +174,9 @@ class BLE extends JSONRPCWebSocket {
     _sendError (/* e */) {
         this.disconnect();
         // log.error(`BLE error: ${JSON.stringify(e)}`);
+        console.log('extension id sending: ' + this._extensionId);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
-            message: `Scratch lost connection to ${this._peripheralType}.`,
+            message: `Scratch lost connection to`,
             extensionId: this._extensionId
         });
     }

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -8,10 +8,11 @@ class BLE extends JSONRPCWebSocket {
      * A BLE peripheral socket object.  It handles connecting, over web sockets, to
      * BLE peripherals, and reading and writing data to them.
      * @param {Runtime} runtime - the Runtime for sending/receiving GUI update events.
+     * @param {string} peripheralType - the type of peripheral.
      * @param {object} peripheralOptions - the list of options for peripheral discovery.
      * @param {object} connectCallback - a callback for connection.
      */
-    constructor (runtime, peripheralOptions, connectCallback) {
+    constructor (runtime, peripheralType, peripheralOptions, connectCallback) {
         const ws = new WebSocket(ScratchLinkWebSocket);
         super(ws);
 
@@ -25,6 +26,7 @@ class BLE extends JSONRPCWebSocket {
         this._connected = false;
         this._characteristicDidChangeCallback = null;
         this._peripheralOptions = peripheralOptions;
+        this._peripheralType = peripheralType;
         this._discoverTimeoutID = null;
         this._runtime = runtime;
     }
@@ -172,7 +174,9 @@ class BLE extends JSONRPCWebSocket {
     _sendError (/* e */) {
         this.disconnect();
         // log.error(`BLE error: ${JSON.stringify(e)}`);
-        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR);
+        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
+            message: `Scratch lost connection to ${this._peripheralType}.`
+        });
     }
 
     _sendDiscoverTimeout () {

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -8,11 +8,11 @@ class BLE extends JSONRPCWebSocket {
      * A BLE peripheral socket object.  It handles connecting, over web sockets, to
      * BLE peripherals, and reading and writing data to them.
      * @param {Runtime} runtime - the Runtime for sending/receiving GUI update events.
-     * @param {string} peripheralType - the type of peripheral.
+     * @param {string} extensionId - the id of the extension using this socket.
      * @param {object} peripheralOptions - the list of options for peripheral discovery.
      * @param {object} connectCallback - a callback for connection.
      */
-    constructor (runtime, peripheralType, peripheralOptions, connectCallback) {
+    constructor (runtime, extensionId, peripheralOptions, connectCallback) {
         const ws = new WebSocket(ScratchLinkWebSocket);
         super(ws);
 
@@ -25,8 +25,8 @@ class BLE extends JSONRPCWebSocket {
         this._connectCallback = connectCallback;
         this._connected = false;
         this._characteristicDidChangeCallback = null;
+        this._extensionId = extensionId;
         this._peripheralOptions = peripheralOptions;
-        this._peripheralType = peripheralType;
         this._discoverTimeoutID = null;
         this._runtime = runtime;
     }
@@ -175,7 +175,8 @@ class BLE extends JSONRPCWebSocket {
         this.disconnect();
         // log.error(`BLE error: ${JSON.stringify(e)}`);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
-            message: `Scratch lost connection to ${this._peripheralType}.`
+            message: `Scratch lost connection to ${this._peripheralType}.`,
+            extensionId: this._extensionId
         });
     }
 

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -174,7 +174,6 @@ class BLE extends JSONRPCWebSocket {
     _sendError (/* e */) {
         this.disconnect();
         // log.error(`BLE error: ${JSON.stringify(e)}`);
-        console.log('extension id sending: ' + this._extensionId);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
             message: `Scratch lost connection to`,
             extensionId: this._extensionId

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -8,12 +8,12 @@ class BT extends JSONRPCWebSocket {
      * A BT peripheral socket object.  It handles connecting, over web sockets, to
      * BT peripherals, and reading and writing data to them.
      * @param {Runtime} runtime - the Runtime for sending/receiving GUI update events.
-     * @param {string} peripheralType - the type of peripheral.
+     * @param {string} extensionId - the id of the extension using this socket.
      * @param {object} peripheralOptions - the list of options for peripheral discovery.
      * @param {object} connectCallback - a callback for connection.
      * @param {object} messageCallback - a callback for message sending.
      */
-    constructor (runtime, peripheralType, peripheralOptions, connectCallback, messageCallback) {
+    constructor (runtime, extensionId, peripheralOptions, connectCallback, messageCallback) {
         const ws = new WebSocket(ScratchLinkWebSocket);
         super(ws);
 
@@ -26,8 +26,8 @@ class BT extends JSONRPCWebSocket {
         this._connectCallback = connectCallback;
         this._connected = false;
         this._characteristicDidChangeCallback = null;
+        this._extensionId = extensionId;
         this._peripheralOptions = peripheralOptions;
-        this._peripheralType = peripheralType;
         this._discoverTimeoutID = null;
         this._messageCallback = messageCallback;
         this._runtime = runtime;

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -117,7 +117,6 @@ class BT extends JSONRPCWebSocket {
     _sendError (/* e */) {
         this.disconnect();
         // log.error(`BT error: ${JSON.stringify(e)}`);
-        console.log('extension id sending: ' + this._extensionId);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
             message: `Scratch lost connection to`,
             extensionId: this._extensionId

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -117,8 +117,10 @@ class BT extends JSONRPCWebSocket {
     _sendError (/* e */) {
         this.disconnect();
         // log.error(`BT error: ${JSON.stringify(e)}`);
+        console.log('extension id sending: ' + this._extensionId);
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
-            message: `Scratch lost connection to ${this._peripheralType}.`
+            message: `Scratch lost connection to`,
+            extensionId: this._extensionId
         });
     }
 

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -8,11 +8,12 @@ class BT extends JSONRPCWebSocket {
      * A BT peripheral socket object.  It handles connecting, over web sockets, to
      * BT peripherals, and reading and writing data to them.
      * @param {Runtime} runtime - the Runtime for sending/receiving GUI update events.
+     * @param {string} peripheralType - the type of peripheral.
      * @param {object} peripheralOptions - the list of options for peripheral discovery.
      * @param {object} connectCallback - a callback for connection.
      * @param {object} messageCallback - a callback for message sending.
      */
-    constructor (runtime, peripheralOptions, connectCallback, messageCallback) {
+    constructor (runtime, peripheralType, peripheralOptions, connectCallback, messageCallback) {
         const ws = new WebSocket(ScratchLinkWebSocket);
         super(ws);
 
@@ -26,6 +27,7 @@ class BT extends JSONRPCWebSocket {
         this._connected = false;
         this._characteristicDidChangeCallback = null;
         this._peripheralOptions = peripheralOptions;
+        this._peripheralType = peripheralType;
         this._discoverTimeoutID = null;
         this._messageCallback = messageCallback;
         this._runtime = runtime;
@@ -115,7 +117,9 @@ class BT extends JSONRPCWebSocket {
     _sendError (/* e */) {
         this.disconnect();
         // log.error(`BT error: ${JSON.stringify(e)}`);
-        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR);
+        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
+            message: `Scratch lost connection to ${this._peripheralType}.`
+        });
     }
 
     _sendDiscoverTimeout () {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -111,8 +111,8 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.PERIPHERAL_CONNECTED, () =>
             this.emit(Runtime.PERIPHERAL_CONNECTED)
         );
-        this.runtime.on(Runtime.PERIPHERAL_ERROR, message =>
-            this.emit(Runtime.PERIPHERAL_ERROR, message)
+        this.runtime.on(Runtime.PERIPHERAL_ERROR, data =>
+            this.emit(Runtime.PERIPHERAL_ERROR, data)
         );
         this.runtime.on(Runtime.PERIPHERAL_SCAN_TIMEOUT, () =>
             this.emit(Runtime.PERIPHERAL_SCAN_TIMEOUT)

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -111,8 +111,8 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.PERIPHERAL_CONNECTED, () =>
             this.emit(Runtime.PERIPHERAL_CONNECTED)
         );
-        this.runtime.on(Runtime.PERIPHERAL_ERROR, () =>
-            this.emit(Runtime.PERIPHERAL_ERROR)
+        this.runtime.on(Runtime.PERIPHERAL_ERROR, message =>
+            this.emit(Runtime.PERIPHERAL_ERROR, message)
         );
         this.runtime.on(Runtime.PERIPHERAL_SCAN_TIMEOUT, () =>
             this.emit(Runtime.PERIPHERAL_SCAN_TIMEOUT)


### PR DESCRIPTION
### Resolves

This is progress towards: https://github.com/LLK/scratch-gui/issues/2956.

### Proposed Changes

Shows customized alerts for peripheral errors/disconnections including extension icon and name.

<img width="727" alt="screen shot 2018-09-22 at 5 40 22 pm" src="https://user-images.githubusercontent.com/699840/45921972-a5237d00-be8e-11e8-9b5e-d2a3ebb91ccf.png">

### Reason for Changes

To warn the user that a peripheral has disconnected and blocks may no longer work.

### Notes
- Requires this PR to land: https://github.com/LLK/scratch-gui/pull/3209
- Sometimes it will show two errors for a single hardware malfunction, but that's to fix in a future PR.