### PR TITLE
Implement "point towards random direction"

### DIFF
--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -123,6 +123,9 @@ class Scratch3MotionBlocks {
         if (args.TOWARDS === '_mouse_') {
             targetX = util.ioQuery('mouse', 'getScratchX');
             targetY = util.ioQuery('mouse', 'getScratchY');
+        } else if (args.TOWARDS === '_random_') {
+            util.target.setDirection(Math.round(Math.random() * 360) - 180);
+            return;
         } else {
             const pointTarget = this.runtime.getSpriteTargetByName(args.TOWARDS);
             if (!pointTarget) return;


### PR DESCRIPTION
### Resolves
Towards LLK/scratch-gui#1702
Sibling pull request in LLK/scratch-blocks will be made soon!

### Proposed Changes
Make the sprite point in a random direction when `_random_` is selected in the "point towards" dropdown.

Notice that this is different from pointing towards a random _position_ on the stage: that would mean that if you're in the top-right quadrant, you're most likely to point towards the bottom left quadrant because there are more positions there to choose from.

### Reason for Changes
Matches the "go to" block. Also, it's a nifty feature.

"180" is subtracted in this change, I'm not sure if that was a good idea: this matches what the 'direction' getter will show... but there's no point, since it'll be clamped later anyway. Should the -180 be removed?

We use only integer directions to make the "direction" getter an integer, which matches e.g. "glide to random" behaviour.

### Test Coverage

It's very hard to test randomness in a deterministic way with automated tests (I suppose we could try it 100 times and ensure we get different results at least once, but that's still risky). EDIT: Maybe we could mock `Math.random()`?

But I tested manually like this:
![A script which, 1000 times, turns towards random and then moves in that direction and back. It does this while pen is enabled and while the sprite is hidden.](https://user-images.githubusercontent.com/18113170/48315900-0d135b80-e5d4-11e8-9f7d-d31e459cd471.png)

Before changes:
![A single line in a single direction](https://user-images.githubusercontent.com/18113170/48315911-36cc8280-e5d4-11e8-8407-52a76a2d74d5.png)

After changes:
![A circle, with a few radii missing (coloured white rather than blue)](https://user-images.githubusercontent.com/18113170/48315940-9c207380-e5d4-11e8-9ccc-8d488c2e5873.png)

This only ever points towards integer directions, so the gaps are probably expected, since we only expect each direction to be hit around 3 times with 1000 attempts. Increasing the repeats to 10,000 causes the circle to become completely solid.


