### PR TITLE
Fix midi instruments doc

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -537,7 +537,7 @@ class Scratch3MusicBlocks {
 
     /**
      * An array that is a mapping from MIDI instrument numbers to Scratch instrument numbers.
-     * @type {number[]} an array of Scratch instrument numbers.
+     * @type {number[]}
      */
     get MIDI_INSTRUMENTS () {
         return [


### PR DESCRIPTION
### Resolves

Fix breaking travis `NPM_SCRIPT=build` job.

### Proposed Changes

Remove description from `@type` tag for `MIDI_INSTRUMENTS`.

### Reason for Changes

> The `@type` tag does not permit a description;

This is causing jsdoc to exit with code 1.
