### PR TITLE
Request cloud variable update in top level setVariableValue API

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1410,6 +1410,11 @@ class VirtualMachine extends EventEmitter {
             const variable = target.lookupVariableById(variableId);
             if (variable) {
                 variable.value = value;
+
+                if (variable.isCloud) {
+                    this.runtime.ioDevices.cloud.requestUpdateVariable(variable.name, variable.value);
+                }
+
                 return true;
             }
         }

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -667,6 +667,36 @@ test('setVariableValue', t => {
     t.end();
 });
 
+test('setVariableValue requests update for cloud variable', t => {
+    const vm = new VirtualMachine();
+    const spr = new Sprite(null, vm.runtime);
+    const target = spr.createClone();
+    target.isStage = true;
+    target.createVariable('a-variable', 'a-name', Variable.SCALAR_TYPE, true /* isCloud */);
+
+    vm.runtime.targets = [target];
+
+    // Mock cloud io device requestUpdateVariable function
+    let requestUpdateVarWasCalled = false;
+    let varName;
+    let varValue;
+    vm.runtime.ioDevices.cloud.requestUpdateVariable = (name, value) => {
+        requestUpdateVarWasCalled = true;
+        varName = name;
+        varValue = value;
+    };
+
+    vm.setVariableValue(target.id, 'not-a-variable', 100);
+    t.equal(requestUpdateVarWasCalled, false);
+
+    vm.setVariableValue(target.id, 'a-variable', 100);
+    t.equal(requestUpdateVarWasCalled, true);
+    t.equal(varName, 'a-name');
+    t.equal(varValue, 100);
+
+    t.end();
+});
+
 test('getVariableValue', t => {
     const vm = new VirtualMachine();
     const spr = new Sprite(null, vm.runtime);


### PR DESCRIPTION
### Resolves

Resolves #1728, but does not fully resolve slider monitors updating cloud variables until LLK/scratch-gui#3652 gets merged.

### Proposed Changes

Make a cloud device requestVariableUpdate when setting a variable through the vm's top level setVariableValue API. Add unit test for new functionality.

### Reason for Changes

Things that use the VM's top level setVariableValue API (like slider monitors controlled by the GUI) were previously not making cloud variable updates, they should.

### Test Coverage

Added a unit test for new functionality.
