### PR TITLE
Handle coordinate precision the same as Scratch 2

### DIFF
--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -270,7 +270,7 @@ class Scratch3MotionBlocks {
         return util.target.direction;
     }
 
-    // This corresponds to snapToInteger in Scratch 2's
+    // This corresponds to snapToInteger in Scratch 2
     limitPrecision (coordinate) {
         const rounded = Math.round(coordinate);
         const delta = coordinate - rounded;

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -272,8 +272,8 @@ class Scratch3MotionBlocks {
 
     limitPrecision (coordinate) {
         const rounded = Math.round(coordinate);
-        const epsilon = coordinate - rounded;
-        const preciseCoord = (Math.abs(epsilon) < 1e-7) ? rounded : coordinate;
+        const delta = coordinate - rounded;
+        const preciseCoord = (Math.abs(delta) < 1e-7) ? rounded : coordinate;
 
         return preciseCoord;
     }

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -274,9 +274,9 @@ class Scratch3MotionBlocks {
     limitPrecision (coordinate) {
         const rounded = Math.round(coordinate);
         const delta = coordinate - rounded;
-        const preciseCoord = (Math.abs(delta) < 1e-9) ? rounded : coordinate;
+        const limitedCoord = (Math.abs(delta) < 1e-9) ? rounded : coordinate;
 
-        return preciseCoord;
+        return limitedCoord;
     }
 }
 

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -270,6 +270,7 @@ class Scratch3MotionBlocks {
         return util.target.direction;
     }
 
+    // This corresponds to snapToInteger in Scratch 2's
     limitPrecision (coordinate) {
         const rounded = Math.round(coordinate);
         const delta = coordinate - rounded;

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -273,7 +273,7 @@ class Scratch3MotionBlocks {
     limitPrecision (coordinate) {
         const rounded = Math.round(coordinate);
         const delta = coordinate - rounded;
-        const preciseCoord = (Math.abs(delta) < 1e-7) ? rounded : coordinate;
+        const preciseCoord = (Math.abs(delta) < 1e-9) ? rounded : coordinate;
 
         return preciseCoord;
     }

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -259,15 +259,23 @@ class Scratch3MotionBlocks {
     }
 
     getX (args, util) {
-        return util.target.x;
+        return this.limitPrecision(util.target.x);
     }
 
     getY (args, util) {
-        return util.target.y;
+        return this.limitPrecision(util.target.y);
     }
 
     getDirection (args, util) {
         return util.target.direction;
+    }
+
+    limitPrecision (coordinate) {
+        const rounded = Math.round(coordinate);
+        const epsilon = coordinate - rounded;
+        const preciseCoord = (Math.abs(epsilon) < 1e-7) ? rounded : coordinate;
+
+        return preciseCoord;
     }
 }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -257,17 +257,6 @@ class RenderedTarget extends Target {
     }
 
     /**
-     * Round a number to n digits
-     * @param {number} value The number to be rounded
-     * @param {number} places The number of decimal places to round to
-     * @return {number} The rounded number
-     */
-    _roundCoord (value, places) {
-        const power = Math.pow(10, places);
-        return Math.round(value * power) / power;
-    }
-
-    /**
      * Set the X and Y coordinates.
      * @param {!number} x New X coordinate, in Scratch coordinates.
      * @param {!number} y New Y coordinate, in Scratch coordinates.
@@ -280,8 +269,6 @@ class RenderedTarget extends Target {
         const oldY = this.y;
         if (this.renderer) {
             const position = this.renderer.getFencedPositionOfDrawable(this.drawableID, [x, y]);
-            position[0] = this._roundCoord(position[0], 8);
-            position[1] = this._roundCoord(position[1], 8);
             this.x = position[0];
             this.y = position[1];
 
@@ -293,8 +280,8 @@ class RenderedTarget extends Target {
                 this.runtime.requestRedraw();
             }
         } else {
-            this.x = this._roundCoord(x, 8);
-            this.y = this._roundCoord(y, 8);
+            this.x = x;
+            this.y = y;
         }
         this.emit(RenderedTarget.EVENT_TARGET_MOVED, this, oldX, oldY, force);
         this.runtime.requestTargetsUpdate(this);

--- a/test/unit/blocks_motion.js
+++ b/test/unit/blocks_motion.js
@@ -1,0 +1,26 @@
+const test = require('tap').test;
+const Motion = require('../../src/blocks/scratch3_motion');
+const Runtime = require('../../src/engine/runtime');
+const Sprite = require('../../src/sprites/sprite.js');
+const RenderedTarget = require('../../src/sprites/rendered-target.js');
+
+test('getPrimitives', t => {
+    const rt = new Runtime();
+    const motion = new Motion(rt);
+    t.type(motion.getPrimitives(), 'object');
+    t.end();
+});
+
+test('Coordinates have limited precision', t => {
+    const rt = new Runtime();
+    const motion = new Motion(rt);
+    const sprite = new Sprite(null, rt);
+    const target = new RenderedTarget(sprite, rt);
+    const util = {target};
+
+    motion.goToXY({ X: 0.999999999, Y: 0.999999999}, util);
+
+    t.equals(motion.getX({}, util), 1);
+    t.equals(motion.getY({}, util), 1);
+    t.end();
+});

--- a/test/unit/blocks_motion.js
+++ b/test/unit/blocks_motion.js
@@ -18,7 +18,7 @@ test('Coordinates have limited precision', t => {
     const target = new RenderedTarget(sprite, rt);
     const util = {target};
 
-    motion.goToXY({ X: 0.999999999, Y: 0.999999999}, util);
+    motion.goToXY({X: 0.999999999, Y: 0.999999999}, util);
 
     t.equals(motion.getX({}, util), 1);
     t.equals(motion.getY({}, util), 1);


### PR DESCRIPTION
### Resolves

Fixes #1242 

### Proposed Changes

Instead of only rounding the coordinates to 8 places, we use [the same logic as Scratch 2](https://github.com/LLK/scratch-flash/blob/646523e6846ad0dd993213a38b46fe2ea511d026/src/primitives/MotionAndPenPrims.as#L225-L230) to check whether the difference is negligible between the current coordinate and the rounded version of the coordinate. If the difference is less than a certain threshold, use the rounded version. This PR also removes `_roundCoord`, which was a previous approach to rounding coordinates. 

### Reason for Changes

[`_roundCoord` previously limited coordinates to 8 decimal places](https://github.com/LLK/scratch-vm/pull/1160), but it used different logic to limit coordinate precision than Scratch 2 did. The difference in logic however causes incompatibility for some projects, like https://llk.github.io/scratch-gui/develop/#229606968. 

### Test Coverage

I've added a unit test for the motion block's limited coordinates in `test/unit/blocks_motion.js` that uses some of the same logic as this test Scratch project: https://llk.github.io/scratch-gui/develop/#223591096
