### PR TITLE
Task Queue unit test stubbed timer

### DIFF
--- a/test/unit/util_task-queue.js
+++ b/test/unit/util_task-queue.js
@@ -1,18 +1,16 @@
 const test = require('tap').test;
 
-const Timer = require('../../src/util/timer');
 const TaskQueue = require('../../src/util/task-queue');
 
 const testCompare = require('../fixtures/test-compare');
-
-// TODO: temporary comment to trigger git
 
 test('constructor', t => {
     // Max tokens = 1000, refill 1000 tokens per second (1 per millisecond), and start with 0 tokens
     const bukkit = new TaskQueue(1000, 1000, 0);
 
-    const timer = new Timer();
-    timer.start();
+    // Simulate time passing with a stubbed timer
+    const simulatedTimeStart = Date.now();
+    bukkit._timer = {timeElapsed: () => Date.now() - simulatedTimeStart};
 
     const taskResults = [];
     const promises = [];
@@ -28,13 +26,13 @@ test('constructor', t => {
     bukkit.cancelAll();
     promises.push(
         bukkit.do(() => taskResults.push('a'), 50).then(() =>
-            testCompare(t, timer.timeElapsed(), '>=', 50, 'Costly task must wait')
+            testCompare(t, bukkit._timer.timeElapsed(), '>=', 50, 'Costly task must wait')
         ),
         bukkit.do(() => taskResults.push('b'), 10).then(() =>
-            testCompare(t, timer.timeElapsed(), '>=', 60, 'Tasks must run in serial')
+            testCompare(t, bukkit._timer.timeElapsed(), '>=', 60, 'Tasks must run in serial')
         ),
         bukkit.do(() => taskResults.push('c'), 1).then(() =>
-            testCompare(t, timer.timeElapsed(), '<', 80, 'Cheap task should run soon')
+            testCompare(t, bukkit._timer.timeElapsed(), '<', 80, 'Cheap task should run soon')
         )
     );
     return Promise.all(promises).then(() => {

--- a/test/unit/util_task-queue.js
+++ b/test/unit/util_task-queue.js
@@ -5,6 +5,8 @@ const TaskQueue = require('../../src/util/task-queue');
 
 const testCompare = require('../fixtures/test-compare');
 
+// TODO: temporary comment to trigger git
+
 test('constructor', t => {
     // Max tokens = 1000, refill 1000 tokens per second (1 per millisecond), and start with 0 tokens
     const bukkit = new TaskQueue(1000, 1000, 0);


### PR DESCRIPTION
Potentially Resolves #1807: Task queue tests are flaky

Could be a solution instead of #1808: Skip task queue tests

Tested Locally:
- Ran `npm run env -- tap ./test/unit/util_task-queue.js` and `4/4` passed
- Ran `npm test` and `2487/2487` passed