### PR TITLE
Add method for collecting all targets' assets

### DIFF
--- a/src/serialization/serialize-assets.js
+++ b/src/serialization/serialize-assets.js
@@ -50,21 +50,7 @@ const serializeCostumes = function (runtime, optTargetId) {
     return serializeAssets(runtime, 'costumes', optTargetId);
 };
 
-/*
- * Return all costumes and sounds in the provided runtime
- * @param {Runtime} runtime
- * @returns {Array<object>} An array of costumes and sounds
- */
-const collectAssets = function (runtime) {
-    return runtime.targets.reduce((acc, target) => (
-        acc
-            .concat(target.sprite.sounds.map(sound => sound.asset))
-            .concat(target.sprite.costumes.map(costume => costume.asset))
-    ), []);
-};
-
 module.exports = {
-    collectAssets,
     serializeSounds,
     serializeCostumes
 };

--- a/src/serialization/serialize-assets.js
+++ b/src/serialization/serialize-assets.js
@@ -50,7 +50,21 @@ const serializeCostumes = function (runtime, optTargetId) {
     return serializeAssets(runtime, 'costumes', optTargetId);
 };
 
+/*
+ * Return all costumes and sounds in the provided runtime
+ * @param {Runtime} runtime
+ * @returns {Array<object>} An array of costumes and sounds
+ */
+const collectAssets = function (runtime) {
+    return runtime.targets.reduce((acc, target) => (
+        acc
+            .concat(target.sprite.sounds.map(sound => sound.asset))
+            .concat(target.sprite.costumes.map(costume => costume.asset))
+    ), []);
+};
+
 module.exports = {
+    collectAssets,
     serializeSounds,
     serializeCostumes
 };

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -18,7 +18,7 @@ const Variable = require('./engine/variable');
 
 const {loadCostume} = require('./import/load-costume.js');
 const {loadSound} = require('./import/load-sound.js');
-const {collectAssets, serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
+const {serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
 require('canvas-toBlob');
 
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
@@ -340,7 +340,11 @@ class VirtualMachine extends EventEmitter {
      * @type {Array<object>} Array of all costumes and sounds currently in the runtime
      */
     get assets () {
-        return collectAssets(this.runtime);
+        return this.runtime.targets.reduce((acc, target) => (
+            acc
+                .concat(target.sprite.sounds.map(sound => sound.asset))
+                .concat(target.sprite.costumes.map(costume => costume.asset))
+        ), []);
     }
 
     _addFileDescsToZip (fileDescs, zip) {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -18,7 +18,7 @@ const Variable = require('./engine/variable');
 
 const {loadCostume} = require('./import/load-costume.js');
 const {loadSound} = require('./import/load-sound.js');
-const {serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
+const {collectAssets, serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
 require('canvas-toBlob');
 
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
@@ -334,6 +334,13 @@ class VirtualMachine extends EventEmitter {
                 level: 6 // Tradeoff between best speed (1) and best compression (9)
             }
         });
+    }
+
+    /*
+     * @type {Array<object>} Array of all costumes and sounds currently in the runtime
+     */
+    get assets () {
+        return collectAssets(this.runtime);
     }
 
     _addFileDescsToZip (fileDescs, zip) {

--- a/test/unit/vm_collectAssets.js
+++ b/test/unit/vm_collectAssets.js
@@ -1,0 +1,42 @@
+const test = require('tap').test;
+
+const {collectAssets} = require('../../src/serialization/serialize-assets');
+
+const RenderedTarget = require('../../src/sprites/rendered-target');
+const Sprite = require('../../src/sprites/sprite');
+const VirtualMachine = require('../../src/virtual-machine');
+
+test('spec', t => {
+    t.type(collectAssets, 'function');
+    t.end();
+});
+
+test('collectAssets', t => {
+    const vm = new VirtualMachine();
+    const sprite = new Sprite(null, vm.runtime);
+    const target = new RenderedTarget(sprite, vm.runtime);
+    vm.runtime.targets = [target];
+    const [
+        soundAsset1,
+        soundAsset2,
+        costumeAsset1
+    ] = [{assetId: 1}, {assetId: 2}, {assetId: 3}];
+    sprite.sounds = [{id: 1, asset: soundAsset1}, {id: 2, asset: soundAsset2}];
+    sprite.costumes = [{id: 1, asset: costumeAsset1}];
+    const assets = collectAssets(vm.runtime);
+    t.deepEqual(assets, [soundAsset1, soundAsset2, costumeAsset1]);
+    t.end();
+});
+
+test('getter', t => {
+    const vm = new VirtualMachine();
+    const sprite = new Sprite(null, vm.runtime);
+    const target = new RenderedTarget(sprite, vm.runtime);
+    vm.runtime.targets = [target];
+    sprite.sounds = [{id: 1, asset: {}}, {id: 2, asset: {}}];
+    sprite.costumes = [{id: 1, asset: {}}];
+    const assets = vm.assets;
+    t.type(assets.length, 'number');
+    t.equal(assets.length, 3);
+    t.end();
+});

--- a/test/unit/vm_collectAssets.js
+++ b/test/unit/vm_collectAssets.js
@@ -1,15 +1,8 @@
 const test = require('tap').test;
 
-const {collectAssets} = require('../../src/serialization/serialize-assets');
-
 const RenderedTarget = require('../../src/sprites/rendered-target');
 const Sprite = require('../../src/sprites/sprite');
 const VirtualMachine = require('../../src/virtual-machine');
-
-test('spec', t => {
-    t.type(collectAssets, 'function');
-    t.end();
-});
 
 test('collectAssets', t => {
     const vm = new VirtualMachine();
@@ -23,20 +16,9 @@ test('collectAssets', t => {
     ] = [{assetId: 1}, {assetId: 2}, {assetId: 3}];
     sprite.sounds = [{id: 1, asset: soundAsset1}, {id: 2, asset: soundAsset2}];
     sprite.costumes = [{id: 1, asset: costumeAsset1}];
-    const assets = collectAssets(vm.runtime);
-    t.deepEqual(assets, [soundAsset1, soundAsset2, costumeAsset1]);
-    t.end();
-});
-
-test('getter', t => {
-    const vm = new VirtualMachine();
-    const sprite = new Sprite(null, vm.runtime);
-    const target = new RenderedTarget(sprite, vm.runtime);
-    vm.runtime.targets = [target];
-    sprite.sounds = [{id: 1, asset: {}}, {id: 2, asset: {}}];
-    sprite.costumes = [{id: 1, asset: {}}];
     const assets = vm.assets;
     t.type(assets.length, 'number');
     t.equal(assets.length, 3);
+    t.deepEqual(assets, [soundAsset1, soundAsset2, costumeAsset1]);
     t.end();
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolves #1601

### Proposed Changes

_Describe what this Pull Request does_
Adds a VM getter that returns all assets stored on all targets.

### Reason for Changes

_Explain why these changes should be made_
Towards incremental saving, this gives a way for the GUI to save all the assets individually.  For now, it is the responsibility of the consumer to determine if these assets should be saved or not. Otherwise the VM would need to be responsible for saving, which has been out of its scope.  Does not include the project JSON since that would require knowledge of a project ID, which the VM has not been responsible for so far.

### Test Coverage

_Please show how you have added tests to cover your changes_
Added unit tests for the function as well as the getter on the VM.