### PR TITLE
Make the wait block's logic and behavior more consistent with Scratch 2

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -150,6 +150,7 @@ class Scratch3ControlBlocks {
 
         if (this._stackTimerNeedsInit(stackFrame)) {
             this._startStackTimer(stackFrame, duration);
+            this.runtime.requestRedraw();
             util.yield();
         } else if (!this._stackTimerFinished(stackFrame)) {
             util.yield();

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -71,7 +71,6 @@ class Scratch3ControlBlocks {
      */
     _startStackTimer (util, duration) {
         duration = Math.max(0, 1000 * Cast.toNumber(duration));
-
         util.stackFrame.timer = new Timer();
         util.stackFrame.timer.start();
         util.stackFrame.duration = duration;

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -108,9 +108,9 @@ class Scratch3ControlBlocks {
     }
 
     wait (args, util) {
-        const duration = Math.max(0, 1000 * Cast.toNumber(args.DURATION));
-
         if (util.stackTimerNeedsInit()) {
+            const duration = Math.max(0, 1000 * Cast.toNumber(args.DURATION));
+
             util.startStackTimer(duration);
             this.runtime.requestRedraw();
             util.yield();

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -1,5 +1,4 @@
 const Cast = require('../util/cast');
-const Timer = require('../util/timer');
 
 class Scratch3ControlBlocks {
     constructor (runtime) {
@@ -39,42 +38,6 @@ class Scratch3ControlBlocks {
             control_clear_counter: this.clearCounter,
             control_all_at_once: this.allAtOnce
         };
-    }
-
-    /**
-     * Check the stack timer and return a boolean based on whether it has finished or not.
-     * @param {object} stackFrame - part of the utility object provided by the runtime.
-     * @return {boolean} - true if the stack timer has finished.
-     * @private
-     */
-    _stackTimerFinished (stackFrame) {
-        const timeElapsed = stackFrame.timer.timeElapsed();
-        if (timeElapsed < stackFrame.duration) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Check if the stack timer needs initialization.
-     * @param {object} stackFrame - part of the utility object provided by the runtime.
-     * @return {boolean} - true if the stack timer needs to be initialized.
-     * @private
-     */
-    _stackTimerNeedsInit (stackFrame) {
-        return !stackFrame.timer;
-    }
-
-    /**
-     * Start the stack timer
-     * @param {object} stackFrame - part of the utility object provided by the runtime.
-     * @param {number} duration - a duration in milliseconds to set the timer for.
-     * @private
-     */
-    _startStackTimer (stackFrame, duration) {
-        stackFrame.timer = new Timer();
-        stackFrame.timer.start();
-        stackFrame.duration = duration;
     }
 
     getHats () {
@@ -145,14 +108,13 @@ class Scratch3ControlBlocks {
     }
 
     wait (args, util) {
-        const stackFrame = util.stackFrame;
         const duration = Math.max(0, 1000 * Cast.toNumber(args.DURATION));
 
-        if (this._stackTimerNeedsInit(stackFrame)) {
-            this._startStackTimer(stackFrame, duration);
+        if (util.stackTimerNeedsInit()) {
+            util.startStackTimer(duration);
             this.runtime.requestRedraw();
             util.yield();
-        } else if (!this._stackTimerFinished(stackFrame)) {
+        } else if (!util.stackTimerFinished()) {
             util.yield();
         }
     }

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -42,7 +42,7 @@ class Scratch3ControlBlocks {
     }
 
     /**
-     * Check the stack timer, and if its time is not up yet, yield the thread.
+     * Check the stack timer and return a boolean based on whether it has finished or not.
      * @param {object} stackFrame - part of the utility object provided by the runtime.
      * @return {boolean} - true if the stack timer has finished.
      * @private
@@ -66,9 +66,9 @@ class Scratch3ControlBlocks {
     }
 
     /**
-     * Start the stack timer and the yield the thread if necessary.
+     * Start the stack timer
      * @param {object} stackFrame - part of the utility object provided by the runtime.
-     * @param {number} duration - a duration in seconds to set the timer for.
+     * @param {number} duration - a duration in milliseconds to set the timer for.
      * @private
      */
     _startStackTimer (stackFrame, duration) {
@@ -151,8 +151,7 @@ class Scratch3ControlBlocks {
         if (this._stackTimerNeedsInit(stackFrame)) {
             this._startStackTimer(stackFrame, duration);
             util.yield();
-        }
-        if (!this._stackTimerFinished(stackFrame)) {
+        } else if (!this._stackTimerFinished(stackFrame)) {
             util.yield();
         }
     }

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -41,7 +41,7 @@ class BlockUtility {
 
     /**
      * Use the runtime's currentMSecs value as a timestamp value for now
-     * This is useful in some cases where we need compatability with Scratch 2
+     * This is useful in some cases where we need compatibility with Scratch 2
      * @type {function}
      */
     get nowObj () {

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -21,8 +21,6 @@ class BlockUtility {
          * @type {?Thread}
          */
         this.thread = thread;
-
-        this.timer = null;
     }
 
     /**
@@ -41,14 +39,18 @@ class BlockUtility {
         return this.sequencer.runtime;
     }
 
-    get nowObject () {
+    /**
+     * Use the runtime's currentMSecs value as a timestamp value for now
+     * This is useful in some cases where we need compatability with Scratch 2
+     * @type {function}
+     */
+    get nowObj () {
         if (this.runtime) {
-           return {
-                now: () => {
-                    return this.runtime.currentMSecs;
-                }
+            return {
+                now: () => this.runtime.currentMSecs
             };
         }
+        return null;
     }
 
     /**
@@ -66,7 +68,6 @@ class BlockUtility {
     /**
      * Check the stack timer and return a boolean based on whether it has finished or not.
      * @return {boolean} - true if the stack timer has finished.
-     * @private
      */
     stackTimerFinished () {
         const timeElapsed = this.stackFrame.timer.timeElapsed();
@@ -79,20 +80,22 @@ class BlockUtility {
     /**
      * Check if the stack timer needs initialization.
      * @return {boolean} - true if the stack timer needs to be initialized.
-     * @private
      */
     stackTimerNeedsInit () {
         return !this.stackFrame.timer;
     }
 
     /**
-     * Start the stack timer
-     * @param {object} stackFrame - part of the utility object provided by the runtime.
+     * Create and start a stack timer
      * @param {number} duration - a duration in milliseconds to set the timer for.
-     * @private
      */
     startStackTimer (duration) {
-        this.stackFrame.timer = new Timer(this.nowObject);
+        if (this.nowObj) {
+            this.stackFrame.timer = new Timer(this.nowObj);
+        } else {
+            this.stackFrame.timer = new Timer();
+        }
+        
         this.stackFrame.timer.start();
         this.stackFrame.duration = duration;
     }

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -95,7 +95,6 @@ class BlockUtility {
         } else {
             this.stackFrame.timer = new Timer();
         }
-        
         this.stackFrame.timer.start();
         this.stackFrame.duration = duration;
     }

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -49,7 +49,6 @@ class BlockUtility {
                 }
             };
         }
-        return null;
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -305,6 +305,7 @@ class Runtime extends EventEmitter {
          */
         this.currentStepTime = null;
 
+        // Set an intial value for this.currentMSecs
         this.updateCurrentMSecs();
 
         /**
@@ -2176,6 +2177,12 @@ class Runtime extends EventEmitter {
         this.profiler = null;
     }
 
+    /**
+     * Update the timestamp value in milliseconds that is saved on the Runtime.
+     * This value is helpful in certain instances for compatability with Scratch 2,
+     * which uses the same `currentMSecs` timestamp value for certain operations
+     * in Interpreter.as, such as a millisecond clock for steps
+     */
     updateCurrentMSecs () {
         this.currentMSecs = Date.now();
     }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -2178,10 +2178,9 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Update the timestamp value in milliseconds that is saved on the Runtime.
-     * This value is helpful in certain instances for compatability with Scratch 2,
-     * which uses the same `currentMSecs` timestamp value for certain operations
-     * in Interpreter.as, such as a millisecond clock for steps
+     * Update a millisecond timestamp value that is saved on the Runtime.
+     * This value is helpful in certain instances for compatibility with Scratch 2,
+     * which sometimes uses a `currentMSecs` timestamp value in Interpreter.as
      */
     updateCurrentMSecs () {
         this.currentMSecs = Date.now();

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -305,6 +305,8 @@ class Runtime extends EventEmitter {
          */
         this.currentStepTime = null;
 
+        this.updateCurrentMSecs();
+
         /**
          * Whether any primitive has requested a redraw.
          * Affects whether `Sequencer.stepThreads` will yield
@@ -2172,6 +2174,10 @@ class Runtime extends EventEmitter {
      */
     disableProfiling () {
         this.profiler = null;
+    }
+
+    updateCurrentMSecs () {
+        this.currentMSecs = Date.now();
     }
 }
 

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -50,17 +50,7 @@ class Sequencer {
          * A utility timer for timing thread sequencing.
          * @type {!Timer}
          */
-        this.timer = new Timer(this.nowObject);
-    }
-
-    get nowObject () {
-        if (this.runtime) {
-           return {
-                now: () => {
-                    return this.runtime.currentMSecs;
-                }
-            };
-        }
+        this.timer = new Timer();
     }
 
     /**

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -41,16 +41,16 @@ let executeProfilerId = -1;
 class Sequencer {
     constructor (runtime) {
         /**
-         * Reference to the runtime owning this sequencer.
-         * @type {!Runtime}
-         */
-        this.runtime = runtime;
-
-        /**
          * A utility timer for timing thread sequencing.
          * @type {!Timer}
          */
         this.timer = new Timer();
+
+        /**
+         * Reference to the runtime owning this sequencer.
+         * @type {!Runtime}
+         */
+        this.runtime = runtime;
     }
 
     /**

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -68,6 +68,9 @@ class Sequencer {
     stepThreads () {
         // Work time is 75% of the thread stepping interval.
         const WORK_TIME = 0.75 * this.runtime.currentStepTime;
+        // For compatibility with Scatch 2, update the millisecond clock
+        // on the Runtime once per step (see Interpreter.as in Scratch 2
+        // for original use of `currentMSecs`)
         this.runtime.updateCurrentMSecs();
         // Start counting toward WORK_TIME.
         this.timer.start();

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -61,7 +61,6 @@ class Sequencer {
                 }
             };
         }
-        return null;
     }
 
     /**

--- a/src/util/timer.js
+++ b/src/util/timer.js
@@ -18,8 +18,12 @@ class Timer {
          * Used to store the start time of a timer action.
          * Updated when calling `timer.start`.
          */
-         console.log('nowObj', nowObj);
         this.startTime = 0;
+
+        /**
+         * Used to pass custom logic for determining the value for "now"
+         * which is sometimes useful for compatibility with Scratch 2
+         */
         this.nowObj = nowObj;
     }
 

--- a/src/util/timer.js
+++ b/src/util/timer.js
@@ -21,7 +21,7 @@ class Timer {
         this.startTime = 0;
 
         /**
-         * Used to pass custom logic for determining the value for "now"
+         * Used to pass custom logic for determining the value for "now",
          * which is sometimes useful for compatibility with Scratch 2
          */
         this.nowObj = nowObj;
@@ -47,7 +47,6 @@ class Timer {
             }
         };
     }
-
 
     /**
      * Use this object to route all time functions through single access points.

--- a/src/util/timer.js
+++ b/src/util/timer.js
@@ -18,6 +18,7 @@ class Timer {
          * Used to store the start time of a timer action.
          * Updated when calling `timer.start`.
          */
+         console.log('nowObj', nowObj);
         this.startTime = 0;
         this.nowObj = nowObj;
     }

--- a/src/util/timer.js
+++ b/src/util/timer.js
@@ -13,12 +13,13 @@
  */
 
 class Timer {
-    constructor () {
+    constructor (nowObj = Timer.nowObj) {
         /**
          * Used to store the start time of a timer action.
          * Updated when calling `timer.start`.
          */
         this.startTime = 0;
+        this.nowObj = nowObj;
     }
 
     /**
@@ -42,6 +43,7 @@ class Timer {
         };
     }
 
+
     /**
      * Use this object to route all time functions through single access points.
      */
@@ -59,7 +61,7 @@ class Timer {
      * @returns {number} ms elapsed since 1 January 1970 00:00:00 UTC.
      */
     time () {
-        return Timer.nowObj.now();
+        return this.nowObj.now();
     }
 
     /**
@@ -70,7 +72,7 @@ class Timer {
      * @returns {number} ms-scale accurate time relative to other relative times.
      */
     relativeTime () {
-        return Timer.nowObj.now();
+        return this.nowObj.now();
     }
 
     /**
@@ -78,11 +80,11 @@ class Timer {
      * at the most accurate precision possible.
      */
     start () {
-        this.startTime = Timer.nowObj.now();
+        this.startTime = this.nowObj.now();
     }
 
     timeElapsed () {
-        return Timer.nowObj.now() - this.startTime;
+        return this.nowObj.now() - this.startTime;
     }
 }
 

--- a/test/integration/execute.js
+++ b/test/integration/execute.js
@@ -27,7 +27,7 @@ const VirtualMachine = require('../../src/index');
  * been reached.
  */
 
-const whenThreadsComplete = (t, vm, timeLimit = 2500) => (
+const whenThreadsComplete = (t, vm, timeLimit = 2000) => (
     // When the number of threads reaches 0 the test is expected to be complete.
     new Promise((resolve, reject) => {
         const intervalId = setInterval(() => {

--- a/test/integration/execute.js
+++ b/test/integration/execute.js
@@ -27,7 +27,7 @@ const VirtualMachine = require('../../src/index');
  * been reached.
  */
 
-const whenThreadsComplete = (t, vm, timeLimit = 2000) => (
+const whenThreadsComplete = (t, vm, timeLimit = 2500) => (
     // When the number of threads reaches 0 the test is expected to be complete.
     new Promise((resolve, reject) => {
         const intervalId = setInterval(() => {

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -261,10 +261,10 @@ test('wait', t => {
     const waitTime = args.DURATION * 1000;
     const startTest = Date.now();
     const threshold = 1000 / 60; // 60 hz
-    let yields = 0
+    let yields = 0;
     const util = {
         stackFrame: {},
-        yield: () => yields++,
+        yield: () => yields++
     };
 
     c.wait(args, util);

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -270,7 +270,9 @@ test('wait', t => {
     // Delay tests until after Wait block should have finished
     setTimeout(() => {
         const timeElapsed = util.stackFrame.timer.timeElapsed();
-
+        console.log('timeElapsed', timeElapsed);
+        console.log('waitTime', waitTime);
+        console.log('threshold', threshold);
         t.equal(waitTime, util.stackFrame.duration);
         t.ok(timeElapsed >= (waitTime - threshold) &&
              timeElapsed <= (waitTime + threshold));

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -1,7 +1,6 @@
 const test = require('tap').test;
 const Control = require('../../src/blocks/scratch3_control');
 const Runtime = require('../../src/engine/runtime');
-const BlockUtility = require('../../src/engine/block-utility');
 
 test('getPrimitives', t => {
     const rt = new Runtime();
@@ -258,13 +257,13 @@ test('allAtOnce', t => {
 test('wait', t => {
     const rt = new Runtime();
     const c = new Control(rt);
-    const args = { DURATION: .01 };
+    const args = {DURATION: .01};
     const waitTime = args.DURATION * 1000;
     const threshold = 1000 / 60; // 60 hz
     const util = {
         stackFrame: {},
-        yield: () => true,
-    }
+        yield: () => true
+    };
 
     c.wait(args, util);
 

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -1,6 +1,7 @@
 const test = require('tap').test;
 const Control = require('../../src/blocks/scratch3_control');
 const Runtime = require('../../src/engine/runtime');
+const BlockUtility = require('../../src/engine/block-utility');
 
 test('getPrimitives', t => {
     const rt = new Runtime();
@@ -252,4 +253,28 @@ test('allAtOnce', t => {
     c.allAtOnce({}, util);
     t.true(ran);
     t.end();
+});
+
+test('wait', t => {
+    const rt = new Runtime();
+    const c = new Control(rt);
+    const args = { DURATION: .01 };
+    const waitTime = args.DURATION * 1000;
+    const threshold = 1000 / 60; // 60 hz
+    const util = {
+        stackFrame: {},
+        yield: () => true,
+    }
+
+    c.wait(args, util);
+
+    // Delay tests until after Wait block should have finished
+    setTimeout(() => {
+        const timeElapsed = util.stackFrame.timer.timeElapsed();
+
+        t.equal(waitTime, util.stackFrame.duration);
+        t.ok(timeElapsed >= (waitTime - threshold) &&
+             timeElapsed <= (waitTime + threshold));
+        t.end();
+    }, waitTime);
 });

--- a/test/unit/blocks_control.js
+++ b/test/unit/blocks_control.js
@@ -266,16 +266,17 @@ test('wait', t => {
     };
 
     c.wait(args, util);
+    let timeElapsed = 0;
 
-    // Delay tests until after Wait block should have finished
-    setTimeout(() => {
-        const timeElapsed = util.stackFrame.timer.timeElapsed();
-        console.log('timeElapsed', timeElapsed);
-        console.log('waitTime', waitTime);
-        console.log('threshold', threshold);
-        t.equal(waitTime, util.stackFrame.duration);
-        t.ok(timeElapsed >= (waitTime - threshold) &&
-             timeElapsed <= (waitTime + threshold));
-        t.end();
-    }, waitTime);
+    while (timeElapsed < waitTime) {
+        timeElapsed = util.stackFrame.timer.timeElapsed() 
+    }
+
+    console.log('timeElapsed', timeElapsed);
+    console.log('waitTime', waitTime);
+    console.log('threshold', threshold);
+    t.equal(waitTime, util.stackFrame.duration);
+    t.ok(timeElapsed >= (waitTime - threshold) &&
+         timeElapsed <= (waitTime + threshold));
+    t.end();
 });


### PR DESCRIPTION
### Resolves

Fixes [the seagull project](https://llk.github.io/scratch-gui/develop/#169401431) in #1478, where the "BREATH" sprite doesn't disappear as expected. It also includes some compatibility fixes for [a space invaders project](https://scratch.mit.edu/projects/252324412/) and a [project that tracks the Scratch loop](https://scratch.mit.edu/projects/259055091)

### Proposed Changes

- This PR replaces the wait block's use of JavaScript promises with logic that keeps track of how much time has elapsed with the Timer utility. This makes the wait block's timing more consistent with how [it was implemented in Scratch 2](https://github.com/LLK/scratch-flash/blob/develop/src/interpreter/Interpreter.as#L604-L609) and avoids race conditions with the JS event loop.
- Adds a timer and timer-related logic to blocks' utility functions
- Adds a time server to the runtime to make available a millisecond clock that updates as threads are stepped. This is useful when a block's timing needs to mimic logic for [Sprite 2's `currentMSecs` timestamp.](https://github.com/LLK/scratch-flash/blob/72e4729b8189d11bbe51b6d94144b0a3c392ac9a/src/interpreter/Interpreter.as#L245)

### Reason for Changes

In the example seagulls project, the "BREATHE" sprite doesn't disappear because of a race condition with its wait blocks. The hide block executes before the show block. Using the timer utility and timestamps makes the wait times more consistent.

We also needed a milliseconds clock that keeps the same timestamp for an entire step of the Sequencer, [as in Scratch 2.](https://github.com/LLK/scratch-flash/blob/72e4729b8189d11bbe51b6d94144b0a3c392ac9a/src/interpreter/Interpreter.as#L245) This cached value is what allowed the enemy ships in [this Space Invaders project](https://scratch.mit.edu/projects/252324412/) to move in unison. Without this cached value, my wait block timer fix made the ships even more out of sync. This millisecond timestamp is passed as a custom `nowObj` for the wait block's timer. 

### Test Coverage

I've added tests for the wait block in `blocks_control.js`. 