### PR TITLE
Stop other sounds

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -42,6 +42,7 @@ class Scratch3SensingBlocks {
         this.runtime.on('ANSWER', this._onAnswer.bind(this));
         this.runtime.on('PROJECT_START', this._resetAnswer.bind(this));
         this.runtime.on('PROJECT_STOP_ALL', this._clearAllQuestions.bind(this));
+        this.runtime.on('STOP_FOR_TARGET', this._clearTargetQuestions.bind(this));
     }
 
     /**
@@ -132,6 +133,21 @@ class Scratch3SensingBlocks {
     _clearAllQuestions () {
         this._questionList = [];
         this.runtime.emit('QUESTION', null);
+    }
+
+    _clearTargetQuestions (stopTarget) {
+        const currentlyAsking = this._questionList.length > 0 && this._questionList[0][2] === stopTarget;
+        this._questionList = this._questionList.filter(question => (
+            question[2] !== stopTarget
+        ));
+
+        if (currentlyAsking) {
+            if (this._questionList.length > 0) {
+                this._askNextQuestion();
+            } else {
+                this.runtime.emit('QUESTION', null);
+            }
+        }
     }
 
     askAndWait (args, util) {

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -2,6 +2,12 @@ const MathUtil = require('../util/math-util');
 const Cast = require('../util/cast');
 const Clone = require('../util/clone');
 
+/**
+ * Occluded boolean value to make its use more understandable.
+ * @const {boolean}
+ */
+const STORE_WAITING = true;
+
 class Scratch3SoundBlocks {
     constructor (runtime) {
         /**
@@ -10,14 +16,16 @@ class Scratch3SoundBlocks {
          */
         this.runtime = runtime;
 
+        this.waitingSounds = {};
+
         // Clear sound effects on green flag and stop button events.
         this.stopAllSounds = this.stopAllSounds.bind(this);
-        this._stopAllSoundsForTarget = this._stopAllSoundsForTarget.bind(this);
+        this._stopWaitingSoundsForTarget = this._stopWaitingSoundsForTarget.bind(this);
         this._clearEffectsForAllTargets = this._clearEffectsForAllTargets.bind(this);
         if (this.runtime) {
             this.runtime.on('PROJECT_STOP_ALL', this.stopAllSounds);
             this.runtime.on('PROJECT_STOP_ALL', this._clearEffectsForAllTargets);
-            this.runtime.on('STOP_FOR_TARGET', this._stopAllSoundsForTarget);
+            this.runtime.on('STOP_FOR_TARGET', this._stopWaitingSoundsForTarget);
             this.runtime.on('PROJECT_START', this._clearEffectsForAllTargets);
         }
 
@@ -145,19 +153,42 @@ class Scratch3SoundBlocks {
 
     playSound (args, util) {
         // Don't return the promise, it's the only difference for AndWait
-        this.playSoundAndWait(args, util);
+        this._playSound(args, util);
     }
 
     playSoundAndWait (args, util) {
+        return this._playSound(args, util, STORE_WAITING);
+    }
+
+    _playSound (args, util, storeWaiting) {
         const index = this._getSoundIndex(args.SOUND_MENU, util);
         if (index >= 0) {
             const {target} = util;
             const {sprite} = target;
             const {soundId} = sprite.sounds[index];
             if (sprite.soundBank) {
+                if (storeWaiting === STORE_WAITING) {
+                    this._addWaitingSound(target.id, soundId);
+                } else {
+                    this._removeWaitingSound(target.id, soundId);
+                }
                 return sprite.soundBank.playSound(target, soundId);
             }
         }
+    }
+
+    _addWaitingSound (targetId, soundId) {
+        if (!this.waitingSounds[targetId]) {
+            this.waitingSounds[targetId] = new Set();
+        }
+        this.waitingSounds[targetId].add(soundId);
+    }
+
+    _removeWaitingSound (targetId, soundId) {
+        if (!this.waitingSounds[targetId]) {
+            return;
+        }
+        this.waitingSounds[targetId].delete(soundId);
     }
 
     _getSoundIndex (soundName, util) {
@@ -205,6 +236,20 @@ class Scratch3SoundBlocks {
     _stopAllSoundsForTarget (target) {
         if (target.sprite.soundBank) {
             target.sprite.soundBank.stopAllSounds(target);
+            if (this.waitingSounds[target.id]) {
+                this.waitingSounds[target.id].clear();
+            }
+        }
+    }
+
+    _stopWaitingSoundsForTarget (target) {
+        if (target.sprite.soundBank) {
+            if (this.waitingSounds[target.id]) {
+                for (const soundId of this.waitingSounds[target.id].values()) {
+                    target.sprite.soundBank.stop(target, soundId);
+                }
+                this.waitingSounds[target.id].clear();
+            }
         }
     }
 

--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -11,9 +11,13 @@ class Scratch3SoundBlocks {
         this.runtime = runtime;
 
         // Clear sound effects on green flag and stop button events.
+        this.stopAllSounds = this.stopAllSounds.bind(this);
+        this._stopAllSoundsForTarget = this._stopAllSoundsForTarget.bind(this);
         this._clearEffectsForAllTargets = this._clearEffectsForAllTargets.bind(this);
         if (this.runtime) {
+            this.runtime.on('PROJECT_STOP_ALL', this.stopAllSounds);
             this.runtime.on('PROJECT_STOP_ALL', this._clearEffectsForAllTargets);
+            this.runtime.on('STOP_FOR_TARGET', this._stopAllSoundsForTarget);
             this.runtime.on('PROJECT_START', this._clearEffectsForAllTargets);
         }
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -378,6 +378,15 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for target being stopped by a stop for target call.
+     * Used by blocks that need to stop individual targets.
+     * @const {string}
+     */
+    static get STOP_FOR_TARGET () {
+        return 'STOP_FOR_TARGET';
+    }
+
+    /**
      * Event name for visual value report.
      * @const {string}
      */
@@ -1382,6 +1391,9 @@ class Runtime extends EventEmitter {
      * @param {Thread=} optThreadException Optional thread to skip.
      */
     stopForTarget (target, optThreadException) {
+        // Emit stop event to allow blocks to clean up any state.
+        this.emit(Runtime.STOP_FOR_TARGET, target, optThreadException);
+
         // Stop any threads on the target.
         for (let i = 0; i < this.threads.length; i++) {
             if (this.threads[i] === optThreadException) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1055,9 +1055,6 @@ class RenderedTarget extends Target {
      */
     onStopAll () {
         this.clearEffects();
-        if (this.sprite.soundBank) {
-            this.sprite.soundBank.stopAllSounds();
-        }
     }
 
     /**

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -67,7 +67,7 @@ test('ask and stop all dismisses question', t => {
 test('ask and stop other scripts dismisses if it is the last question', t => {
     const rt = new Runtime();
     const s = new Sensing(rt);
-    const util = {target: {visible: false}, thread: {}};
+    const util = {target: {visible: false, sprite: {}}, thread: {}};
 
     const expectedQuestion = 'a question';
 
@@ -94,8 +94,8 @@ test('ask and stop other scripts dismisses if it is the last question', t => {
 test('ask and stop other scripts asks next question', t => {
     const rt = new Runtime();
     const s = new Sensing(rt);
-    const util = {target: {visible: false}, thread: {}};
-    const util2 = {target: {visible: false}, thread: {}};
+    const util = {target: {visible: false, sprite: {}}, thread: {}};
+    const util2 = {target: {visible: false, sprite: {}}, thread: {}};
 
     const expectedQuestion = 'a question';
     const nextQuestion = 'a followup';

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -37,6 +37,90 @@ test('ask and answer with a hidden target', t => {
     });
 });
 
+test('ask and stop all dismisses question', t => {
+    const rt = new Runtime();
+    const s = new Sensing(rt);
+    const util = {target: {visible: false}};
+
+    const expectedQuestion = 'a question';
+
+    let call = 0;
+
+    rt.addListener('QUESTION', question => {
+        if (call === 0) {
+            // (2) Assert the question was passed.
+            t.strictEqual(question, expectedQuestion);
+        } else if (call === 1) {
+            // (4) Assert the question was dismissed.
+            t.strictEqual(question, null);
+            t.end();
+        }
+        call += 1;
+    });
+
+    // (1) Emit the question.
+    s.askAndWait({QUESTION: expectedQuestion}, util);
+    // (3) Emit the stop all event.
+    rt.stopAll();
+});
+
+test('ask and stop other scripts dismisses if it is the last question', t => {
+    const rt = new Runtime();
+    const s = new Sensing(rt);
+    const util = {target: {visible: false}, thread: {}};
+
+    const expectedQuestion = 'a question';
+
+    let call = 0;
+
+    rt.addListener('QUESTION', question => {
+        if (call === 0) {
+            // (2) Assert the question was passed.
+            t.strictEqual(question, expectedQuestion);
+        } else if (call === 1) {
+            // (4) Assert the question was dismissed.
+            t.strictEqual(question, null);
+            t.end();
+        }
+        call += 1;
+    });
+
+    // (1) Emit the questions.
+    s.askAndWait({QUESTION: expectedQuestion}, util);
+    // (3) Emit the stop for target event.
+    rt.stopForTarget(util.target, util.thread);
+});
+
+test('ask and stop other scripts asks next question', t => {
+    const rt = new Runtime();
+    const s = new Sensing(rt);
+    const util = {target: {visible: false}, thread: {}};
+    const util2 = {target: {visible: false}, thread: {}};
+
+    const expectedQuestion = 'a question';
+    const nextQuestion = 'a followup';
+
+    let call = 0;
+
+    rt.addListener('QUESTION', question => {
+        if (call === 0) {
+            // (2) Assert the question was passed.
+            t.strictEqual(question, expectedQuestion);
+        } else if (call === 1) {
+            // (4) Assert the next question was passed.
+            t.strictEqual(question, nextQuestion);
+            t.end();
+        }
+        call += 1;
+    });
+
+    // (1) Emit the questions.
+    s.askAndWait({QUESTION: expectedQuestion}, util);
+    s.askAndWait({QUESTION: nextQuestion}, util2);
+    // (3) Emit the stop for target event.
+    rt.stopForTarget(util.target, util.thread);
+});
+
 test('ask and answer with a visible target', t => {
     const rt = new Runtime();
     const s = new Sensing(rt);


### PR DESCRIPTION
### Resolves

Fix https://github.com/LLK/scratch-vm/issues/1410

### Proposed Changes

Depends on https://github.com/LLK/scratch-vm/pull/1631
Move all sounds stopping to be controled by scratch3_sounds, RenderedTarget should not instruct the sounds to stop in `stopAll`.
Stop sounds for single stopping targets in scratch3_sounds.

### Reason for Changes

In scratch 2 the `stop other scripts in sprite` block also stops sounds playing from that target.

It seemed to make sense to have this per-target stopping and all targets stopping control in scratch3_sounds.
