### PR TITLE
Fix sprite upload from vector image uploading at the wrong size

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -211,7 +211,7 @@ const loadCostumeFromAsset = function (costume, runtime, optVersion) {
             typeof costume.rotationCenterY === 'number' && !isNaN(costume.rotationCenterY)) {
         rotationCenter = [costume.rotationCenterX, costume.rotationCenterY];
     }
-    if (costume.asset.assetType === AssetType.ImageVector) {
+    if (costume.asset.assetType.runtimeFormat === AssetType.ImageVector.runtimeFormat) {
         return loadVector_(costume, runtime, rotationCenter, optVersion);
     }
     return loadBitmap_(costume, runtime, rotationCenter, optVersion);


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#3608.

### Proposed Changes

Fix a bug in load-costume where sprites from vector file upload were not getting loaded correctly because of a failed `===` comparison between two object references. Compare asset type `runtimeFormat` (which is a string) instead of AssetType object references because costume assets can get flattened (e.g. while uploading a sprite from an image file).

This was a regression introduced by #1691 and the corresponding LLK/scratch-gui#3491 and not caught by #1719.

### Test Coverage

Manually tested with svg images.