### PR TITLE
Add runtime event for when the project is loaded

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -401,6 +401,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for targets installed report.
+     * @const {string}
+     */
+    static get TARGETS_INSTALLED () {
+        return 'TARGETS_INSTALLED';
+    }
+
+    /**
      * Event name for targets update report.
      * @const {string}
      */
@@ -1900,6 +1908,14 @@ class Runtime extends EventEmitter {
      */
     clonesAvailable () {
         return this._cloneCounter < Runtime.MAX_CLONES;
+    }
+
+    /**
+     * Report that targets have finished being installed in the Virtual Machine.
+     * @param {Target} installedTargets - the newly installedTargets.
+     */
+    emitTargetsInstalled (installedTargets) {
+        this.emit(Runtime.TARGETS_INSTALLED, installedTargets);
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -401,7 +401,7 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Event name for targets installed report.
+     * Event name for project loaded report.
      * @const {string}
      */
     static get PROJECT_LOADED () {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -404,8 +404,8 @@ class Runtime extends EventEmitter {
      * Event name for targets installed report.
      * @const {string}
      */
-    static get TARGETS_INSTALLED () {
-        return 'TARGETS_INSTALLED';
+    static get PROJECT_LOADED () {
+        return 'PROJECT_LOADED';
     }
 
     /**
@@ -1911,11 +1911,10 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Report that targets have finished being installed in the Virtual Machine.
-     * @param {Target} installedTargets - the newly installed targets.
+     * Report that the project has loaded in the Virtual Machine.
      */
-    emitTargetsInstalled (installedTargets) {
-        this.emit(Runtime.TARGETS_INSTALLED, installedTargets);
+    emitProjectLoaded () {
+        this.emit(Runtime.PROJECT_LOADED);
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1912,7 +1912,7 @@ class Runtime extends EventEmitter {
 
     /**
      * Report that targets have finished being installed in the Virtual Machine.
-     * @param {Target} installedTargets - the newly installedTargets.
+     * @param {Target} installedTargets - the newly installed targets.
      */
     emitTargetsInstalled (installedTargets) {
         this.emit(Runtime.TARGETS_INSTALLED, installedTargets);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -277,6 +277,7 @@ class VirtualMachine extends EventEmitter {
 
         return validationPromise
             .then(validatedInput => this.deserializeProject(validatedInput[0], validatedInput[1]))
+            .then(() => this.runtime.emitProjectLoaded())
             .catch(error => {
                 // Intentionally rejecting here (want errors to be handled by caller)
                 if (error.hasOwnProperty('validationError')) {
@@ -460,7 +461,6 @@ class VirtualMachine extends EventEmitter {
             this.emitTargetsUpdate();
             this.emitWorkspaceUpdate();
             this.runtime.setEditingTarget(this.editingTarget);
-            this.runtime.emitTargetsInstalled(targets);
         });
     }
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -460,6 +460,7 @@ class VirtualMachine extends EventEmitter {
             this.emitTargetsUpdate();
             this.emitWorkspaceUpdate();
             this.runtime.setEditingTarget(this.editingTarget);
+            this.runtime.emitTargetsInstalled(targets);
         });
     }
 

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -125,7 +125,7 @@ test('Installing targets emits runtime event', t => {
     });
 
     vm.loadProject(project).then(() => {
-        // Event emitted on project load
+        // Event emitted when targets are installed during project load
         t.equal(targetsInstalled, true);
         targetsInstalled = null;
 

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -112,27 +112,18 @@ test('getLabelForOpcode', t => {
     t.end();
 });
 
-test('Installing targets emits runtime event', t => {
+test('Project loaded emits runtime event', t => {
     const vm = new VirtualMachine();
     const projectUri = path.resolve(__dirname, '../fixtures/default.sb2');
     const project = readFileToBuffer(projectUri);
-    const spriteUri = path.resolve(__dirname, '../fixtures/example_sprite.sprite2');
-    const sprite = readFileToBuffer(spriteUri);
-    let targetsInstalled = null;
+    let projectLoaded = false;
 
-    vm.runtime.addListener('TARGETS_INSTALLED', () => {
-        targetsInstalled = true;
+    vm.runtime.addListener('PROJECT_LOADED', () => {
+        projectLoaded = true;
     });
 
     vm.loadProject(project).then(() => {
-        // Event emitted when targets are installed during project load
-        t.equal(targetsInstalled, true);
-        targetsInstalled = null;
-
-        // Event emitted when later targets are installed
-        vm.addSprite(sprite).then(() => {
-            t.equal(targetsInstalled, true);
-            t.end();
-        });
+        t.equal(projectLoaded, true, 'Project load event emitted');
+        t.end();
     });
 });


### PR DESCRIPTION
### Resolves

This PR resolves #1639

### Proposed Changes

Add an event to a project's runtime to alert any listeners that the project's targets have been installed in the virtual machine.

### Reason for Changes

As mentioned in the issue, extensions don't currently have a way to know if targets are installed. This can lead to race conditions where extensions check for a target (like the stage) when they are being loaded, but the targets are only installed after the extensions load.

### Test Coverage

Add a test in `test/unit/engine_runtime.js` to check whether the event is fired by the runtime instance whenever targets are installed.


