### PR TITLE
Reset the supported language list in getInfo. This works because refr…

### DIFF
--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -31,7 +31,7 @@ class Scratch3TranslateBlocks {
          * @private
          */
         this._viewerLanguageCode = this.getViewerLanguageCode();
-        
+
         /**
          * List of supported language name and language code pairs, for use in the block menu.
          * Filled in by getInfo so it is updated when the interface language changes.
@@ -116,8 +116,6 @@ class Scratch3TranslateBlocks {
                             type: ArgumentType.STRING,
                             menu: 'languages',
                             defaultValue: this._randomLanguageCode
-
-
                         }
                     }
                 },

--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -31,24 +31,23 @@ class Scratch3TranslateBlocks {
          * @private
          */
         this._viewerLanguageCode = this.getViewerLanguageCode();
-
+        
         /**
          * List of supported language name and language code pairs, for use in the block menu.
+         * Filled in by getInfo so it is updated when the interface language changes.
          * @type {Array.<object.<string, string>>}
          * @private
          */
-        this._supportedLanguages = languageNames.menuMap[this._viewerLanguageCode].map(entry => {
-            const obj = {text: entry.name, value: entry.code};
-            return obj;
-        });
+        this._supportedLanguages = [];
 
         /**
          * A randomly selected language code, for use as the default value in the language menu.
+         * Properly filled in getInfo so it is updated when the interface languages changes.
          * @type {string}
          * @private
          */
-        this._randomLanguageCode = this._supportedLanguages[
-            Math.floor(Math.random() * this._supportedLanguages.length)].value;
+        this._randomLanguageCode = 'en';
+
 
         /**
          * The result from the most recent translation.
@@ -84,6 +83,10 @@ class Scratch3TranslateBlocks {
      * @returns {object} metadata for this extension and its blocks.
      */
     getInfo () {
+        this._supportedLanguages = this._getSupportedLanguages(this.getViewerLanguageCode());
+        this._randomLanguageCode = this._supportedLanguages[
+             Math.floor(Math.random() * this._supportedLanguages.length)].value;
+
         return {
             id: 'translate',
             name: formatMessage({
@@ -113,6 +116,8 @@ class Scratch3TranslateBlocks {
                             type: ArgumentType.STRING,
                             menu: 'languages',
                             defaultValue: this._randomLanguageCode
+
+
                         }
                     }
                 },
@@ -133,6 +138,19 @@ class Scratch3TranslateBlocks {
         };
     }
 
+    /**
+     * Computes a list of language code and name pairs for the given language.
+     * @param {string} code The language code to get the list of language pairs
+     * @return {Array.<object.<string, string>>} An array of languge name and
+     *   language code pairs.
+     * @private
+     */
+    _getSupportedLanguages (code) {
+        return languageNames.menuMap[code].map(entry => {
+            const obj = {text: entry.name, value: entry.code};
+            return obj;
+        });
+    }
     /**
      * Get the human readable language value for the reporter block.
      * @return {string} the language name of the project viewer.

--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -85,7 +85,7 @@ class Scratch3TranslateBlocks {
     getInfo () {
         this._supportedLanguages = this._getSupportedLanguages(this.getViewerLanguageCode());
         this._randomLanguageCode = this._supportedLanguages[
-             Math.floor(Math.random() * this._supportedLanguages.length)].value;
+            Math.floor(Math.random() * this._supportedLanguages.length)].value;
 
         return {
             id: 'translate',


### PR DESCRIPTION
…eshBlocks is called

when the language gets changed. Fixes #1365.

### Resolves

#1365 

### Proposed Changes

Refresh the language list whenever getInfo is called.
I know this isn't the preferred place to fix this, but I put together the PR mostly to talk about how we'd want to handle these types of things in extensions. Right now setLocale eventually eventually calls getInfo so it works :)
