### PR TITLE
Close Scratch Link web socket on every new peripheral scan attempt

### DIFF
--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -556,13 +556,12 @@ class EV3 {
      */
     scan () {
         if (this._bt) {
-            this._bt.requestPeripheral();
-        } else {
-            this._bt = new BT(this._runtime, this._extensionId, {
-                majorDeviceClass: 8,
-                minorDeviceClass: 1
-            }, this._onConnect, this._onMessage);
+            this._bt.disconnect();
         }
+        this._bt = new BT(this._runtime, this._extensionId, {
+            majorDeviceClass: 8,
+            minorDeviceClass: 1
+        }, this._onConnect, this._onMessage);
     }
 
     /**
@@ -582,7 +581,7 @@ class EV3 {
         this._clearSensorsAndMotors();
         window.clearInterval(this._pollingIntervalID);
         this._pollingIntervalID = null;
-        
+
         if (this._bt) {
             this._bt.disconnect();
         }

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -346,7 +346,7 @@ class EV3Motor {
      */
     coast () {
         if (this._power === 0) return;
-        
+
         const cmd = this._parent.generateCommand(
             Ev3Command.DIRECT_COMMAND_NO_REPLY,
             [
@@ -555,10 +555,14 @@ class EV3 {
      * Called by the runtime when user wants to scan for an EV3 peripheral.
      */
     scan () {
-        this._bt = new BT(this._runtime, this._extensionId, {
-            majorDeviceClass: 8,
-            minorDeviceClass: 1
-        }, this._onConnect, this._onMessage);
+        if (this._bt) {
+            this._bt.requestPeripheral();
+        } else {
+            this._bt = new BT(this._runtime, this._extensionId, {
+                majorDeviceClass: 8,
+                minorDeviceClass: 1
+            }, this._onConnect, this._onMessage);
+        }
     }
 
     /**
@@ -566,17 +570,22 @@ class EV3 {
      * @param {number} id - the id of the peripheral to connect to.
      */
     connect (id) {
-        this._bt.connectPeripheral(id);
+        if (this._bt) {
+            this._bt.connectPeripheral(id);
+        }
     }
 
     /**
      * Called by the runtime when user wants to disconnect from the EV3 peripheral.
      */
     disconnect () {
-        this._bt.disconnect();
         this._clearSensorsAndMotors();
         window.clearInterval(this._pollingIntervalID);
         this._pollingIntervalID = null;
+        
+        if (this._bt) {
+            this._bt.disconnect();
+        }
     }
 
     /**

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -206,14 +206,13 @@ class MicroBit {
      */
     scan () {
         if (this._ble) {
-            this._ble.requestPeripheral();
-        } else {
-            this._ble = new BLE(this._runtime, this._extensionId, {
-                filters: [
-                    {services: [BLEUUID.service]}
-                ]
-            }, this._onConnect);
+            this._ble.disconnect();
         }
+        this._ble = new BLE(this._runtime, this._extensionId, {
+            filters: [
+                {services: [BLEUUID.service]}
+            ]
+        }, this._onConnect);
     }
 
     /**

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -205,11 +205,15 @@ class MicroBit {
      * Called by the runtime when user wants to scan for a peripheral.
      */
     scan () {
-        this._ble = new BLE(this._runtime, this._extensionId, {
-            filters: [
-                {services: [BLEUUID.service]}
-            ]
-        }, this._onConnect);
+        if (this._ble) {
+            this._ble.requestPeripheral();
+        } else {
+            this._ble = new BLE(this._runtime, this._extensionId, {
+                filters: [
+                    {services: [BLEUUID.service]}
+                ]
+            }, this._onConnect);
+        }
     }
 
     /**
@@ -217,7 +221,9 @@ class MicroBit {
      * @param {number} id - the id of the peripheral to connect to.
      */
     connect (id) {
-        this._ble.connectPeripheral(id);
+        if (this._ble) {
+            this._ble.connectPeripheral(id);
+        }
     }
 
     /**
@@ -225,7 +231,9 @@ class MicroBit {
      */
     disconnect () {
         window.clearInterval(this._timeoutID);
-        this._ble.disconnect();
+        if (this._ble) {
+            this._ble.disconnect();
+        }
     }
 
     /**

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -571,15 +571,14 @@ class WeDo2 {
      */
     scan () {
         if (this._ble) {
-            this._ble.requestPeripheral();
-        } else {
-            this._ble = new BLE(this._runtime, this._extensionId, {
-                filters: [{
-                    services: [BLEService.DEVICE_SERVICE]
-                }],
-                optionalServices: [BLEService.IO_SERVICE]
-            }, this._onConnect);
+            this._ble.disconnect();
         }
+        this._ble = new BLE(this._runtime, this._extensionId, {
+            filters: [{
+                services: [BLEService.DEVICE_SERVICE]
+            }],
+            optionalServices: [BLEService.IO_SERVICE]
+        }, this._onConnect);
     }
 
     /**

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -570,12 +570,16 @@ class WeDo2 {
      * Called by the runtime when user wants to scan for a WeDo 2.0 peripheral.
      */
     scan () {
-        this._ble = new BLE(this._runtime, this._extensionId, {
-            filters: [{
-                services: [BLEService.DEVICE_SERVICE]
-            }],
-            optionalServices: [BLEService.IO_SERVICE]
-        }, this._onConnect);
+        if (this._ble) {
+            this._ble.requestPeripheral();
+        } else {
+            this._ble = new BLE(this._runtime, this._extensionId, {
+                filters: [{
+                    services: [BLEService.DEVICE_SERVICE]
+                }],
+                optionalServices: [BLEService.IO_SERVICE]
+            }, this._onConnect);
+        }
     }
 
     /**
@@ -583,7 +587,9 @@ class WeDo2 {
      * @param {number} id - the id of the peripheral to connect to.
      */
     connect (id) {
-        this._ble.connectPeripheral(id);
+        if (this._ble) {
+            this._ble.connectPeripheral(id);
+        }
     }
 
     /**
@@ -598,7 +604,9 @@ class WeDo2 {
             distance: 0
         };
 
-        this._ble.disconnect();
+        if (this._ble) {
+            this._ble.disconnect();
+        }
     }
 
     /**

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -42,7 +42,7 @@ class BLE extends JSONRPCWebSocket {
             this.sendRemoteRequest('discover', this._peripheralOptions)
                 .catch(e => {
                     this._sendRequestError(e);
-                }); // never reached?
+                });
         }
         // TODO: else?
     }
@@ -152,6 +152,7 @@ class BLE extends JSONRPCWebSocket {
     didReceiveCall (method, params) {
         switch (method) {
         case 'didDiscoverPeripheral':
+            console.log('did discover peripheral', params);
             this._availablePeripherals[params.peripheralId] = params;
             this._runtime.emit(
                 this._runtime.constructor.PERIPHERAL_LIST_UPDATE,

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -152,7 +152,6 @@ class BLE extends JSONRPCWebSocket {
     didReceiveCall (method, params) {
         switch (method) {
         case 'didDiscoverPeripheral':
-            console.log('did discover peripheral', params);
             this._availablePeripherals[params.peripheralId] = params;
             this._runtime.emit(
                 this._runtime.constructor.PERIPHERAL_LIST_UPDATE,

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -1,6 +1,6 @@
 const JSONRPCWebSocket = require('../util/jsonrpc-web-socket');
 const ScratchLinkWebSocket = 'wss://device-manager.scratch.mit.edu:20110/scratch/bt';
-const log = require('../util/log');
+// const log = require('../util/log');
 
 class BT extends JSONRPCWebSocket {
 
@@ -39,7 +39,6 @@ class BT extends JSONRPCWebSocket {
      * If the web socket is not yet open, request when the socket promise resolves.
      */
     requestPeripheral () {
-        console.log('bt requestPeripheral');
         if (!this._discovering) {
             if (this._ws.readyState === 1) { // is this needed since it's only called on ws.onopen?
                 this._availablePeripherals = {};
@@ -102,7 +101,6 @@ class BT extends JSONRPCWebSocket {
         // TODO: Add peripheral 'undiscover' handling
         switch (method) {
         case 'didDiscoverPeripheral':
-            console.log('did discover peripheral', params);
             this._discovering = false;
             this._availablePeripherals[params.peripheralId] = params;
             this._runtime.emit(
@@ -122,8 +120,8 @@ class BT extends JSONRPCWebSocket {
         }
     }
 
-    _sendRequestError (e) {
-        log.error(`BT error: ${JSON.stringify(e)}`);
+    _sendRequestError (/* e */) {
+        // log.error(`BT error: ${JSON.stringify(e)}`);
 
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_REQUEST_ERROR, {
             message: `Scratch lost connection to`,

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -26,7 +26,6 @@ class BT extends JSONRPCWebSocket {
         this._connectCallback = connectCallback;
         this._connected = false;
         this._characteristicDidChangeCallback = null;
-        this._discovering = false;
         this._extensionId = extensionId;
         this._peripheralOptions = peripheralOptions;
         this._discoverTimeoutID = null;
@@ -39,18 +38,15 @@ class BT extends JSONRPCWebSocket {
      * If the web socket is not yet open, request when the socket promise resolves.
      */
     requestPeripheral () {
-        if (!this._discovering) {
-            if (this._ws.readyState === 1) { // is this needed since it's only called on ws.onopen?
-                this._availablePeripherals = {};
-                this._discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
-                this.sendRemoteRequest('discover', this._peripheralOptions)
-                    .catch(
-                        e => this._sendRequestError(e)
-                    );
-                this._discovering = true;
-            }
-            // TODO: else?
+        if (this._ws.readyState === 1) { // is this needed since it's only called on ws.onopen?
+            this._availablePeripherals = {};
+            this._discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
+            this.sendRemoteRequest('discover', this._peripheralOptions)
+                .catch(
+                    e => this._sendRequestError(e)
+                );
         }
+        // TODO: else?
     }
 
     /**
@@ -101,7 +97,6 @@ class BT extends JSONRPCWebSocket {
         // TODO: Add peripheral 'undiscover' handling
         switch (method) {
         case 'didDiscoverPeripheral':
-            this._discovering = false;
             this._availablePeripherals[params.peripheralId] = params;
             this._runtime.emit(
                 this._runtime.constructor.PERIPHERAL_LIST_UPDATE,


### PR DESCRIPTION
### Resolves

- Resolves #1671: Close web socket before making a new one for hardware extensions
- Also fixes an error when LEGO WeDo2 modal step 1 was cancelled without attempting a scan

### Test Coverage

Should be tested on Windows with EV3
