### PR TITLE
Add a flag to force the video layer to be transparent.

### DIFF
--- a/src/io/video.js
+++ b/src/io/video.js
@@ -163,7 +163,7 @@ class Video {
         // if we haven't already created and started a preview frame render loop, do so
         if (!this._renderPreviewFrame) {
             renderer.updateDrawableProperties(this._drawable, {
-                ghost: this._ghost,
+                ghost: this._forceTransparentPreview ? 100 : this._ghost,
                 visible: true
             });
 

--- a/src/io/video.js
+++ b/src/io/video.js
@@ -39,6 +39,12 @@ class Video {
          * @type {number}
          */
         this._ghost = 0;
+
+        /**
+         * Store a flag that allows the preview to be forced transparent.
+         * @type {number}
+         */
+        this._forceTransparentPreview = false;
     }
 
     static get FORMAT_IMAGE_DATA () {
@@ -127,7 +133,9 @@ class Video {
     setPreviewGhost (ghost) {
         this._ghost = ghost;
         if (this._drawable) {
-            this.runtime.renderer.updateDrawableProperties(this._drawable, {ghost});
+            this.runtime.renderer.updateDrawableProperties(this._drawable, {
+                ghost: this._forceTransparentPreview ? 100 : ghost
+            });
         }
     }
 
@@ -187,6 +195,21 @@ class Video {
     get videoReady () {
         if (this.provider) return this.provider.videoReady;
         return false;
+    }
+
+    /**
+     * Method implemented by all IO devices to allow external changes.
+     * The only change available externally is hiding the preview, used e.g. to
+     * prevent drawing the preview into project thumbnails.
+     * @param {object} - data passed to this IO device.
+     * @property {boolean} forceTransparentPreview - whether the preview should be forced transparent.
+     */
+    postData ({forceTransparentPreview}) {
+        this._forceTransparentPreview = forceTransparentPreview;
+        // Setting the ghost to the current value will pick up the forceTransparentPreview
+        // flag and override the current ghost. The complexity is to prevent blocks
+        // from overriding forceTransparentPreview
+        this.setPreviewGhost(this._ghost);
     }
 }
 


### PR DESCRIPTION
This is needed to allow the GUI to toggle the video preview using `postIOData('video', {forceTransparentPreview: true})` before taking a snapshot.

@rschamp I added a new flag and used it where the ghost value gets set to ensure that you cannot use the blocks to re-enable the preview before the thumbnail gets taken.