### PR TITLE
Fix an issue where the targetId of a monitor could be reassigned

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -625,18 +625,22 @@ class Blocks {
             // Variable blocks may be sprite specific depending on the owner of the variable
             let isSpriteLocalVariable = false;
             if (block.opcode === 'data_variable') {
-                isSpriteLocalVariable = !optRuntime.getEditingTarget().isStage &&
-                    optRuntime.getEditingTarget().variables[block.fields.VARIABLE.id];
+                isSpriteLocalVariable = !(optRuntime.getTargetForStage().variables[block.fields.VARIABLE.id]);
             } else if (block.opcode === 'data_listcontents') {
-                isSpriteLocalVariable = !optRuntime.getEditingTarget().isStage &&
-                    optRuntime.getEditingTarget().variables[block.fields.LIST.id];
+                isSpriteLocalVariable = !(optRuntime.getTargetForStage().variables[block.fields.LIST.id]);
             }
-
 
             const isSpriteSpecific = isSpriteLocalVariable ||
                 (optRuntime.monitorBlockInfo.hasOwnProperty(block.opcode) &&
                 optRuntime.monitorBlockInfo[block.opcode].isSpriteSpecific);
-            block.targetId = isSpriteSpecific ? optRuntime.getEditingTarget().id : null;
+            if (isSpriteSpecific) {
+                // If creating a new sprite specific monitor, the only possible target is
+                // the current editing one b/c you cannot dynamically create monitors.
+                // Also, do not change the targetId if it has already been assigned
+                block.targetId = block.targetId || optRuntime.getEditingTarget().id;
+            } else {
+                block.targetId = null;
+            }
 
             if (wasMonitored && !block.isMonitored) {
                 optRuntime.requestHideMonitor(block.id);


### PR DESCRIPTION
This caused a local variable monitor to try running its thread on a different sprite, causing a new local variable to be created with the same monitor id.

### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-vm/issues/1623

### Proposed Changes

_Describe what this Pull Request does_

The change is twofold
1. Fix the way `isSpriteLocalVariable` check works, it does not depend on the editing target at the time.
3. Prevent reassigning `targetId` on blocks, to allow checkbox to be "checked" (via hide/show block) 

Consternation ensued about whether the hide/show should be emitting checkbox events to the runtime (it probably shouldn't be). 