### PR TITLE
Serialize variable isCloud flag to xml.

### DIFF
--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -35,7 +35,8 @@ class Variable {
 
     toXML (isLocal) {
         isLocal = (isLocal === true);
-        return `<variable type="${this.type}" id="${this.id}" islocal="${isLocal}">${this.name}</variable>`;
+        return `<variable type="${this.type}" id="${this.id}" islocal="${isLocal
+        }" iscloud="${this.isCloud}">${this.name}</variable>`;
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

Serialize isCloud flag when serializing variables to XML.

Related to LLK/scratch-blocks#1801

### Reason for Changes

Towards fixing an issue with variable renaming.

### Test Coverage

Manually tested along with LLK/scratch-blocks#1801

1. Create a cloud variable
2. Switch to the costumes tab
3. Switch back to the blocks tab
4. Right click on the variable reporter in the toolbox to rename the cloud variable.
5. Rename the variable.
6. Observe that the variable is renamed keeping the cloud unicode character. On scratch.ly, the cloud unicode character is gone after the rename.
