### PR TITLE
Fix unit tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - 8
-- node
+- 10
 env:
   global:
   - NODE_ENV=production

--- a/test/unit/dispatch.js
+++ b/test/unit/dispatch.js
@@ -49,7 +49,8 @@ test('local', t => {
 
 test('remote', t => {
     const fixturesDir = path.resolve(__dirname, '../fixtures');
-    const worker = new Worker('./test/fixtures/dispatch-test-worker-shim.js', null, {cwd: fixturesDir});
+    const shimPath = path.resolve(fixturesDir, 'dispatch-test-worker-shim.js');
+    const worker = new Worker(shimPath, null, {cwd: fixturesDir});
     dispatch.addWorker(worker);
 
     const waitForWorker = new Promise(resolve => {


### PR DESCRIPTION
### Resolves

Resolves #1767

### Proposed Changes

1. Explicitly specify Node 8 & 10 in `.travis.yml`
2. Fix unit tests when running in Node 11

Note that I let Travis run on just 30a1ba5 to demonstrate that the Node 11 fix works.

### Reason for Changes

1. Explicitly specifying supported Node.js versions should help prevent surprises like this in the future. As of submitting this PR, Node 8 and Node 10 are the two releases listed as "Active LTS" here: https://github.com/nodejs/Release#release-schedule
2. The fix for the dispatch unit test is simple and protects against an ambiguity in the Worker API, so I think it's reasonable to keep it even if we turn off testing Node 11 for now.
