### PR TITLE
Old MIDI drum block support, featuring approximations via pitch shift

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -610,7 +610,7 @@ class Scratch3MusicBlocks {
 
     /**
      * An array that is a mapping from MIDI drum numbers in range (35..81) to Scratch drum numbers.
-     * @type {Array[Array]} an array of information about the drums, in the format [drumNum, pitch, decay].
+     * @type {Array[]} an array of information about the drums, in the format [drumNum, pitch, decay].
      */
     get MIDI_DRUMS () {
         return [
@@ -938,6 +938,8 @@ class Scratch3MusicBlocks {
      * the MIDI to Scratch drum mapping.
      * @param {number} drumNum - the drum number.
      * @param {beats} beats - the duration in beats to pause after playing the sound.
+     * @param {object} util - utility object provided by the runtime.
+     * @param {boolean} mapMidi - whether or not drumNum is a MIDI drum number.
      */
     _playDrumForBeats (drumNum, beats, util, mapMidi) {
         if (this._stackTimerNeedsInit(util)) {
@@ -1002,7 +1004,7 @@ class Scratch3MusicBlocks {
 
         // Dirty hack to make the pitch effect work - otherwise the effect isn't applied, for some reason.
         // (Other audio effects work fine without this, though.)
-        const pitchEffect = chain._effects.find(effect => effect.name === 'pitch')
+        const pitchEffect = chain._effects.find(effect => effect.name === 'pitch');
         if (pitchEffect) {
             pitchEffect.updatePlayer(player);
         }

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -799,7 +799,8 @@ class Scratch3MusicBlocks {
                             type: ArgumentType.NUMBER,
                             defaultValue: 0.25
                         }
-                    }
+                    },
+                    hideFromPalette: true
                 },
                 {
                     opcode: 'restForBeats',

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -1006,6 +1006,10 @@ class Scratch3MusicBlocks {
         });
 
         player.play();
+        // Connect the player to the gain node.
+        player.connect({getInputNode () {
+            return volumeGain;
+        }});
     }
 
     /**

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -613,6 +613,7 @@ class Scratch3MusicBlocks {
 
     /**
      * An array that is a mapping from MIDI drum numbers in range (35..81) to Scratch drum numbers.
+     * The pitch and decay properties are not currently being used.
      * @type {Array[]} an array of information about the drums, in the format [drumNum, pitch, decay].
      */
     get MIDI_DRUMS () {
@@ -940,7 +941,7 @@ class Scratch3MusicBlocks {
         if (midiDescription) {
             drumNum = midiDescription[0];
         } else {
-            drumNum = 2;
+            drumNum = 2; // Default instrument used in Scratch 2.0
         }
         drumNum += 1; // drumNum input to _playDrumForBeats is one-indexed
         this._playDrumForBeats(drumNum, args.BEATS, util);

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -613,7 +613,7 @@ class Scratch3MusicBlocks {
 
     /**
      * An array that is a mapping from MIDI drum numbers in range (35..81) to Scratch drum numbers.
-     * @type {Array[Array]} an array of information about the drums, in the format [drumNum, pitch, decay].
+     * @type {Array[]} an array of information about the drums, in the format [drumNum, pitch, decay].
      */
     get MIDI_DRUMS () {
         return [
@@ -941,6 +941,8 @@ class Scratch3MusicBlocks {
      * the MIDI to Scratch drum mapping.
      * @param {number} drumNum - the drum number.
      * @param {beats} beats - the duration in beats to pause after playing the sound.
+     * @param {object} util - utility object provided by the runtime.
+     * @param {boolean} mapMidi - whether or not drumNum is a MIDI drum number.
      */
     _playDrumForBeats (drumNum, beats, util, mapMidi) {
         if (this._stackTimerNeedsInit(util)) {
@@ -1005,7 +1007,7 @@ class Scratch3MusicBlocks {
 
         // Dirty hack to make the pitch effect work - otherwise the effect isn't applied, for some reason.
         // (Other audio effects work fine without this, though.)
-        const pitchEffect = chain._effects.find(effect => effect.name === 'pitch')
+        const pitchEffect = chain._effects.find(effect => effect.name === 'pitch');
         if (pitchEffect) {
             pitchEffect.updatePlayer(player);
         }

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -609,6 +609,62 @@ class Scratch3MusicBlocks {
     }
 
     /**
+     * An array that is a mapping from MIDI drum numbers in range (35..81) to Scratch drum numbers.
+     * @type {Array[Array]} an array of information about the drums, in the format [drumNum, pitch, decay].
+     */
+    get MIDI_DRUMS () {
+        return [
+            [1, -4], // "BassDrum" in 2.0, "Bass Drum" in 3.0 (which was "Tom" in 2.0)
+            [1, 0], // Same as just above
+            [2, 0],
+            [0, 0],
+            [7, 0],
+            [0, 2],
+            [1, -6, 4],
+            [5, 0],
+            [1, -3, 3.2],
+            [5, 0], // "HiHatPedal" in 2.0, "Closed Hi-Hat" in 3.0
+            [1, 0, 3],
+            [4, -8],
+            [1, 4, 3],
+            [1, 7, 2.7],
+            [3, -8],
+            [1, 10, 2.7],
+            [4, -2],
+            [3, -11],
+            [4, 2],
+            [6, 0],
+            [3, 0, 3.5],
+            [10, 0],
+            [3, -8, 3.5],
+            [16, -6],
+            [4, 2],
+            [12, 2],
+            [12, 0],
+            [13, 0, 0.2],
+            [13, 0, 2],
+            [13, -5, 2],
+            [12, 12],
+            [12, 5],
+            [10, 19],
+            [10, 12],
+            [14, 0],
+            [14, 0], // "Maracas" in 2.0, "Cabasa" in 3.0 (TODO: pitch up?)
+            [17, 12],
+            [17, 5],
+            [15, 0], // "GuiroShort" in 2.0, "Guiro" in 3.0 (which was "GuiroLong" in 2.0) (TODO: decay?)
+            [15, 0],
+            [8, 0],
+            [9, 0],
+            [9, -4],
+            [17, -5],
+            [17, 0],
+            [11, -6, 1],
+            [11, -6, 3]
+        ];
+    }
+
+    /**
      * The key to load & store a target's music-related state.
      * @type {string}
      */
@@ -709,6 +765,26 @@ class Scratch3MusicBlocks {
                         id: 'music.playDrumForBeats',
                         default: 'play drum [DRUM] for [BEATS] beats',
                         description: 'play drum sample for a number of beats'
+                    }),
+                    arguments: {
+                        DRUM: {
+                            type: ArgumentType.NUMBER,
+                            menu: 'DRUM',
+                            defaultValue: 1
+                        },
+                        BEATS: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: 0.25
+                        }
+                    }
+                },
+                {
+                    opcode: 'midiPlayDrumForBeats',
+                    blockType: BlockType.COMMAND,
+                    text: formatMessage({
+                        id: 'music.midiPlayDrumForBeats',
+                        default: 'play drum [DRUM] for [BEATS] beats',
+                        description: 'play drum sample for a number of beats according to a mapping of MIDI codes'
                     }),
                     arguments: {
                         DRUM: {
@@ -843,14 +919,46 @@ class Scratch3MusicBlocks {
      * @property {number} BEATS - the duration in beats of the drum sound.
      */
     playDrumForBeats (args, util) {
+        this._playDrumForBeats(args.DRUM, args.BEATS, util, false);
+    }
+
+    /**
+     * Play a drum sound for some number of beats according to the range of "MIDI" drum codes supported.
+     * This block is implemented for compatibility with old Scratch projects that use the
+     * 'drum:duration:elapsed:from:' block.
+     * @param {object} args - the block arguments.
+     * @param {object} util - utility object provided by the runtime.
+     */
+    midiPlayDrumForBeats (args, util) {
+        this._playDrumForBeats(args.DRUM, args.BEATS, util, true);
+    }
+
+    /**
+     * Internal code to play a drum sound for some number of beats. If mapMidi is true, choose the sound according to
+     * the MIDI to Scratch drum mapping.
+     * @param {number} drumNum - the drum number.
+     * @param {beats} beats - the duration in beats to pause after playing the sound.
+     */
+    _playDrumForBeats (drumNum, beats, util, mapMidi) {
         if (this._stackTimerNeedsInit(util)) {
-            let drum = Cast.toNumber(args.DRUM);
-            drum = Math.round(drum);
-            drum -= 1; // drums are one-indexed
-            drum = MathUtil.wrapClamp(drum, 0, this.DRUM_INFO.length - 1);
-            let beats = Cast.toNumber(args.BEATS);
+            drumNum = Cast.toNumber(drumNum);
+            drumNum = Math.round(drumNum);
+            let pitchShift = 0;
+            if (mapMidi) {
+                const midiDescription = this.MIDI_DRUMS[drumNum - 35];
+                if (midiDescription) {
+                    drumNum = midiDescription[0];
+                    pitchShift = midiDescription[1] * 10; // 10 = one semitone
+                } else {
+                    drumNum = 2;
+                }
+            } else {
+                drumNum -= 1; // drums are one-indexed
+            }
+            drumNum = MathUtil.wrapClamp(drumNum, 0, this.DRUM_INFO.length - 1);
+            beats = Cast.toNumber(beats);
             beats = this._clampBeats(beats);
-            this._playDrumNum(util, drum);
+            this._playDrumNum(util, drumNum, pitchShift);
             this._startStackTimer(util, this._beatsToSec(beats));
         } else {
             this._checkStackTimer(util);
@@ -860,10 +968,11 @@ class Scratch3MusicBlocks {
     /**
      * Play a drum sound using its 0-indexed number.
      * @param {object} util - utility object provided by the runtime.
-     * @param  {number} drumNum - the number of the drum to play.
+     * @param {number} drumNum - the number of the drum to play.
+     * @param {number} pitchShift - pitch shift to be applied (in addition to sprite's "pitch" audio effect).
      * @private
      */
-    _playDrumNum (util, drumNum) {
+    _playDrumNum (util, drumNum, pitchShift) {
         if (util.runtime.audioEngine === null) return;
         if (util.target.sprite.soundBank === null) return;
         // If we're playing too many sounds, do not play the drum sound.
@@ -884,8 +993,19 @@ class Scratch3MusicBlocks {
 
         const engine = util.runtime.audioEngine;
         const chain = engine.createEffectChain();
-        chain.setEffectsFromTarget(util.target);
+        const soundEffects = Object.assign({}, util.target.soundEffects);
+        if (pitchShift) {
+            soundEffects.pitch = (soundEffects.pitch || 0) + pitchShift;
+        }
+        chain.setEffectsFromTarget(soundEffects);
         player.connect(chain);
+
+        // Dirty hack to make the pitch effect work - otherwise the effect isn't applied, for some reason.
+        // (Other audio effects work fine without this, though.)
+        const pitchEffect = chain._effects.find(effect => effect.name === 'pitch')
+        if (pitchEffect) {
+            pitchEffect.updatePlayer(player);
+        }
 
         this._concurrencyCounter++;
         player.once('stop', () => {

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -613,8 +613,9 @@ class Scratch3MusicBlocks {
 
     /**
      * An array that is a mapping from MIDI drum numbers in range (35..81) to Scratch drum numbers.
+     * It's in the format [drumNum, pitch, decay].
      * The pitch and decay properties are not currently being used.
-     * @type {Array[]} an array of information about the drums, in the format [drumNum, pitch, decay].
+     * @type {Array[]}
      */
     get MIDI_DRUMS () {
         return [

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -612,6 +612,62 @@ class Scratch3MusicBlocks {
     }
 
     /**
+     * An array that is a mapping from MIDI drum numbers in range (35..81) to Scratch drum numbers.
+     * @type {Array[Array]} an array of information about the drums, in the format [drumNum, pitch, decay].
+     */
+    get MIDI_DRUMS () {
+        return [
+            [1, -4], // "BassDrum" in 2.0, "Bass Drum" in 3.0 (which was "Tom" in 2.0)
+            [1, 0], // Same as just above
+            [2, 0],
+            [0, 0],
+            [7, 0],
+            [0, 2],
+            [1, -6, 4],
+            [5, 0],
+            [1, -3, 3.2],
+            [5, 0], // "HiHatPedal" in 2.0, "Closed Hi-Hat" in 3.0
+            [1, 0, 3],
+            [4, -8],
+            [1, 4, 3],
+            [1, 7, 2.7],
+            [3, -8],
+            [1, 10, 2.7],
+            [4, -2],
+            [3, -11],
+            [4, 2],
+            [6, 0],
+            [3, 0, 3.5],
+            [10, 0],
+            [3, -8, 3.5],
+            [16, -6],
+            [4, 2],
+            [12, 2],
+            [12, 0],
+            [13, 0, 0.2],
+            [13, 0, 2],
+            [13, -5, 2],
+            [12, 12],
+            [12, 5],
+            [10, 19],
+            [10, 12],
+            [14, 0],
+            [14, 0], // "Maracas" in 2.0, "Cabasa" in 3.0 (TODO: pitch up?)
+            [17, 12],
+            [17, 5],
+            [15, 0], // "GuiroShort" in 2.0, "Guiro" in 3.0 (which was "GuiroLong" in 2.0) (TODO: decay?)
+            [15, 0],
+            [8, 0],
+            [9, 0],
+            [9, -4],
+            [17, -5],
+            [17, 0],
+            [11, -6, 1],
+            [11, -6, 3]
+        ];
+    }
+
+    /**
      * The key to load & store a target's music-related state.
      * @type {string}
      */
@@ -712,6 +768,26 @@ class Scratch3MusicBlocks {
                         id: 'music.playDrumForBeats',
                         default: 'play drum [DRUM] for [BEATS] beats',
                         description: 'play drum sample for a number of beats'
+                    }),
+                    arguments: {
+                        DRUM: {
+                            type: ArgumentType.NUMBER,
+                            menu: 'DRUM',
+                            defaultValue: 1
+                        },
+                        BEATS: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: 0.25
+                        }
+                    }
+                },
+                {
+                    opcode: 'midiPlayDrumForBeats',
+                    blockType: BlockType.COMMAND,
+                    text: formatMessage({
+                        id: 'music.midiPlayDrumForBeats',
+                        default: 'play drum [DRUM] for [BEATS] beats',
+                        description: 'play drum sample for a number of beats according to a mapping of MIDI codes'
                     }),
                     arguments: {
                         DRUM: {
@@ -846,14 +922,46 @@ class Scratch3MusicBlocks {
      * @property {number} BEATS - the duration in beats of the drum sound.
      */
     playDrumForBeats (args, util) {
+        this._playDrumForBeats(args.DRUM, args.BEATS, util, false);
+    }
+
+    /**
+     * Play a drum sound for some number of beats according to the range of "MIDI" drum codes supported.
+     * This block is implemented for compatibility with old Scratch projects that use the
+     * 'drum:duration:elapsed:from:' block.
+     * @param {object} args - the block arguments.
+     * @param {object} util - utility object provided by the runtime.
+     */
+    midiPlayDrumForBeats (args, util) {
+        this._playDrumForBeats(args.DRUM, args.BEATS, util, true);
+    }
+
+    /**
+     * Internal code to play a drum sound for some number of beats. If mapMidi is true, choose the sound according to
+     * the MIDI to Scratch drum mapping.
+     * @param {number} drumNum - the drum number.
+     * @param {beats} beats - the duration in beats to pause after playing the sound.
+     */
+    _playDrumForBeats (drumNum, beats, util, mapMidi) {
         if (this._stackTimerNeedsInit(util)) {
-            let drum = Cast.toNumber(args.DRUM);
-            drum = Math.round(drum);
-            drum -= 1; // drums are one-indexed
-            drum = MathUtil.wrapClamp(drum, 0, this.DRUM_INFO.length - 1);
-            let beats = Cast.toNumber(args.BEATS);
+            drumNum = Cast.toNumber(drumNum);
+            drumNum = Math.round(drumNum);
+            let pitchShift = 0;
+            if (mapMidi) {
+                const midiDescription = this.MIDI_DRUMS[drumNum - 35];
+                if (midiDescription) {
+                    drumNum = midiDescription[0];
+                    pitchShift = midiDescription[1] * 10; // 10 = one semitone
+                } else {
+                    drumNum = 2;
+                }
+            } else {
+                drumNum -= 1; // drums are one-indexed
+            }
+            drumNum = MathUtil.wrapClamp(drumNum, 0, this.DRUM_INFO.length - 1);
+            beats = Cast.toNumber(beats);
             beats = this._clampBeats(beats);
-            this._playDrumNum(util, drum);
+            this._playDrumNum(util, drumNum, pitchShift);
             this._startStackTimer(util, this._beatsToSec(beats));
         } else {
             this._checkStackTimer(util);
@@ -863,10 +971,11 @@ class Scratch3MusicBlocks {
     /**
      * Play a drum sound using its 0-indexed number.
      * @param {object} util - utility object provided by the runtime.
-     * @param  {number} drumNum - the number of the drum to play.
+     * @param {number} drumNum - the number of the drum to play.
+     * @param {number} pitchShift - pitch shift to be applied (in addition to sprite's "pitch" audio effect).
      * @private
      */
-    _playDrumNum (util, drumNum) {
+    _playDrumNum (util, drumNum, pitchShift) {
         if (util.runtime.audioEngine === null) return;
         if (util.target.sprite.soundBank === null) return;
         // If we're playing too many sounds, do not play the drum sound.
@@ -887,8 +996,19 @@ class Scratch3MusicBlocks {
 
         const engine = util.runtime.audioEngine;
         const chain = engine.createEffectChain();
-        chain.setEffectsFromTarget(util.target);
+        const soundEffects = Object.assign({}, util.target.soundEffects);
+        if (pitchShift) {
+            soundEffects.pitch = (soundEffects.pitch || 0) + pitchShift;
+        }
+        chain.setEffectsFromTarget(soundEffects);
         player.connect(chain);
+
+        // Dirty hack to make the pitch effect work - otherwise the effect isn't applied, for some reason.
+        // (Other audio effects work fine without this, though.)
+        const pitchEffect = chain._effects.find(effect => effect.name === 'pitch')
+        if (pitchEffect) {
+            pitchEffect.updatePlayer(player);
+        }
 
         this._concurrencyCounter++;
         player.once('stop', () => {

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -923,7 +923,7 @@ class Scratch3MusicBlocks {
      * @property {number} BEATS - the duration in beats of the drum sound.
      */
     playDrumForBeats (args, util) {
-        this._playDrumForBeats(args.DRUM, args.BEATS, util, false);
+        this._playDrumForBeats(args.DRUM, args.BEATS, util);
     }
 
     /**
@@ -934,31 +934,29 @@ class Scratch3MusicBlocks {
      * @param {object} util - utility object provided by the runtime.
      */
     midiPlayDrumForBeats (args, util) {
-        this._playDrumForBeats(args.DRUM, args.BEATS, util, true);
+        let drumNum = Cast.toNumber(args.DRUM);
+        drumNum = Math.round(drumNum);
+        const midiDescription = this.MIDI_DRUMS[drumNum - 35];
+        if (midiDescription) {
+            drumNum = midiDescription[0];
+        } else {
+            drumNum = 2;
+        }
+        drumNum += 1; // drumNum input to _playDrumForBeats is one-indexed
+        this._playDrumForBeats(drumNum, args.BEATS, util);
     }
 
     /**
-     * Internal code to play a drum sound for some number of beats. If mapMidi is true, choose the sound according to
-     * the MIDI to Scratch drum mapping.
+     * Internal code to play a drum sound for some number of beats.
      * @param {number} drumNum - the drum number.
      * @param {beats} beats - the duration in beats to pause after playing the sound.
      * @param {object} util - utility object provided by the runtime.
-     * @param {boolean} mapMidi - whether or not drumNum is a MIDI drum number.
      */
-    _playDrumForBeats (drumNum, beats, util, mapMidi) {
+    _playDrumForBeats (drumNum, beats, util) {
         if (this._stackTimerNeedsInit(util)) {
             drumNum = Cast.toNumber(drumNum);
             drumNum = Math.round(drumNum);
-            if (mapMidi) {
-                const midiDescription = this.MIDI_DRUMS[drumNum - 35];
-                if (midiDescription) {
-                    drumNum = midiDescription[0];
-                } else {
-                    drumNum = 2;
-                }
-            } else {
-                drumNum -= 1; // drums are one-indexed
-            }
+            drumNum -= 1; // drums are one-indexed
             drumNum = MathUtil.wrapClamp(drumNum, 0, this.DRUM_INFO.length - 1);
             beats = Cast.toNumber(beats);
             beats = this._clampBeats(beats);

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -503,6 +503,21 @@ const specMap = {
             }
         ]
     },
+    'drum:duration:elapsed:from:': {
+        opcode: 'music_midiPlayDrumForBeats',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'DRUM'
+            },
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'BEATS'
+            }
+        ]
+    },
     'rest:elapsed:from:': {
         opcode: 'music_restForBeats',
         argMap: [


### PR DESCRIPTION
### Resolves

Fixes #1424. Sort of a follow up to #1329 and #355.

This also (not) accidentally allows the "set (audio) effect" block's "pitch" to have an effect on drums. I figure this is okay since the pan left/right effect already worked; and it's necessary to have the MIDI drum approximations.

### Proposed Changes

Adds support for the obsolete `drum:duration:elapsed:from:` block, including very similar MIDI drum approximations to the ones originally created [for Scratch 2.0](https://github.com/LLK/scratch-flash/blob/646523e6846ad0dd993213a38b46fe2ea511d026/src/sound/SoundBank.as#L339-L388).

### Reason for Changes

Compatibility with old Scratch projects (and new ones which use that block).

### Test Coverage

Tested manually by confirming that:

* The examples in [this project](https://scratch.mit.edu/projects/248475643/) are all correct.
* @as-com's ["Canyon.mid"](https://scratch.mit.edu/projects/115797375/) project runs correctly. (It's *beautiful!*)
