### PR TITLE
Differentiate peripheral errors: request vs. disconnect

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -448,11 +448,19 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Event name for reporting that a peripheral has encountered an error.
+     * Event name for reporting that a peripheral has encountered a request error.
      * @const {string}
      */
-    static get PERIPHERAL_ERROR () {
-        return 'PERIPHERAL_ERROR';
+    static get PERIPHERAL_REQUEST_ERROR () {
+        return 'PERIPHERAL_REQUEST_ERROR';
+    }
+
+    /**
+     * Event name for reporting that a peripheral has encountered a disconnect error.
+     * @const {string}
+     */
+    static get PERIPHERAL_DISCONNECT_ERROR () {
+        return 'PERIPHERAL_DISCONNECT_ERROR';
     }
 
     /**

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -1,6 +1,6 @@
 const JSONRPCWebSocket = require('../util/jsonrpc-web-socket');
 const ScratchLinkWebSocket = 'wss://device-manager.scratch.mit.edu:20110/scratch/ble';
-const log = require('../util/log');
+// const log = require('../util/log');
 
 class BLE extends JSONRPCWebSocket {
 
@@ -69,7 +69,6 @@ class BLE extends JSONRPCWebSocket {
      */
     disconnect () {
         this._ws.close();
-        this._connected = false;
     }
 
     /**
@@ -171,21 +170,22 @@ class BLE extends JSONRPCWebSocket {
         }
     }
 
-    _sendRequestError (e) {
-        console.log('request error');
-        log.error(`BLE error: ${JSON.stringify(e)}`);
+    _sendRequestError (/* e */) {
+        // log.error(`BLE error: ${JSON.stringify(e)}`);
+
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_REQUEST_ERROR, {
             message: `Scratch lost connection to`,
             extensionId: this._extensionId
         });
     }
 
-    _sendDisconnectError (e) {
-        console.log('attempting sendDiconnect error, and this_connected is:');
-        console.log(this._connected);
+    _sendDisconnectError (/* e */) {
+        // log.error(`BLE error: ${JSON.stringify(e)}`);
+
         if (!this._connected) return;
-        console.log('disconnect error');
-        log.error(`BLE error: ${JSON.stringify(e)}`);
+
+        this._connected = false;
+
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_DISCONNECT_ERROR, {
             message: `Scratch lost connection to`,
             extensionId: this._extensionId

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -69,7 +69,6 @@ class BT extends JSONRPCWebSocket {
      */
     disconnect () {
         this._ws.close();
-        this._connected = false;
     }
 
     /**
@@ -116,6 +115,7 @@ class BT extends JSONRPCWebSocket {
 
     _sendRequestError (/* e */) {
         // log.error(`BT error: ${JSON.stringify(e)}`);
+
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_REQUEST_ERROR, {
             message: `Scratch lost connection to`,
             extensionId: this._extensionId
@@ -123,8 +123,12 @@ class BT extends JSONRPCWebSocket {
     }
 
     _sendDisconnectError (/* e */) {
-        if (this._connected) this.disconnect();
         // log.error(`BT error: ${JSON.stringify(e)}`);
+
+        if (!this._connected) return;
+
+        this._connected = false;
+
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_DISCONNECT_ERROR, {
             message: `Scratch lost connection to`,
             extensionId: this._extensionId

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -19,8 +19,8 @@ class BT extends JSONRPCWebSocket {
 
         this._ws = ws;
         this._ws.onopen = this.requestPeripheral.bind(this); // only call request peripheral after socket opens
-        this._ws.onerror = this._sendError.bind(this, 'ws onerror');
-        this._ws.onclose = this._sendError.bind(this, 'ws onclose');
+        this._ws.onerror = this._sendDisconnectError.bind(this, 'ws onerror');
+        this._ws.onclose = this._sendDisconnectError.bind(this, 'ws onclose');
 
         this._availablePeripherals = {};
         this._connectCallback = connectCallback;
@@ -42,7 +42,7 @@ class BT extends JSONRPCWebSocket {
             this._availablePeripherals = {};
             this._discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
             this.sendRemoteRequest('discover', this._peripheralOptions)
-                .catch(e => this._sendError(e)); // never reached?
+                .catch(e => this._sendRequestError(e)); // never reached?
         }
         // TODO: else?
     }
@@ -60,7 +60,7 @@ class BT extends JSONRPCWebSocket {
                 this._connectCallback();
             })
             .catch(e => {
-                this._sendError(e);
+                this._sendRequestError(e);
             });
     }
 
@@ -82,7 +82,7 @@ class BT extends JSONRPCWebSocket {
     sendMessage (options) {
         return this.sendRemoteRequest('send', options)
             .catch(e => {
-                this._sendError(e);
+                this._sendDisconnectError(e);
             });
     }
 
@@ -114,10 +114,18 @@ class BT extends JSONRPCWebSocket {
         }
     }
 
-    _sendError (/* e */) {
+    _sendRequestError (/* e */) {
+        // log.error(`BT error: ${JSON.stringify(e)}`);
+        this._runtime.emit(this._runtime.constructor.PERIPHERAL_REQUEST_ERROR, {
+            message: `Scratch lost connection to`,
+            extensionId: this._extensionId
+        });
+    }
+
+    _sendDisconnectError (/* e */) {
         if (this._connected) this.disconnect();
         // log.error(`BT error: ${JSON.stringify(e)}`);
-        this._runtime.emit(this._runtime.constructor.PERIPHERAL_ERROR, {
+        this._runtime.emit(this._runtime.constructor.PERIPHERAL_DISCONNECT_ERROR, {
             message: `Scratch lost connection to`,
             extensionId: this._extensionId
         });

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -111,8 +111,11 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.PERIPHERAL_CONNECTED, () =>
             this.emit(Runtime.PERIPHERAL_CONNECTED)
         );
-        this.runtime.on(Runtime.PERIPHERAL_ERROR, data =>
-            this.emit(Runtime.PERIPHERAL_ERROR, data)
+        this.runtime.on(Runtime.PERIPHERAL_REQUEST_ERROR, () =>
+            this.emit(Runtime.PERIPHERAL_REQUEST_ERROR)
+        );
+        this.runtime.on(Runtime.PERIPHERAL_DISCONNECT_ERROR, data =>
+            this.emit(Runtime.PERIPHERAL_DISCONNECT_ERROR, data)
         );
         this.runtime.on(Runtime.PERIPHERAL_SCAN_TIMEOUT, () =>
             this.emit(Runtime.PERIPHERAL_SCAN_TIMEOUT)


### PR DESCRIPTION
### Resolves

Resolves #1638: Hardware disconnection alerts appear when no device was connected

### Proposed Changes

Handle two different types of peripheral errors in the VM:
- **request**: trigger connection modal error pane
- **disconnect**: trigger top-level GUI alert

### Associated

PR to land in GUI: https://github.com/LLK/scratch-gui/pull/3335
