### PR TITLE
Text to Speech use encodeURIComponent

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -472,7 +472,7 @@ class Scratch3Text2SpeechBlocks {
         let path = `${SERVER_HOST}/synth`;
         path += `?locale=${this.localeToPolly(this.getCurrentLanguage())}`;
         path += `&gender=${gender}`;
-        path += `&text=${encodeURI(words.substring(0, 128))}`;
+        path += `&text=${encodeURIComponent(words.substring(0, 128))}`;
 
         // Perform HTTP request to get audio file
         return new Promise(resolve => {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1620

### Proposed Changes

Use encodeURIComponent instead of encodeURI when sending text to the speech server.

### Reason for Changes

encodeURIComponent correctly encodes # and & as characters.

now you can speak #awesome!