### PR TITLE
Create cloud variables

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -366,7 +366,7 @@ class Blocks {
             // into a state where a local var was requested for the stage,
             // create a stage (global) var after checking for name conflicts
             // on all the sprites.
-            if (e.isLocal && editingTarget && !editingTarget.isStage) {
+            if (e.isLocal && editingTarget && !editingTarget.isStage && !e.isCloud) {
                 if (!editingTarget.lookupVariableById(e.varId)) {
                     editingTarget.createVariable(e.varId, e.varName, e.varType);
                 }
@@ -378,7 +378,7 @@ class Blocks {
                         return;
                     }
                 }
-                stage.createVariable(e.varId, e.varName, e.varType);
+                stage.createVariable(e.varId, e.varName, e.varType, e.isCloud);
             }
             break;
         case 'var_rename':

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -322,7 +322,7 @@ class Runtime extends EventEmitter {
         /** @type {Object.<string, Object>} */
         this.ioDevices = {
             clock: new Clock(),
-            cloud: new Cloud(),
+            cloud: new Cloud(this),
             deviceManager: new DeviceManager(),
             keyboard: new Keyboard(this),
             mouse: new Mouse(this),

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -233,11 +233,16 @@ class Target extends EventEmitter {
      * @param {string} id Id of variable
      * @param {string} name Name of variable.
      * @param {string} type Type of variable, '', 'broadcast_msg', or 'list'
+     * @param {boolean} isCloud Whether the variable to create has the isCloud flag set.
+     * Additional checks are made that the variable can be created as a cloud variable.
      */
-    createVariable (id, name, type) {
+    createVariable (id, name, type, isCloud) {
         if (!this.variables.hasOwnProperty(id)) {
             const newVariable = new Variable(id, name, type, false);
             this.variables[id] = newVariable;
+            if (isCloud && this.isStage) {
+                this.runtime.ioDevices.cloud.requestCreateCloudVariable(newVariable);
+            }
         }
     }
 

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -4,7 +4,6 @@ const Variable = require('../../src/engine/variable');
 const adapter = require('../../src/engine/adapter');
 const Runtime = require('../../src/engine/runtime');
 const events = require('../fixtures/events.json');
-const Cloud = require('../../src/io/cloud');
 
 test('spec', t => {
     const target = new Target();

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -4,6 +4,7 @@ const Variable = require('../../src/engine/variable');
 const adapter = require('../../src/engine/adapter');
 const Runtime = require('../../src/engine/runtime');
 const events = require('../fixtures/events.json');
+const Cloud = require('../../src/io/cloud');
 
 test('spec', t => {
     const target = new Target();
@@ -67,6 +68,58 @@ test('createListVariable creates a list', t => {
     t.assert(variable.value instanceof Array, true);
     t.equal(variable.value.length, 0);
     t.equal(variable.isCloud, false);
+
+    t.end();
+});
+
+test('createVariable calls cloud io device\'s requestCreateCloudVariable', t => {
+    const runtime = new Runtime();
+    // Mock the requestCreateCloudVariable function
+    let requestCreateCloudWasCalled = false;
+    runtime.ioDevices.cloud.requestCreateCloudVariable = () => {
+        requestCreateCloudWasCalled = true;
+    };
+
+    const target = new Target(runtime);
+    target.isStage = true;
+    target.createVariable('foo', 'bar', Variable.SCALAR_TYPE, true /* isCloud */);
+
+    const variables = target.variables;
+    t.equal(Object.keys(variables).length, 1);
+    const variable = variables[Object.keys(variables)[0]];
+    t.equal(variable.id, 'foo');
+    t.equal(variable.name, 'bar');
+    t.equal(variable.type, Variable.SCALAR_TYPE);
+    t.equal(variable.value, 0);
+    // isCloud flag doesn't get set by the target createVariable function
+    t.equal(variable.isCloud, false);
+    t.equal(requestCreateCloudWasCalled, true);
+
+    t.end();
+});
+
+test('createVariable does not call cloud io device\'s requestCreateCloudVariable if target is not stage', t => {
+    const runtime = new Runtime();
+    // Mock the requestCreateCloudVariable function
+    let requestCreateCloudWasCalled = false;
+    runtime.ioDevices.cloud.requestCreateCloudVariable = () => {
+        requestCreateCloudWasCalled = true;
+    };
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.createVariable('foo', 'bar', Variable.SCALAR_TYPE, true /* isCloud */);
+
+    const variables = target.variables;
+    t.equal(Object.keys(variables).length, 1);
+    const variable = variables[Object.keys(variables)[0]];
+    t.equal(variable.id, 'foo');
+    t.equal(variable.name, 'bar');
+    t.equal(variable.type, Variable.SCALAR_TYPE);
+    t.equal(variable.value, 0);
+    // isCloud flag doesn't get set by the target createVariable function
+    t.equal(variable.isCloud, false);
+    t.equal(requestCreateCloudWasCalled, false);
 
     t.end();
 });


### PR DESCRIPTION
### Proposed Changes

Add ability to create cloud variables, requesting the cloud provider to create a cloud variable on the server and waiting for confirmation from the cloud provider to update the actual isCloud flag and cloud variable limit.

### Reason for Changes

Creating cloud variables!

### Test Coverage

Testing instructions included in the related gui PR.

### Related PRs
- LLK/scratch-gui#3749
- LLK/scratch-blocks#1782