### PR TITLE
Show Scratch Link install prompt when trying to connect to EV3 w/o Link

### DIFF
--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -19,7 +19,7 @@ class BT extends JSONRPCWebSocket {
 
         this._ws = ws;
         this._ws.onopen = this.requestPeripheral.bind(this); // only call request peripheral after socket opens
-        this._ws.onerror = this._sendDisconnectError.bind(this, 'ws onerror');
+        this._ws.onerror = this._sendRequestError.bind(this, 'ws onerror');
         this._ws.onclose = this._sendDisconnectError.bind(this, 'ws onclose');
 
         this._availablePeripherals = {};


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3554 

### Proposed Changes

Make websocket error on BT connection trigger a request error instead of a disconnect error.