### PR TITLE
depend on scratch-sb1-converter and convert sb1 files to sb2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12204,6 +12204,15 @@
         "base64-loader": "1.0.0"
       }
     },
+    "scratch-sb1-converter": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/scratch-sb1-converter/-/scratch-sb1-converter-0.2.1.tgz",
+      "integrity": "sha512-Elk3/kVwPEoOGde/4/zvtoSj1tWV/S08qHY+DqhH73JLRjKquw8gvG33BJ5RFnQ/mxgquUlLApr+NjUzNg+TdA==",
+      "requires": {
+        "minilog": "3.1.0",
+        "text-encoding": "^0.6.4"
+      }
+    },
     "scratch-storage": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "minilog": "3.1.0",
     "nets": "3.2.0",
     "scratch-parser": "4.3.3",
-    "scratch-sb1-converter": "github:mzgoddard/scratch-sb1-converter#build-to-sb2-",
+    "scratch-sb1-converter": "0.2.1",
     "scratch-translate-extension-languages": "0.0.20181205140428",
     "socket.io-client": "2.0.4",
     "text-encoding": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "minilog": "3.1.0",
     "nets": "3.2.0",
     "scratch-parser": "4.3.3",
+    "scratch-sb1-converter": "github:mzgoddard/scratch-sb1-converter#build-to-sb2-",
     "scratch-translate-extension-languages": "0.0.20181205140428",
     "socket.io-client": "2.0.4",
     "text-encoding": "0.6.4",

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -8,7 +8,7 @@ const ExtensionManager = require('./extension-support/extension-manager');
 const log = require('./util/log');
 const MathUtil = require('./util/math-util');
 const Runtime = require('./engine/runtime');
-const {SB1File} = require('scratch-sb1-converter');
+const {SB1File, ValidationError} = require('scratch-sb1-converter');
 const sb2 = require('./serialization/sb2');
 const sb3 = require('./serialization/sb3');
 const StringUtil = require('./util/string-util');
@@ -294,10 +294,13 @@ class VirtualMachine extends EventEmitter {
                 const sb1 = new SB1File(input);
                 const json = sb1.json;
                 json.projectVersion = 2;
-                console.log(json);
                 return resolve([json, sb1.zip]);
             } catch (e) {
-                console.error(e);
+                if (e instanceof ValidationError) {
+                    // The input does not validate as a Scratch 1 file.
+                } else {
+                    throw e;
+                }
             }
 
             // The second argument of false below indicates to the validator that the
@@ -442,7 +445,7 @@ class VirtualMachine extends EventEmitter {
 
         const runtime = this.runtime;
         const deserializePromise = function () {
-            let projectVersion = projectJSON.projectVersion;
+            const projectVersion = projectJSON.projectVersion;
             if (projectVersion === 2) {
                 return sb2.deserialize(projectJSON, runtime, false, zip);
             }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -310,12 +310,12 @@ class VirtualMachine extends EventEmitter {
                         // The project appears to be a Scratch 1 file but it
                         // could not be successfully translated into a Scratch 2
                         // project.
-                        throw sb1Error;
+                        return Promise.reject(sb1Error);
                     }
                 }
-                // Through original error since the input does not appear to be
+                // Throw original error since the input does not appear to be
                 // an SB1File.
-                throw error;
+                return Promise.reject(error);
             });
 
         return validationPromise

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -302,7 +302,7 @@ class VirtualMachine extends EventEmitter {
                     const sb1 = new SB1File(input);
                     const json = sb1.json;
                     json.projectVersion = 2;
-                    return [json, sb1.zip];
+                    return Promise.resolve([json, sb1.zip]);
                 } catch (sb1Error) {
                     if (sb1Error instanceof ValidationError) {
                         // The input does not validate as a Scratch 1 file.

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -8,6 +8,7 @@ const ExtensionManager = require('./extension-support/extension-manager');
 const log = require('./util/log');
 const MathUtil = require('./util/math-util');
 const Runtime = require('./engine/runtime');
+const {SB1File} = require('scratch-sb1-converter');
 const sb2 = require('./serialization/sb2');
 const sb3 = require('./serialization/sb3');
 const StringUtil = require('./util/string-util');
@@ -289,6 +290,16 @@ class VirtualMachine extends EventEmitter {
         }
 
         const validationPromise = new Promise((resolve, reject) => {
+            try {
+                const sb1 = new SB1File(input);
+                const json = sb1.json;
+                json.projectVersion = 2;
+                console.log(json);
+                return resolve([json, sb1.zip]);
+            } catch (e) {
+                console.error(e);
+            }
+
             // The second argument of false below indicates to the validator that the
             // input should be parsed/validated as an entire project (and not a single sprite)
             validate(input, false, (error, res) => {
@@ -431,7 +442,7 @@ class VirtualMachine extends EventEmitter {
 
         const runtime = this.runtime;
         const deserializePromise = function () {
-            const projectVersion = projectJSON.projectVersion;
+            let projectVersion = projectJSON.projectVersion;
             if (projectVersion === 2) {
                 return sb2.deserialize(projectJSON, runtime, false, zip);
             }


### PR DESCRIPTION
### Resolves

- Initial Scratch 1 file (`.sb` extension) support

### Proposed Changes

This depends on https://github.com/llk/scratch-sb1-converter/pull/12

Depend on scratch-sb1-converter. Use SB1File to check if the project being loaded is an `.sb` file. If so convert it to SB2 json and a (fake) zip.

### Reason for Changes

Supporting Scratch 1 files!
