### PR TITLE
VM changes for the sensing_of block.

### DIFF
--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -313,12 +313,11 @@ class Scratch3SensingBlocks {
             }
         }
 
-        // Variables
+        // Local variables (not lists).
         const varName = args.PROPERTY;
-        for (const id in attrTarget.variables) {
-            if (attrTarget.variables[id].name === varName) {
-                return attrTarget.variables[id].value;
-            }
+        const variable = attrTarget.lookupVariableByNameAndType(varName, '', true);
+        if (variable) {
+            return variable.value;
         }
 
         // Otherwise, 0

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -313,7 +313,7 @@ class Scratch3SensingBlocks {
             }
         }
 
-        // Local variables (not lists).
+        // Target variables.
         const varName = args.PROPERTY;
         const variable = attrTarget.lookupVariableByNameAndType(varName, '', true);
         if (variable) {

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -567,6 +567,16 @@ class Blocks {
                 if (!optRuntime){
                     break;
                 }
+                // The selected item in the sensing of block menu needs to change based on the
+                // selected target.  Set it to the first item in the menu list.
+                if (block.opcode === 'sensing_of_object_menu') {
+                    if (block.fields.OBJECT.value === '_stage_') {
+                        this._blocks[block.parent].fields.PROPERTY.value = 'backdrop #';
+                    } else {
+                        this._blocks[block.parent].fields.PROPERTY.value = 'x position';
+                    }
+                    optRuntime.requestBlocksUpdate();
+                }
 
                 const flyoutBlock = block.shadow && block.parent ? this._blocks[block.parent] : block;
                 if (flyoutBlock.isMonitored) {

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -569,7 +569,7 @@ class Blocks {
                 }
                 // The selected item in the sensing of block menu needs to change based on the
                 // selected target.  Set it to the first item in the menu list.
-                // TODO: https://github.com/LLK/scratch-vm/issues/1787
+                // TODO: (#1787)
                 if (block.opcode === 'sensing_of_object_menu') {
                     if (block.fields.OBJECT.value === '_stage_') {
                         this._blocks[block.parent].fields.PROPERTY.value = 'backdrop #';

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -569,6 +569,7 @@ class Blocks {
                 }
                 // The selected item in the sensing of block menu needs to change based on the
                 // selected target.  Set it to the first item in the menu list.
+                // TODO: https://github.com/LLK/scratch-vm/issues/1787
                 if (block.opcode === 'sensing_of_object_menu') {
                     if (block.fields.OBJECT.value === '_stage_') {
                         this._blocks[block.parent].fields.PROPERTY.value = 'backdrop #';

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -614,6 +614,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for reporting that a block was updated and needs to be rerendered.
+     * @const {string}
+     */
+    static get BLOCKS_NEED_UPDATE () {
+        return 'BLOCKS_NEED_UPDATE';
+    }
+
+    /**
      * How rapidly we try to step threads by default, in ms.
      */
     static get THREAD_STEP_INTERVAL () {
@@ -2167,6 +2175,13 @@ class Runtime extends EventEmitter {
     requestTargetsUpdate (target) {
         if (!target.isOriginal) return;
         this._refreshTargets = true;
+    }
+
+    /**
+     * Emit an event that indicate that the blocks on the workspace need updating.
+     */
+    requestBlocksUpdate () {
+        this.emit(Runtime.BLOCK_NEED_UPDATE);
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -2181,7 +2181,7 @@ class Runtime extends EventEmitter {
      * Emit an event that indicate that the blocks on the workspace need updating.
      */
     requestBlocksUpdate () {
-        this.emit(Runtime.BLOCK_NEED_UPDATE);
+        this.emit(Runtime.BLOCKS_NEED_UPDATE);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -108,6 +108,9 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.BLOCKSINFO_UPDATE, blocksInfo => {
             this.emit(Runtime.BLOCKSINFO_UPDATE, blocksInfo);
         });
+        this.runtime.on(Runtime.BLOCKS_NEED_UPDATE, () => {
+            this.emitWorkspaceUpdate();
+        });
         this.runtime.on(Runtime.PERIPHERAL_LIST_UPDATE, info => {
             this.emit(Runtime.PERIPHERAL_LIST_UPDATE, info);
         });

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -234,12 +234,12 @@ test('get attribute of sprite variable', t => {
     const sensing = new Sensing(rt);
     const s = new Sprite();
     const target = new RenderedTarget(s, rt);
-    const thing = {
+    const variable = {
         name: 'cars',
         value: 'trucks'
     };
     rt.getSpriteTargetByName = () => target;
-    target.lookupVariableByNameAndType = () => thing;
+    target.lookupVariableByNameAndType = () => variable;
     t.equal(sensing.getAttributeOf({PROPERTY: 'cars'}), 'trucks');
 
     t.end();
@@ -248,10 +248,10 @@ test('get attribute of variable that does not exist', t => {
     const rt = new Runtime();
     const sensing = new Sensing(rt);
     const s = new Sprite();
-    const stage = new RenderedTarget(s, rt);
-    rt.getTargetForStage = () => stage;
-    stage.lookupVariableByNameAndType = () => null;
-    t.equal(sensing.getAttributeOf({PROPERTY: 'stage'}), 0);
+    const target = new RenderedTarget(s, rt);
+    rt.getTargetForStage = () => target;
+    target.lookupVariableByNameAndType = () => null;
+    t.equal(sensing.getAttributeOf({PROPERTY: 'variableThatDoesNotExist'}), 0);
 
     t.end();
 });

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -229,6 +229,33 @@ test('loud? boolean', t => {
     t.end();
 });
 
+test('get attribute of sprite variable', t => {
+    const rt = new Runtime();
+    const sensing = new Sensing(rt);
+    const s = new Sprite();
+    const target = new RenderedTarget(s, rt);
+    const thing = {
+        name: 'cars',
+        value: 'trucks'
+    };
+    rt.getSpriteTargetByName = () => target;
+    target.lookupVariableByNameAndType = () => thing;
+    t.equal(sensing.getAttributeOf({PROPERTY: 'cars'}), 'trucks');
+
+    t.end();
+});
+test('get attribute of variable that does not exist', t => {
+    const rt = new Runtime();
+    const sensing = new Sensing(rt);
+    const s = new Sprite();
+    const stage = new RenderedTarget(s, rt);
+    rt.getTargetForStage = () => stage;
+    stage.lookupVariableByNameAndType = () => null;
+    t.equal(sensing.getAttributeOf({PROPERTY: 'stage'}), 0);
+
+    t.end();
+});
+
 test('username block', t => {
     const rt = new Runtime();
     const sensing = new Sensing(rt);

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -4,7 +4,6 @@ const Runtime = require('../../src/engine/runtime');
 const Sprite = require('../../src/sprites/sprite');
 const RenderedTarget = require('../../src/sprites/rendered-target');
 const BlockUtility = require('../../src/engine/block-utility');
-const Variable = require('../../src/engine/variable');
 
 
 test('getPrimitives', t => {

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -5,7 +5,6 @@ const Sprite = require('../../src/sprites/sprite');
 const RenderedTarget = require('../../src/sprites/rendered-target');
 const BlockUtility = require('../../src/engine/block-utility');
 
-
 test('getPrimitives', t => {
     const rt = new Runtime();
     const s = new Sensing(rt);

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -4,6 +4,8 @@ const Runtime = require('../../src/engine/runtime');
 const Sprite = require('../../src/sprites/sprite');
 const RenderedTarget = require('../../src/sprites/rendered-target');
 const BlockUtility = require('../../src/engine/block-utility');
+const Variable = require('../../src/engine/variable');
+
 
 test('getPrimitives', t => {
     const rt = new Runtime();
@@ -236,10 +238,12 @@ test('get attribute of sprite variable', t => {
     const target = new RenderedTarget(s, rt);
     const variable = {
         name: 'cars',
-        value: 'trucks'
+        value: 'trucks',
+        type: ''
     };
+    // Add variable to set the map (it should be empty before this).
+    target.variables.anId = variable;
     rt.getSpriteTargetByName = () => target;
-    target.lookupVariableByNameAndType = () => variable;
     t.equal(sensing.getAttributeOf({PROPERTY: 'cars'}), 'trucks');
 
     t.end();
@@ -250,7 +254,6 @@ test('get attribute of variable that does not exist', t => {
     const s = new Sprite();
     const target = new RenderedTarget(s, rt);
     rt.getTargetForStage = () => target;
-    target.lookupVariableByNameAndType = () => null;
     t.equal(sensing.getAttributeOf({PROPERTY: 'variableThatDoesNotExist'}), 0);
 
     t.end();


### PR DESCRIPTION
### Resolves

Resolves #1762 and resolves LLK/scratch-gui#2389 and resolves LLK/scratch-gui#2390.

### Proposed Changes

This handles lists properly (by ignoring them like Scratch2 and makes the attribute menu update based on what was chosen in the target menu.

Comments from this PR are all in https://github.com/LLK/scratch-vm/pull/1774 which github seems to now think includes far more than it actually does.
