### PR TITLE
Remove "Don't translate Google"

### DIFF
--- a/src/extensions/scratch3_speech2text/index.js
+++ b/src/extensions/scratch3_speech2text/index.js
@@ -614,7 +614,7 @@ class Scratch3Speech2TextBlocks {
             name: formatMessage({
                 id: 'speech.extensionName',
                 default: 'Speech to Text',
-                description: 'Name of extension that adds speech recognition blocks. Do Not translate Google.'
+                description: 'Name of extension that adds speech recognition blocks.'
             }),
             menuIconURI: menuIconURI,
             blockIconURI: iconURI,


### PR DESCRIPTION
### Resolves
Resolves #1603 

### Proposed Changes
Removes "Don't translate Google" from translation description

### Reason for Changes
The original text didn't contain Google.
