### PR TITLE
use Object.keys instead of for ... in, because with Opal.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -799,7 +799,7 @@ class Blocks {
     getAllVariableAndListReferences (optBlocks) {
         const blocks = optBlocks ? optBlocks : this._blocks;
         const allReferences = Object.create(null);
-        for (const blockId in blocks) {
+        Object.keys(blocks).forEach(blockId => {
             let varOrListField = null;
             let varType = null;
             if (blocks[blockId].fields.VARIABLE) {
@@ -823,7 +823,7 @@ class Blocks {
                     }];
                 }
             }
-        }
+        });
         return allReferences;
     }
 

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -702,12 +702,11 @@ class Target extends EventEmitter {
         }
         // Rename any local variables that were missed above because they aren't
         // referenced by any blocks
-        for (const id in unreferencedLocalVarIds) {
-            const varId = unreferencedLocalVarIds[id];
+        unreferencedLocalVarIds.forEach(varId => {
             const name = this.variables[varId].name;
             const type = this.variables[varId].type;
             renameConflictingLocalVar(varId, name, type);
-        }
+        });
         // Handle global var conflicts with existing global vars (e.g. a sprite is uploaded, and has
         // blocks referencing some variable that the sprite does not own, and this
         // variable conflicts with a global var)


### PR DESCRIPTION
### Proposed Changes

use Object.keys instead of for ... in in Blocks.getAllVariableAndListReferences.

### Reason for Changes

If added some methods to Array.prototype by some libraries like Opal, it's failed.

### Test Coverage

I checked scratch-gui with this changes. Drag and drop blocks from a sprite to another sprite, and it's done.