### PR TITLE
Clear the pen layer when runtime dispose happens.

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -627,6 +627,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name when the runtime dispose has been called.
+     * @const {string}
+     */
+    static get RUNTIME_DISPOSED () {
+        return 'RUNTIME_DISPOSED';
+    }
+
+    /**
      * Event name for reporting that a block was updated and needs to be rerendered.
      * @const {string}
      */
@@ -1547,6 +1555,7 @@ class Runtime extends EventEmitter {
         this.stopAll();
         this.targets.map(this.disposeTarget, this);
         this._monitorState = OrderedMap({});
+        this.emit(Runtime.RUNTIME_DISPOSED);
         // @todo clear out extensions? turboMode? etc.
 
         // *********** Cloud *******************

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -67,6 +67,7 @@ class Scratch3PenBlocks {
         this._onTargetMoved = this._onTargetMoved.bind(this);
 
         runtime.on('targetWasCreated', this._onTargetCreated);
+        runtime.on('RUNTIME_DISPOSED', this.clear.bind(this));
     }
 
     /**

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -239,3 +239,14 @@ test('setCompatibilityMode does not restart if it was not running', t => {
     t.equal(started, false);
     t.end();
 });
+
+test('Disposing the runtime emits an event', t => {
+    let disposed = false;
+    const rt = new Runtime();
+    rt.addListener('RUNTIME_DISPOSED', () => {
+        disposed = true;
+    });
+    rt.start();
+    t.equal(disposed, true);
+    t.end();
+});

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -246,7 +246,7 @@ test('Disposing the runtime emits an event', t => {
     rt.addListener('RUNTIME_DISPOSED', () => {
         disposed = true;
     });
-    rt.start();
+    rt.dispose();
     t.equal(disposed, true);
     t.end();
 });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-gui/issues/1850

### Proposed Changes

_Describe what this Pull Request does_

Add a RUNTIME_DISPOSED event that the pen extension listens for and clears the pen layer when it occurs. 

No attempt is made in this PR to unload the extension blocks or anything like that. 

Repro that now works:
1. Add pen extension
2. Move the cat around and stamp a bunch of times
3. "File -> New"
4. See that the pen layer is cleared.