### PR TITLE
Use note picker in imported play note blocks

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -990,6 +990,10 @@ const parseBlock = function (sb2block, addBroadcastMsg, getVariableId, extension
                 } else if (fieldValue === 'Stage') {
                     fieldValue = '_stage_';
                 }
+            } else if (expectedArg.inputOp === 'note') {
+                if (shadowObscured) {
+                    fieldValue = 60;
+                }
             } else if (expectedArg.inputOp === 'music.menu.DRUM') {
                 if (shadowObscured) {
                     fieldValue = 1;

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -518,7 +518,7 @@ const specMap = {
         argMap: [
             {
                 type: 'input',
-                inputOp: 'math_number',
+                inputOp: 'note',
                 inputName: 'NOTE'
             },
             {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1756

### Proposed Changes

"Play note"  blocks in projects imported from 2.0 should use the note picker field.

Also, obscured shadows in imported blocks with the note picker should default to 60.

### Test Coverage

Test 2.0 projects with note blocks, such as:
261062957
187641716
