### PR TITLE
Apply sprite's volume to music extension notes and drums

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -985,18 +985,18 @@ class Scratch3MusicBlocks {
             player.take();
         }
 
-        const chain = engine.createEffectChain();
-        chain.setEffectsFromTarget(util.target);
-
         // Set its pitch.
         const sampleNote = sampleArray[sampleIndex];
         const notePitchInterval = this._ratioForPitchInterval(note - sampleNote);
 
-        // Create a gain node for this note, and connect it to the sprite's
-        // simulated effectChain.
+        // Create gain nodes for this note's volume and release, and chain them
+        // to the output.
         const context = engine.audioContext;
+        const volumeGain = context.createGain();
+        volumeGain.gain.setValueAtTime(util.target.volume / 100, engine.currentTime);
         const releaseGain = context.createGain();
-        releaseGain.connect(chain.getInputNode());
+        volumeGain.connect(releaseGain);
+        releaseGain.connect(engine.getInputNode());
 
         // Schedule the release of the note, ramping its gain down to zero,
         // and then stopping the sound.
@@ -1018,7 +1018,7 @@ class Scratch3MusicBlocks {
         player.play();
         // Connect the player to the gain node.
         player.connect({getInputNode () {
-            return releaseGain;
+            return volumeGain;
         }});
         // Set playback now after play creates the outputNode.
         player.outputNode.playbackRate.value = notePitchInterval;

--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -883,9 +883,10 @@ class Scratch3MusicBlocks {
         }
 
         const engine = util.runtime.audioEngine;
-        const chain = engine.createEffectChain();
-        chain.setEffectsFromTarget(util.target);
-        player.connect(chain);
+        const context = engine.audioContext;
+        const volumeGain = context.createGain();
+        volumeGain.gain.setValueAtTime(util.target.volume / 100, engine.currentTime);
+        volumeGain.connect(engine.getInputNode());
 
         this._concurrencyCounter++;
         player.once('stop', () => {
@@ -893,6 +894,10 @@ class Scratch3MusicBlocks {
         });
 
         player.play();
+        // Connect the player to the gain node.
+        player.connect({getInputNode () {
+            return volumeGain;
+        }});
     }
 
     /**


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1732
Resolves https://github.com/LLK/scratch-vm/issues/1407

### Proposed Changes

Don't use the audio engine's effects chain feature in the music extension. Instead, create gain nodes and use those to apply the sprite's volume setting to each note or drum sound when it starts playing. The volume is set instantaneously, before the sound starts. This prevents the bug in #1732. 

This also resolves #1407 by disabling the pan effect for the music extension. 

### Reason for Changes

Previously, we were using the effects chain to apply the volume, but it has a built in transition time (to prevent clicking sounds due to sudden transitions). The unintended consequence was that every note or drum sound was played initially at 100% volume, and then quickly transitioned to the set volume, so even when the volume is 0%, you would hear the onset of the note or drum sound. This change sets the volume instantaneously before playback.

Note that this change does not deal with https://github.com/LLK/scratch-vm/issues/1412, because the volume does not get updated after the sound starts playing.

We also decided to disable the pan effect for the music extension. We are generally moving toward an approach of not "crossing the streams", meaning we don't want settings controlled by blocks outside the extension (such as the "set pan effect" and "set pitch effect" blocks) to interact with the extension. Volume affecting the music extension is an exception, but it's necessary because it's a pre-existing feature.

### Testing

Compare the sound of this recently featured note blocks project before and after the change: 257504394 