### PR TITLE
Fix usage of loadCostumeFromAsset.

### DIFF
--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -146,8 +146,7 @@ class Sprite {
 
         newSprite.costumes = this.costumes_.map(costume => {
             const newCostume = Object.assign({}, costume);
-            const costumeAsset = costume.asset;
-            assetPromises.push(loadCostumeFromAsset(newCostume, costumeAsset, this.runtime));
+            assetPromises.push(loadCostumeFromAsset(newCostume, this.runtime));
             return newCostume;
         });
 


### PR DESCRIPTION
Fixes the issue where duplicating a sprite did not correctly assign a new skinId for the renderer. It was because the renderer didn't appear to be available, so a new skinId was not assigned.

Introduced by https://github.com/LLK/scratch-vm/pull/1737

Fixes https://github.com/LLK/scratch-gui/issues/3924