### PR TITLE
Resolves #1687.  Clear peripheral discover timeout when needed.

### DIFF
--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -38,6 +38,9 @@ class BLE extends JSONRPCWebSocket {
     requestPeripheral () {
         if (this._ws.readyState === 1) { // is this needed since it's only called on ws.onopen?
             this._availablePeripherals = {};
+            if (this._discoverTimeoutID) {
+                window.clearTimeout(this._discoverTimeoutID);
+            }
             this._discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
             this.sendRemoteRequest('discover', this._peripheralOptions)
                 .catch(e => {
@@ -69,6 +72,9 @@ class BLE extends JSONRPCWebSocket {
      */
     disconnect () {
         this._ws.close();
+        if (this._discoverTimeoutID) {
+            window.clearTimeout(this._discoverTimeoutID);
+        }
     }
 
     /**
@@ -158,7 +164,6 @@ class BLE extends JSONRPCWebSocket {
                 this._availablePeripherals
             );
             if (this._discoverTimeoutID) {
-                // TODO: window?
                 window.clearTimeout(this._discoverTimeoutID);
             }
             break;
@@ -193,6 +198,9 @@ class BLE extends JSONRPCWebSocket {
     }
 
     _sendDiscoverTimeout () {
+        if (this._discoverTimeoutID) {
+            window.clearTimeout(this._discoverTimeoutID);
+        }
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_SCAN_TIMEOUT);
     }
 }

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -40,6 +40,9 @@ class BT extends JSONRPCWebSocket {
     requestPeripheral () {
         if (this._ws.readyState === 1) { // is this needed since it's only called on ws.onopen?
             this._availablePeripherals = {};
+            if (this._discoverTimeoutID) {
+                window.clearTimeout(this._discoverTimeoutID);
+            }
             this._discoverTimeoutID = window.setTimeout(this._sendDiscoverTimeout.bind(this), 15000);
             this.sendRemoteRequest('discover', this._peripheralOptions)
                 .catch(e => this._sendRequestError(e)); // never reached?
@@ -69,6 +72,9 @@ class BT extends JSONRPCWebSocket {
      */
     disconnect () {
         this._ws.close();
+        if (this._discoverTimeoutID) {
+            window.clearTimeout(this._discoverTimeoutID);
+        }
     }
 
     /**
@@ -101,7 +107,6 @@ class BT extends JSONRPCWebSocket {
                 this._availablePeripherals
             );
             if (this._discoverTimeoutID) {
-                // TODO: window?
                 window.clearTimeout(this._discoverTimeoutID);
             }
             break;
@@ -136,6 +141,9 @@ class BT extends JSONRPCWebSocket {
     }
 
     _sendDiscoverTimeout () {
+        if (this._discoverTimeoutID) {
+            window.clearTimeout(this._discoverTimeoutID);
+        }
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_SCAN_TIMEOUT);
     }
 }


### PR DESCRIPTION
### Resolves

Resolves #1687: Peripheral scan timeout is not correctly reset

### Note

This needs PR https://github.com/LLK/scratch-vm/pull/1696 to land first in order to work correctly, since it is dependent on the socket now being closed on every scan attempt.
