### PR TITLE
Save and load the language setting for Text to Speech

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -158,21 +158,51 @@ class Scratch3Text2SpeechBlocks {
      */
     get LANGUAGE_INFO () {
         return {
-            'Danish': 'da-DK',
-            'Dutch': 'nl-NL',
-            'English': 'en-US',
-            'French': 'fr-FR',
-            'German': 'de-DE',
-            'Icelandic': 'is-IS',
-            'Italian': 'it-IT',
-            'Japanese': 'ja-JP',
-            'Polish': 'pl-PL',
-            'Portuguese (Brazilian)': 'pt-BR',
-            'Portuguese (European)': 'pt-PT',
-            'Russian': 'ru-RU',
-            'Spanish (European)': 'es-ES',
-            'Spanish (Latin American)': 'es-US'
+            'Danish': 'da',
+            'Dutch': 'nl',
+            'English': 'en',
+            'French': 'fr',
+            'German': 'de',
+            'Icelandic': 'is',
+            'Italian': 'it',
+            'Japanese': 'ja',
+            'Polish': 'pl',
+            'Portuguese (Brazilian)': 'pt-br',
+            'Portuguese (European)': 'pt',
+            'Russian': 'ru',
+            'Spanish (European)': 'es',
+            'Spanish (Latin American)': 'es-419'
         };
+    }
+
+    /**
+     * This is a temporary adapter to convert Scratch locale codes to Amazon polly's locale codes.
+     * @todo remove this once the speech synthesis server can perform this conversion
+     * @param {string} locale the Scratch locale to convert.
+     * @return {string} the Amazon polly locale.
+     */
+    localeToPolly (locale) {
+        const pollyLocales = {
+            'da': 'da-DK', // Danish
+            'nl': 'nl-NL', // Dutch
+            'en': 'en-US', // English
+            'fr': 'fr-FR', // French
+            'de': 'de-DE', // German
+            'is': 'is-IS', // Icelandic
+            'it': 'it-IT', // Italian
+            'ja': 'ja-JP', // Japanese
+            'pl': 'pl-PL', // Polish
+            'pt-br': 'pt-BR', // Portuguese (Brazilian)
+            'pt': 'pt-PT', // Portuguese (European)
+            'ru': 'ru-RU', // Russian
+            'es': 'es-ES', // Spanish (European)
+            'es-419': 'es-US' // Spanish (Latin American)
+        };
+        let converted = 'en-US';
+        if (pollyLocales[locale]) {
+            converted = pollyLocales[locale];
+        }
+        return converted;
     }
 
     /**
@@ -397,7 +427,7 @@ class Scratch3Text2SpeechBlocks {
 
         // Build up URL
         let path = `${SERVER_HOST}/synth`;
-        path += `?locale=${this.currentLanguage}`;
+        path += `?locale=${this.localeToPolly(this.currentLanguage)}`;
         path += `&gender=${gender}`;
         path += `&text=${encodeURI(words.substring(0, 128))}`;
 

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -259,6 +259,17 @@ class Scratch3Text2SpeechBlocks {
      * @returns {object} metadata for this extension and its blocks.
      */
     getInfo () {
+        // Only localize the default input to the "speak" block if we are in a
+        // supported language.
+        let defaultTextToSpeak = 'hello';
+        if (this.isSupportedLanguage(this.getEditorLanguage())) {
+            defaultTextToSpeak = formatMessage({
+                id: 'text2speech.defaultTextToSpeak',
+                default: defaultTextToSpeak,
+                description: 'hello: the default text to speak'
+            });
+        }
+
         return {
             id: 'text2speech',
             name: 'Text to Speech',
@@ -276,11 +287,7 @@ class Scratch3Text2SpeechBlocks {
                     arguments: {
                         WORDS: {
                             type: ArgumentType.STRING,
-                            defaultValue: formatMessage({
-                                id: 'text2speech.defaultTextToSpeak',
-                                default: 'hello',
-                                description: 'hello: the default text to speak'
-                            })
+                            defaultValue: defaultTextToSpeak
                         }
                     }
                 },
@@ -357,7 +364,7 @@ class Scratch3Text2SpeechBlocks {
         const stage = this.runtime.getTargetForStage();
         if (!stage) return;
         // Only set the language if it is in the list.
-        if (Object.values(this.LANGUAGE_INFO).includes(languageCode)) {
+        if (this.isSupportedLanguage(languageCode)) {
             stage.textToSpeechLanguage = languageCode;
         }
         // If the language is null, set it to the default language.
@@ -366,6 +373,16 @@ class Scratch3Text2SpeechBlocks {
         if (!stage.textToSpeechLanguage) {
             stage.textToSpeechLanguage = this.DEFAULT_LANGUAGE;
         }
+    }
+
+    /**
+     * Check if a language code is in the list of supported languages for the
+     * speech synthesis service.
+     * @param {string} languageCode the language code to check.
+     * @returns {boolean} true if the language code is supported.
+     */
+    isSupportedLanguage (languageCode) {
+        return Object.values(this.LANGUAGE_INFO).includes(languageCode);
     }
 
     /**

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -445,6 +445,7 @@ const serializeTarget = function (target, extensions) {
         if (target.hasOwnProperty('tempo')) obj.tempo = target.tempo;
         if (target.hasOwnProperty('videoTransparency')) obj.videoTransparency = target.videoTransparency;
         if (target.hasOwnProperty('videoState')) obj.videoState = target.videoState;
+        if (target.hasOwnProperty('textToSpeechLanguage')) obj.textToSpeechLanguage = target.textToSpeechLanguage;
     } else { // The stage does not need the following properties, but sprites should
         obj.visible = target.visible;
         obj.x = target.x;
@@ -886,6 +887,9 @@ const parseScratchObject = function (object, runtime, extensions, zip) {
     }
     if (object.hasOwnProperty('videoState')) {
         target.videoState = object.videoState;
+    }
+    if (object.hasOwnProperty('textToSpeechLanguage')) {
+        target.textToSpeechLanguage = object.textToSpeechLanguage;
     }
     if (object.hasOwnProperty('variables')) {
         for (const varId in object.variables) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -152,6 +152,14 @@ class RenderedTarget extends Target {
          * @type {string}
          */
         this.videoState = RenderedTarget.VIDEO_STATE.ON;
+
+        /**
+         * The language to use for speech synthesis, in the text2speech extension.
+         * It is initialized to null so that on extension load, we can check for
+         * this and try setting it using the editor locale.
+         * @type {string}
+         */
+        this.textToSpeechLanguage = null;
     }
 
     /**
@@ -1139,6 +1147,7 @@ class RenderedTarget extends Target {
             variables: this.variables,
             costumes: costumes,
             sounds: this.getSounds(),
+            textToSpeechLanguage: this.textToSpeechLanguage,
             tempo: this.tempo,
             volume: this.volume,
             videoTransparency: this.videoTransparency,


### PR DESCRIPTION
### Proposed Changes

- Save and load a property on the stage for the language code used by the Text to Speech extension.
- Move the conversion to Polly's language code format into an adapter function, to be removed once we have this conversion on the proxy server.
- On extension load, set the language for the extension using the editor language, if it is one of the supported languages for speech synthesis.
- Only localize the default input to the `speak` block if the editor is in a supported language. i.e. if the editor is in an unsupported language, we will be using English language speech synthesis, so the block should use the default English input ("hello").

Some remaining improvements I think we need (for future work):
- Handling changes to the editor language after the extension has been loaded. It's not clear to me what should happen in this case (maybe nothing).
- The `set language` block should accept a dropped language name (and this should work in any language). E.g. You should be able to use the “language” reporter from translate to set the text2speech language.
 
### Reason for Changes

This is progress toward making the Text to Speech extension work well across languages. We need to save and load the language so that when a project is shared, it will remember the language of the creator, and correctly speak they text they have entered, if the viewer of the project is using a different language (i.e. even if the project does not contain a `set language` block). 