### PR TITLE
Emit cloud data update

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -364,13 +364,17 @@ class Runtime extends EventEmitter {
 
         /**
          * A function that tracks a new cloud variable in the runtime,
-         * updating the cloud variable limit.
+         * updating the cloud variable limit. Calling this function will
+         * emit a cloud data update event if this is the first cloud variable
+         * being added.
+         * @type {function}
          */
         this.addCloudVariable = this._initializeAddCloudVariable(newCloudDataManager);
 
         /**
          * A function which updates the runtime's cloud variable limit
-         * when removing a cloud variable.
+         * when removing a cloud variable and emits a cloud update event
+         * if the last of the cloud variables is being removed.
          * @type {function}
          */
         this.removeCloudVariable = this._initializeRemoveCloudVariable(newCloudDataManager);
@@ -647,6 +651,7 @@ class Runtime extends EventEmitter {
     // -----------------------------------------------------------------------------
     // -----------------------------------------------------------------------------
 
+    // Helper function for initializing the addCloudVariable function
     _initializeAddCloudVariable (newCloudDataManager) {
         // The addCloudVariable function
         return (() => {
@@ -658,6 +663,7 @@ class Runtime extends EventEmitter {
         });
     }
 
+    // Helper function for initializing the removeCloudVariable function
     _initializeRemoveCloudVariable (newCloudDataManager) {
         return (() => {
             const hadCloudVarsBefore = this.hasCloudData();

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1540,6 +1540,16 @@ class Runtime extends EventEmitter {
         this.targets.map(this.disposeTarget, this);
         this._monitorState = OrderedMap({});
         // @todo clear out extensions? turboMode? etc.
+
+        // *********** Cloud *******************
+
+        // If the runtime currently has cloud data,
+        // emit a has cloud data update event resetting
+        // it to false
+        if (this.hasCloudData()) {
+            this.emit(Runtime.HAS_CLOUD_DATA_UPDATE, false);
+        }
+
         this.ioDevices.cloud.clear();
 
         // Reset runtime cloud data info
@@ -1548,7 +1558,6 @@ class Runtime extends EventEmitter {
         this.canAddCloudVariable = newCloudDataManager.canAddCloudVariable;
         this.addCloudVariable = this._initializeAddCloudVariable(newCloudDataManager);
         this.removeCloudVariable = this._initializeRemoveCloudVariable(newCloudDataManager);
-
     }
 
     /**

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -239,10 +239,12 @@ class Target extends EventEmitter {
     createVariable (id, name, type, isCloud) {
         if (!this.variables.hasOwnProperty(id)) {
             const newVariable = new Variable(id, name, type, false);
-            this.variables[id] = newVariable;
-            if (isCloud && this.isStage) {
+            if (isCloud && this.isStage && this.runtime.canAddCloudVariable()) {
+                newVariable.isCloud = true;
+                this.runtime.addCloudVariable();
                 this.runtime.ioDevices.cloud.requestCreateVariable(newVariable);
             }
+            this.variables[id] = newVariable;
         }
     }
 
@@ -326,6 +328,7 @@ class Target extends EventEmitter {
             if (this.runtime) {
                 if (deletedVariableWasCloud && this.isStage) {
                     this.runtime.ioDevices.cloud.requestDeleteVariable(deletedVariableName);
+                    this.runtime.removeCloudVariable();
                 }
                 this.runtime.monitorBlocks.deleteBlock(id);
                 this.runtime.requestRemoveMonitor(id);

--- a/src/io/cloud.js
+++ b/src/io/cloud.js
@@ -27,19 +27,11 @@ class Cloud {
      */
 
     /**
-     * Part of a cloud io data post indicating a cloud variable was successfully
-     * created.
-     * @typedef {object} VarCreateData
-     * @property {string} name The name of the variable to create
-     */
-
-    /**
      * A cloud io data post message.
      * @typedef {object} CloudIOData
      * @property {VarUpdateData} varUpdate A {@link VarUpdateData} message indicating
      * a cloud variable update
      */
-
 
     /**
      * Cloud IO Device responsible for sending and receiving messages from
@@ -94,10 +86,6 @@ class Cloud {
         if (data.varUpdate) {
             this.updateCloudVariable(data.varUpdate);
         }
-
-        if (data.varCreate) {
-            this.createCloudVariable(data.varCreate);
-        }
     }
 
     requestCreateVariable (variable) {
@@ -144,24 +132,6 @@ class Cloud {
         if (this.provider) {
             this.provider.deleteVariable(name);
         }
-    }
-
-    /**
-     * Create a cloud variable based on the message
-     * received from the cloud provider.
-     * @param {VarCreateData} varCreate A {@link VarCreateData} object received from the
-     * cloud data provider confirming the creation of a cloud variable,
-     * providing its name and value.
-     */
-    createCloudVariable (varCreate) {
-        const varName = varCreate.name;
-
-        const variable = this.stage.lookupVariableByNameAndType(varName, Variable.SCALAR_TYPE);
-        if (!variable) {
-            log.error(`Could not find cloud variable with name: ${varName}`);
-        }
-        variable.isCloud = true;
-        this.runtime.addCloudVariable();
     }
 
     /**

--- a/src/io/cloud.js
+++ b/src/io/cloud.js
@@ -108,7 +108,7 @@ class Cloud {
                 // cloud variable limit when we actually
                 // get a confirmation from the cloud data server
             }
-        }
+        } // TODO else track creation for later
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -129,6 +129,9 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.RUNTIME_STARTED, () => {
             this.emit(Runtime.RUNTIME_STARTED);
         });
+        this.runtime.on(Runtime.HAS_CLOUD_DATA_UPDATE, hasCloudData => {
+            this.emit(Runtime.HAS_CLOUD_DATA_UPDATE, hasCloudData);
+        });
 
         this.extensionManager = new ExtensionManager(this.runtime);
 

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -90,8 +90,7 @@ test('createVariable calls cloud io device\'s requestCreateVariable', t => {
     t.equal(variable.name, 'bar');
     t.equal(variable.type, Variable.SCALAR_TYPE);
     t.equal(variable.value, 0);
-    // isCloud flag doesn't get set by the target createVariable function
-    t.equal(variable.isCloud, false);
+    t.equal(variable.isCloud, true);
     t.equal(requestCreateCloudWasCalled, true);
 
     t.end();
@@ -116,7 +115,7 @@ test('createVariable does not call cloud io device\'s requestCreateVariable if t
     t.equal(variable.name, 'bar');
     t.equal(variable.type, Variable.SCALAR_TYPE);
     t.equal(variable.value, 0);
-    // isCloud flag doesn't get set by the target createVariable function
+    // isCloud flag doesn't get set if the target is not the stage
     t.equal(variable.isCloud, false);
     t.equal(requestCreateCloudWasCalled, false);
 

--- a/test/unit/io_cloud.js
+++ b/test/unit/io_cloud.js
@@ -10,10 +10,11 @@ test('spec', t => {
 
     t.type(cloud, 'object');
     t.type(cloud.postData, 'function');
-    t.type(cloud.requestUpdateVariable, 'function');
-    t.type(cloud.updateCloudVariable, 'function');
     t.type(cloud.requestCreateVariable, 'function');
-    t.type(cloud.createCloudVariable, 'function');
+    t.type(cloud.requestUpdateVariable, 'function');
+    t.type(cloud.requestRenameVariable, 'function');
+    t.type(cloud.requestDeleteVariable, 'function');
+    t.type(cloud.updateCloudVariable, 'function');
     t.type(cloud.setProvider, 'function');
     t.type(cloud.setStage, 'function');
     t.type(cloud.clear, 'function');
@@ -63,30 +64,6 @@ test('postData update message updates the variable', t => {
         value: 3
     }});
     t.strictEquals(fooVar.value, 3);
-    t.end();
-});
-
-test('postData create message sets isCloud flag on the variable and updates runtime cloud limit', t => {
-    const stage = new Target();
-    const fooVar = new Variable(
-        'a fake var id',
-        'foo',
-        Variable.SCALAR_TYPE,
-        false /* isCloud */
-    );
-    stage.variables[fooVar.id] = fooVar;
-
-    t.strictEquals(fooVar.value, 0);
-    t.strictEquals(fooVar.isCloud, false);
-
-    const runtime = new Runtime();
-    const cloud = new Cloud(runtime);
-    cloud.setStage(stage);
-    cloud.postData({varCreate: {
-        name: 'foo'
-    }});
-    t.strictEquals(fooVar.isCloud, true);
-    t.strictEquals(runtime.hasCloudData(), true);
     t.end();
 });
 


### PR DESCRIPTION
### Proposed Changes

Emit an event when value of hasCloudData changes from false to true or true to false.

- The cloud io device no longer waits for a varCreate message from the cloud provider because of the new model of creating the first cloud variable then opening the cloud connection
- The runtime's `addCloudVariable` and `removeCloudVariable` functions have been refactored so they can emit the new event. They are initialized via helper functions.
- Clearing the runtime emits another hasCloudDataUpdate event.

Known Issues:
- Currently (and even before this PR), uploading a project with cloud variables from file does not create new cloud variables on the server, this feature would need to be added later after deciding how to differentiate uploading a new project from file (e.g. replacing the contents of a project ID) from just loading a project in the VM (e.g. viewing a project page).

### Reason for Changes

Cloud connection should open in a new project only when the project uses cloud data.

### Related PRs
- LLK/scratch-gui#3875

### Test Coverage

Updated existing tests.