### PR TITLE
Correct the equality operator such that Infinity is equal to Infinity

### DIFF
--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -116,18 +116,15 @@ class Cast {
         if (isNaN(n1) || isNaN(n2)) {
             // At least one argument can't be converted to a number.
             // Scratch compares strings as case insensitive.
-            const s1 = String(v1).toLowerCase();
-            const s2 = String(v2).toLowerCase();
-            if (s1 < s2) {
-                return -1;
-            } else if (s1 > s2) {
-                return 1;
-            }
-            return 0;
+            n1 = String(v1).toLowerCase();
+            n2 = String(v2).toLowerCase();
         }
-        // Compare as numbers.
-        return n1 - n2;
-
+        if (n1 < n2) {
+            return -1;
+        } else if (n1 > n2) {
+            return 1;
+        }
+        return 0;
     }
 
     /**

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -47,6 +47,8 @@ test('equals', t => {
     t.strictEqual(blocks.equals({OPERAND1: '2', OPERAND2: '1'}), false);
     t.strictEqual(blocks.equals({OPERAND1: '1', OPERAND2: '1'}), true);
     t.strictEqual(blocks.equals({OPERAND1: 'あ', OPERAND2: 'ア'}), false);
+    t.strictEqual(blocks.equals({OPERAND1: Infinity, 'Infinity'}), true);
+    t.strictEqual(blocks.equals({OPERAND1: NaN, NaN}), true);
     t.end();
 });
 

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -47,8 +47,8 @@ test('equals', t => {
     t.strictEqual(blocks.equals({OPERAND1: '2', OPERAND2: '1'}), false);
     t.strictEqual(blocks.equals({OPERAND1: '1', OPERAND2: '1'}), true);
     t.strictEqual(blocks.equals({OPERAND1: 'あ', OPERAND2: 'ア'}), false);
-    t.strictEqual(blocks.equals({OPERAND1: Infinity, 'Infinity'}), true);
-    t.strictEqual(blocks.equals({OPERAND1: NaN, NaN}), true);
+    t.strictEqual(blocks.equals({OPERAND1: Infinity, OPERAND2: 'Infinity'}), true);
+    t.strictEqual(blocks.equals({OPERAND1: NaN, OPERAND2: NaN}), true);
     t.end();
 });
 


### PR DESCRIPTION
### Resolves

This PR resolves #1699 

### Proposed Changes

In this pull request, we make the utility method `Cast.compare` behave more consistently with Scratch 2.0.

The `<(...) = (...)>` block asks this utility how its inputs relate to each other (smaller/equal/greater). If it gets a return value of 0, it considers them equal.

The algorithm Scratch 3.0 uses for number-like strings (like case-sensitive `Infinity` and `-Infinity`) is to subtract one argument from the other. If they're the same, the return value is expected to be zero.

However, when we pass two infinities of the same sign, there isn't an intuitive answer JS can give. Is the difference between Infinity and Infinity, zero or infinity?

Hence, we match the 2.0 algorithm (where we use `<`, `>` and `==`) to resolve the issue. However, to avoid duplicate code, we use the same logic for numbers and strings.

### Reason for Changes

We make these changes in an effort to make more projects run in a similar way in Scratch 2.0 and Scratch 3.0.

### Test Coverage

We introduce two automated tests:
- `Infinity = "Infinity"` - this is what the issue was talking about
- `NaN = NaN` - while this worked already, it seemed good to have this in a unit test

In addition, we verify the issue has been resolved manually.