### PR TITLE
Prevent the runtime from spawning new stepping intervals

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1763,6 +1763,7 @@ class Runtime extends EventEmitter {
         this.compatibilityMode = compatibilityModeOn;
         if (this._steppingInterval) {
             clearInterval(this._steppingInterval);
+            this._steppingInterval = null;
             this.start();
         }
     }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -2172,6 +2172,9 @@ class Runtime extends EventEmitter {
      * Set up timers to repeatedly step in a browser.
      */
     start () {
+        // Do not start if we are already running
+        if (this._steppingInterval) return;
+
         let interval = Runtime.THREAD_STEP_INTERVAL;
         if (this.compatibilityMode) {
             interval = Runtime.THREAD_STEP_INTERVAL_COMPATIBILITY;

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -211,3 +211,31 @@ test('Runtime cannot be started while already running', t => {
     t.equal(started, false);
     t.end();
 });
+
+test('setCompatibilityMode restarts if it was already running', t => {
+    const rt = new Runtime();
+    rt.start(); // Start the first time
+
+    // Set up a flag/listener to check if it gets started again
+    let started = false;
+    rt.addListener('RUNTIME_STARTED', () => {
+        started = true;
+    });
+
+    rt.setCompatibilityMode(true);
+    t.equal(started, true);
+    t.end();
+});
+
+test('setCompatibilityMode does not restart if it was not running', t => {
+    const rt = new Runtime();
+
+    let started = false;
+    rt.addListener('RUNTIME_STARTED', () => {
+        started = true;
+    });
+
+    rt.setCompatibilityMode(true);
+    t.equal(started, false);
+    t.end();
+});

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -195,3 +195,19 @@ test('Starting the runtime emits an event', t => {
     t.equal(started, true);
     t.end();
 });
+
+test('Runtime cannot be started while already running', t => {
+    const rt = new Runtime();
+    rt.start(); // Start the first time
+
+    // Set up a flag/listener to check if it can be started again
+    let started = false;
+    rt.addListener('RUNTIME_STARTED', () => {
+        started = true;
+    });
+
+    // Starting again should not emit another event
+    rt.start();
+    t.equal(started, false);
+    t.end();
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves an issue where you can call `start` multiple times on the runtime, making it possible to have multiple stepping loops running at the same time. This causes projects to run at strange speeds.

### Proposed Changes

_Describe what this Pull Request does_

Prevent start from running if the steppingInterval (an id for the step timeout, not a duration) already exists. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test for this that previously would have failed (checked that).