### PR TITLE
Make duplicateVariable deep copy the array instead of keeping reference.

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -354,7 +354,11 @@ class Target extends EventEmitter {
                 originalVariable.type,
                 originalVariable.isCloud
             );
-            newVariable.value = originalVariable.value;
+            if (newVariable.type === Variable.LIST_TYPE) {
+                newVariable.value = originalVariable.value.slice(0);
+            } else {
+                newVariable.value = originalVariable.value;
+            }
             return newVariable;
         }
         return null;

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -323,6 +323,18 @@ test('duplicateVariable creates a new variable with a new ID by default', t => {
     t.end();
 });
 
+test('duplicateVariable creates new array reference for list variable.value', t => {
+    const target = new Target();
+    const arr = [1, 2, 3];
+    target.createVariable('a var ID', arr, Variable.LIST_TYPE);
+    const originalVariable = target.variables['a var ID'];
+    const newVariable = target.duplicateVariable('a var ID');
+    // Values are deeply equal but not the same object
+    t.deepEqual(originalVariable.value, newVariable.value);
+    t.notEqual(originalVariable.value, newVariable.value);
+    t.end();
+});
+
 test('duplicateVariable creates a new variable with a original ID if specified', t => {
     const target = new Target();
     target.createVariable('a var ID', 'foo', Variable.SCALAR_TYPE);

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -328,6 +328,7 @@ test('duplicateVariable creates new array reference for list variable.value', t 
     const arr = [1, 2, 3];
     target.createVariable('a var ID', 'arr', Variable.LIST_TYPE);
     const originalVariable = target.variables['a var ID'];
+    originalVariable.value = arr;
     const newVariable = target.duplicateVariable('a var ID');
     // Values are deeply equal but not the same object
     t.deepEqual(originalVariable.value, newVariable.value);

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -326,7 +326,7 @@ test('duplicateVariable creates a new variable with a new ID by default', t => {
 test('duplicateVariable creates new array reference for list variable.value', t => {
     const target = new Target();
     const arr = [1, 2, 3];
-    target.createVariable('a var ID', arr, Variable.LIST_TYPE);
+    target.createVariable('a var ID', 'arr', Variable.LIST_TYPE);
     const originalVariable = target.variables['a var ID'];
     const newVariable = target.duplicateVariable('a var ID');
     // Values are deeply equal but not the same object


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-vm/issues/1798

### Proposed Changes

_Describe what this Pull Request does_

Make duplicateVariable deep copy the array instead of keeping reference.

### Reason for Changes

_Explain why these changes should be made_

Previously it looked like clones were sharing private lists, but it was actually just a bug in the way the values were copied while duplicating

### Test Coverage

_Please show how you have added tests to cover your changes_


Added unit test