### PR TITLE
Make setLocale consistently refresh blocks

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1030,10 +1030,9 @@ class VirtualMachine extends EventEmitter {
      *     updated for a new locale (or empty if locale hasn't changed.)
      */
     setLocale (locale, messages) {
-        if (locale === formatMessage.setup().locale) {
-            return Promise.resolve();
+        if (locale !== formatMessage.setup().locale) {
+            formatMessage.setup({locale: locale, translations: {[locale]: messages}});
         }
-        formatMessage.setup({locale: locale, translations: {[locale]: messages}});
         return this.extensionManager.refreshBlocks();
     }
 


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#3438

### Proposed Changes

This change makes the VM's `setLocale` method call `refreshBlocks` even when not changing the language, though it still skips an unnecessary call to `formatMessage.setup` in this case.

### Reason for Changes

The GUI relies on `refreshBlocks` to ensure that the toolbox has updated contents when switching between the community view and the "see inside" view.
