### PR TITLE
Makey Makey extension fixes

### DIFF
--- a/src/extensions/scratch3_makeymakey/index.js
+++ b/src/extensions/scratch3_makeymakey/index.js
@@ -158,7 +158,7 @@ class Scratch3MakeyMakeyBlocks {
             `${KEY_ID_UP} ${KEY_ID_DOWN}`,
             `${KEY_ID_DOWN} ${KEY_ID_UP}`,
             `${KEY_ID_UP} ${KEY_ID_RIGHT} ${KEY_ID_DOWN} ${KEY_ID_LEFT}`,
-            `${KEY_ID_SPACE} ${KEY_ID_SPACE} ${KEY_ID_SPACE}`,
+            `${KEY_ID_UP} ${KEY_ID_LEFT} ${KEY_ID_DOWN} ${KEY_ID_RIGHT}`,
             `${KEY_ID_UP} ${KEY_ID_UP} ${KEY_ID_DOWN} ${KEY_ID_DOWN} ` +
                 `${KEY_ID_LEFT} ${KEY_ID_RIGHT} ${KEY_ID_LEFT} ${KEY_ID_RIGHT}`
         ];

--- a/src/extensions/scratch3_makeymakey/index.js
+++ b/src/extensions/scratch3_makeymakey/index.js
@@ -86,6 +86,9 @@ class Scratch3MakeyMakeyBlocks {
         this.keyPressed = this.keyPressed.bind(this);
         this.runtime.on('KEY_PRESSED', this.keyPressed);
 
+        this._clearkeyPressBuffer = this._clearkeyPressBuffer.bind(this);
+        this.runtime.on('PROJECT_STOP_ALL', this._clearkeyPressBuffer);
+
         /*
          * An object containing a set of sequence objects.
          * These are the key sequences currently being detected by the "when
@@ -335,6 +338,13 @@ class Scratch3MakeyMakeyBlocks {
                 }, SEQUENCE_HAT_TIMEOUT);
             }
         }
+    }
+
+    /**
+     * Clear the key press buffer.
+     */
+    _clearkeyPressBuffer () {
+        this.keyPressBuffer = [];
     }
 
     /*


### PR DESCRIPTION
Just a few small fixes to the Makey Makey extension:

- Clear the key press buffer when the stop button is pressed. This prevents some unintentional triggering of sequence hats.
- Remove the "space space space" sequence from the menu. This sequence led to some confusion because after triggering it, pressing space a 4th time would trigger it again (completing a sequence does not clear the key buffer- which it can't because then overlapping sequences would prevent each other from  completing).
- Add an "up left down right" sequence (so we have both a counter-clockwise and clockwise version)