### PR TITLE
Text to Speech voices update

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -129,7 +129,7 @@ class Scratch3Text2SpeechBlocks {
                     description: 'Name for a funny voice with a high pitch.'
                 }),
                 gender: 'female',
-                playbackRate: 1.4
+                playbackRate: 1.19 // +3 semitones
             },
             [GIANT_ID]: {
                 name: formatMessage({
@@ -138,7 +138,7 @@ class Scratch3Text2SpeechBlocks {
                     description: 'Name for a funny voice with a low pitch.'
                 }),
                 gender: 'male',
-                playbackRate: 0.84
+                playbackRate: 0.84 // -3 semitones
             },
             [KITTEN_ID]: {
                 name: formatMessage({
@@ -147,7 +147,7 @@ class Scratch3Text2SpeechBlocks {
                     description: 'A baby cat.'
                 }),
                 gender: 'female',
-                playbackRate: 1.4
+                playbackRate: 1.41 // +6 semitones
             }
         };
     }

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -42,12 +42,12 @@ const SPEECH_VOLUME = 250;
 /**
  * An id for one of the voices.
  */
-const QUINN_ID = 'QUINN';
+const ALTO_ID = 'ALTO';
 
 /**
  * An id for one of the voices.
  */
-const MAX_ID = 'MAX';
+const TENOR_ID = 'TENOR';
 
 /**
  * An id for one of the voices.
@@ -104,19 +104,19 @@ class Scratch3Text2SpeechBlocks {
      */
     get VOICE_INFO () {
         return {
-            [QUINN_ID]: {
+            [ALTO_ID]: {
                 name: formatMessage({
-                    id: 'text2speech.quinn',
-                    default: 'quinn',
+                    id: 'text2speech.alto',
+                    default: 'alto',
                     description: 'Name for a voice with ambiguous gender.'
                 }),
                 gender: 'female',
                 playbackRate: 1
             },
-            [MAX_ID]: {
+            [TENOR_ID]: {
                 name: formatMessage({
-                    id: 'text2speech.max',
-                    default: 'max',
+                    id: 'text2speech.tenor',
+                    default: 'tenor',
                     description: 'Name for a voice with ambiguous gender.'
                 }),
                 gender: 'male',
@@ -188,7 +188,7 @@ class Scratch3Text2SpeechBlocks {
      */
     static get DEFAULT_TEXT2SPEECH_STATE () {
         return {
-            voiceId: QUINN_ID
+            voiceId: ALTO_ID
         };
     }
 
@@ -263,7 +263,7 @@ class Scratch3Text2SpeechBlocks {
                         VOICE: {
                             type: ArgumentType.STRING,
                             menu: 'voices',
-                            defaultValue: QUINN_ID
+                            defaultValue: ALTO_ID
                         }
                     }
                 },

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -4,6 +4,7 @@ const nets = require('nets');
 const ArgumentType = require('../../extension-support/argument-type');
 const BlockType = require('../../extension-support/block-type');
 const Cast = require('../../util/cast');
+const MathUtil = require('../../util/math-util');
 const Clone = require('../../util/clone');
 const log = require('../../util/log');
 
@@ -338,9 +339,19 @@ class Scratch3Text2SpeechBlocks {
     setVoice (args, util) {
         const state = this._getState(util.target);
 
+        let voice = args.VOICE;
+
+        // If the arg is a dropped number, treat it as a voice index
+        let voiceNum = parseInt(voice, 10);
+        if (!isNaN(voiceNum)) {
+            voiceNum -= 1; // Treat dropped args as one-indexed
+            voiceNum = MathUtil.wrapClamp(voiceNum, 0, Object.keys(this.VOICE_INFO).length - 1);
+            voice = Object.keys(this.VOICE_INFO)[voiceNum];
+        }
+
         // Only set the voice if the arg is a valid voice id.
-        if (Object.keys(this.VOICE_INFO).includes(args.VOICE)) {
-            state.voiceId = args.VOICE;
+        if (Object.keys(this.VOICE_INFO).includes(voice)) {
+            state.voiceId = voice;
         }
     }
 


### PR DESCRIPTION
### Proposed Changes

- Change the first two voice names from "quinn" and "max" to "alto" and "tenor"
This makes them a bit more neutral (they are more like descriptions and less like names, which is hopefully less confusing).

- Adjust the pitch of the squeak voice to be a bit lower
This makes it easier to understand what the voice is saying.

- Add support for dropping a number onto the "set voice" block input
Now you can set the voice using a variable, where a one-indexed value maps to a voice. This makes it easier to make projects that interactively set the voice, and of course now you can set a random voice using the "pick random" block:

![screen shot 2018-10-11 at 11 56 34 am](https://user-images.githubusercontent.com/567844/46817234-bdc7da00-cd4c-11e8-8142-de8bb32aa51c.png)



