### PR TITLE
Shortcut Cast.toNumber if given a number

### DIFF
--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -1,6 +1,14 @@
 const Color = require('../util/color');
 
 /**
+ * Store and possibly polyfill Number.isNaN. Number.isNaN can save time over
+ * self.isNaN by not coercing its input. We need to polyfill it to support
+ * Internet Explorer.
+ * @const
+ */
+const _NumberIsNaN = Number.isNaN || isNaN;
+
+/**
  * @fileoverview
  * Utilities for casting and comparing Scratch data-types.
  * Scratch behaves slightly differently from JavaScript in many respects,
@@ -25,14 +33,14 @@ class Cast {
         if (typeof value === 'number') {
             // Scratch treats NaN as 0, when needed as a number.
             // E.g., 0 + NaN -> 0.
-            if (isNaN(value)) {
+            if (_NumberIsNaN(value)) {
                 return 0;
             }
             return value;
         }
 
         const n = Number(value);
-        if (isNaN(n)) {
+        if (_NumberIsNaN(n)) {
             // Scratch treats NaN as 0, when needed as a number.
             // E.g., 0 + NaN -> 0.
             return 0;

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -20,6 +20,17 @@ class Cast {
      * @return {number} The Scratch-casted number value.
      */
     static toNumber (value) {
+        // If value is already a number we don't need to coerce it with
+        // Number().
+        if (typeof value === 'number') {
+            // Scratch treats NaN as 0, when needed as a number.
+            // E.g., 0 + NaN -> 0.
+            if (isNaN(value)) {
+                return 0;
+            }
+            return value;
+        }
+
         const n = Number(value);
         if (isNaN(n)) {
             // Scratch treats NaN as 0, when needed as a number.


### PR DESCRIPTION

### Resolves

Close #1705 

### Proposed Changes

Check if `typeof value === 'number'` and do a separate isNaN check to confirm its not NaN.

### Reason for Changes

If toNumber is called on a number avoiding passing the number to Number() can provide a small performance improvement.

### Numbers

This change alone does not improve the blocks per second or fps in Scratch due to how the Scratch VM runs. Scratch iterates all threads before checking if it has used too much time instead of checking after each thread. I mention the later because that would be more likely to show a difference in blocks per second or fps (and we don't use that method because it would make projects nondeterministic).

With that in mind for this set of performance numbers I've recorded the percent of time spent in Cast.toNumber with browser inspector performance panels.

Together with other changes this will help speed up Scratch.

|  Project, Platform | before (% of time) | after (% of time) | Change |
|  ------ | ------ | ------ | ------ |
|  89811578, 2017 MBP 15" Chrome | 1.50% | 1.04% | 0.46% |
|  89811578, 2017 MBP 15" Firefox | 1.79% | 1.16% | 0.63% |
|  89811578, 2017 MBP 15" Safari | 2.00% | 2.00% | 0.00% |
|  89811578, 2017 SMS Chromebook | 1.58% | 0.90% | 0.68% |
|  89811578, 2018 Raspberry Pi 3B+ | 1.33% | 1.12% | 0.21% |
