### PR TITLE
Only parse visible monitors

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -682,7 +682,9 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip)
                 }
             }
             for (let n = 0; n < deferredMonitors.length; n++) {
-                parseMonitorObject(deferredMonitors[n], runtime, targets, extensions);
+                if (deferredMonitors[n].visible) {
+                    parseMonitorObject(deferredMonitors[n], runtime, targets, extensions);
+                }
             }
             return targets;
         })


### PR DESCRIPTION
### Resolves

Initializing the video sensing extension for monitors that aren't visible: https://github.com/LLK/scratch-vm/issues/1433

### Proposed Changes

I've added a check for a monitor's visibility before passing it to `parseMonitorObject` in sb2.js, which is where a sb2 project could have `senseVideoMotion` added to its extensions even though there are no video motion blocks in the project.

### Reason for Changes

Scratch 2 adds a video motion monitor to project.json when you check the video motion sensing block, but doesn't remove it once the box is unchecked. If we prevent monitor blocks with `visible: false` from being parsed, we won't initialize extensions for monitor blocks that don't appear to be in use. 

@mzgoddard and I were also thinking we should add checks to ensure the video motion extension also honors the project's initial property values for `videoOn` and `videoAlpha`, but we can do that in a separate PR. 

