### PR TITLE
Add “set language” block for the Text to Speech extension

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -63,6 +63,12 @@ class Scratch3Text2SpeechBlocks {
         this.runtime = runtime;
 
         /**
+         * The current language code to use for speech synthesis.
+         * @type {string}
+         */
+        this.currentLanguage = 'en-US';
+
+        /**
          * Map of soundPlayers by sound id.
          * @type {Map<string, SoundPlayer>}
          */
@@ -129,6 +135,28 @@ class Scratch3Text2SpeechBlocks {
                 gender: 'female',
                 playbackRate: 1.4
             }
+        };
+    }
+
+    /**
+     * An object with language names mapped to their language codes.
+     */
+    get LANGUAGE_INFO () {
+        return {
+            'Danish': 'da-DK',
+            'Dutch': 'nl-NL',
+            'English': 'en-US',
+            'French': 'fr-FR',
+            'German': 'de-DE',
+            'Icelandic': 'is-IS',
+            'Italian': 'it-IT',
+            'Japanese': 'ja-JP',
+            'Polish': 'pl-PL',
+            'Portuguese (Brazilian)': 'pt-BR',
+            'Portuguese (European)': 'pt-PT',
+            'Russian': 'ru-RU',
+            'Spanish (European)': 'es-ES',
+            'Spanish (Latin American)': 'es-US'
         };
     }
 
@@ -224,10 +252,27 @@ class Scratch3Text2SpeechBlocks {
                             defaultValue: QUINN_ID
                         }
                     }
+                },
+                {
+                    opcode: 'setLanguage',
+                    text: formatMessage({
+                        id: 'text2speech.setLanguageBlock',
+                        default: 'set language to [LANGUAGE]',
+                        description: 'Set the language for speech synthesis.'
+                    }),
+                    blockType: BlockType.COMMAND,
+                    arguments: {
+                        LANGUAGE: {
+                            type: ArgumentType.STRING,
+                            menu: 'languages',
+                            defaultValue: this.currentLanguage
+                        }
+                    }
                 }
             ],
             menus: {
-                voices: this.getVoiceMenu()
+                voices: this.getVoiceMenu(),
+                languages: this.getLanguageMenu()
             }
         };
     }
@@ -261,6 +306,17 @@ class Scratch3Text2SpeechBlocks {
     }
 
     /**
+     * Get the menu of languages for the "set language" block.
+     * @return {array} the text and value for each menu item.
+     */
+    getLanguageMenu () {
+        return Object.keys(this.LANGUAGE_INFO).map(languageName => ({
+            text: languageName,
+            value: this.LANGUAGE_INFO[languageName]
+        }));
+    }
+
+    /**
      * Set the voice for speech synthesis for this sprite.
      * @param  {object} args Block arguments
      * @param {object} util Utility object provided by the runtime.
@@ -271,6 +327,17 @@ class Scratch3Text2SpeechBlocks {
         // Only set the voice if the arg is a valid voice id.
         if (Object.keys(this.VOICE_INFO).includes(args.VOICE)) {
             state.voiceId = args.VOICE;
+        }
+    }
+
+    /**
+     * Set the language for speech synthesis.
+     * @param  {object} args Block arguments
+     */
+    setLanguage (args) {
+        // Only set the language if the arg is a valid language code.
+        if (Object.values(this.LANGUAGE_INFO).includes(args.LANGUAGE)) {
+            this.currentLanguage = args.LANGUAGE;
         }
     }
 
@@ -305,7 +372,7 @@ class Scratch3Text2SpeechBlocks {
 
         // Build up URL
         let path = `${SERVER_HOST}/synth`;
-        path += `?locale=${this.getViewerLanguageCode()}`;
+        path += `?locale=${this.currentLanguage}`;
         path += `&gender=${gender}`;
         path += `&text=${encodeURI(words.substring(0, 128))}`;
 


### PR DESCRIPTION
As we progress toward making all three language extensions (text to speech, speech to text, translate) work well with each other, we're trying out different ways to make sure they work together across different languages. This PR adds a block to set the language for speech synthesis in the text to speech extension to one of the languages available from the service we are currently using. 

If we decide to go with this approach, there will be some additional chunks of work, including:

- Decide how to provide the list of available languages, instead of the way it is done here (e.g. possibly generate it with a module)
- Localize the language names that appear in the menu (using something like our existing scratch-translate-extension-languages module)
- Do the conversion between language codes on the server instead of in the extension (i.e. between two letter codes used by Scratch like 'en' and the four letter codes like 'en-US')
- Set the language on load using the Scratch locale, if it matches an available speech language (note that this may require a more sophisticated strategy, such as saving the project creator's language in the project, to handle a case where the project creator does not use a "set language" block, and it is opened by a user viewing Scratch in another language)

