### PR TITLE
Include the original blockId of the top block being dragged.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -340,7 +340,7 @@ class Blocks {
                 // Drag blocks onto another sprite
                 if (e.isOutside) {
                     const newBlocks = adapter(e);
-                    optRuntime.emitBlockEndDrag(newBlocks);
+                    optRuntime.emitBlockEndDrag(newBlocks, e.blockId);
                 }
             }
             break;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1857,9 +1857,10 @@ class Runtime extends EventEmitter {
     /**
      * Emit event to indicate that the block drag has ended with the blocks outside the blocks workspace
      * @param {Array.<object>} blocks The set of blocks dragged to the GUI
+     * @param {string} topBlockId The original id of the top block being dragged
      */
-    emitBlockEndDrag (blocks) {
-        this.emit(Runtime.BLOCK_DRAG_END, blocks);
+    emitBlockEndDrag (blocks, topBlockId) {
+        this.emit(Runtime.BLOCK_DRAG_END, blocks, topBlockId);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -96,8 +96,8 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.BLOCK_DRAG_UPDATE, areBlocksOverGui => {
             this.emit(Runtime.BLOCK_DRAG_UPDATE, areBlocksOverGui);
         });
-        this.runtime.on(Runtime.BLOCK_DRAG_END, blocks => {
-            this.emit(Runtime.BLOCK_DRAG_END, blocks);
+        this.runtime.on(Runtime.BLOCK_DRAG_END, (blocks, topBlockId) => {
+            this.emit(Runtime.BLOCK_DRAG_END, blocks, topBlockId);
         });
         this.runtime.on(Runtime.EXTENSION_ADDED, blocksInfo => {
             this.emit(Runtime.EXTENSION_ADDED, blocksInfo);


### PR DESCRIPTION
This is required by the GUI in order to take a snapshot of the blocks for the backpack. Only the ID is needed, the rest can be done by the GUI.
