### PR TITLE
Add "project changed" event

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -487,6 +487,10 @@ class Blocks {
             }
             break;
         }
+
+        // forceNoGlow is set to true on containers that don't affect the project serialization,
+        // e.g., the toolbox or monitor containers.
+        if (optRuntime && !this.forceNoGlow) optRuntime.emitProjectChanged();
     }
 
     // ---------------------------------------------------------------------

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -502,6 +502,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for report that a change was made that can be saved
+     * @const {string}
+     */
+    static get PROJECT_CHANGED () {
+        return 'PROJECT_CHANGED';
+    }
+
+    /**
      * Event name for targets update report.
      * @const {string}
      */
@@ -1737,7 +1745,6 @@ class Runtime extends EventEmitter {
         // Script glows must be cleared.
         this._scriptGlowsPreviousFrame = [];
         this._updateGlows();
-        this.requestTargetsUpdate(editingTarget);
     }
 
     /**
@@ -2033,6 +2040,13 @@ class Runtime extends EventEmitter {
      */
     emitProjectLoaded () {
         this.emit(Runtime.PROJECT_LOADED);
+    }
+
+    /**
+     * Report that the project has changed in a way that would affect serialization
+     */
+    emitProjectChanged () {
+        this.emit(Runtime.PROJECT_CHANGED);
     }
 
     /**


### PR DESCRIPTION
And emit it whenever we think the project has changed. Try to not emit it when a change has happened internally that shouldn't affect the serialized project.

This iteration fires the event too frequently, e.g., when switching sprites. This is meant as a simple initial implementation that can be improved.

/cc @benjiwheeler @cwillisf @kchadha 