### PR TITLE
Always pop the stack when the promised value is from the last op

### DIFF
--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -112,8 +112,8 @@ const handlePromise = (primitiveReportedValue, sequencer, thread, blockCached, l
     // Promise handlers
     primitiveReportedValue.then(resolvedValue => {
         handleReport(resolvedValue, sequencer, thread, blockCached, lastOperation);
-        // If its a command block.
-        if (lastOperation && typeof resolvedValue === 'undefined') {
+        // If its a command block or a top level reporter in a stackClick.
+        if (lastOperation) {
             let stackFrame;
             let nextBlockId;
             do {

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -112,7 +112,7 @@ const handlePromise = (primitiveReportedValue, sequencer, thread, blockCached, l
     // Promise handlers
     primitiveReportedValue.then(resolvedValue => {
         handleReport(resolvedValue, sequencer, thread, blockCached, lastOperation);
-        // If its a command block or a top level reporter in a stackClick.
+        // If it's a command block or a top level reporter in a stackClick.
         if (lastOperation) {
             let stackFrame;
             let nextBlockId;


### PR DESCRIPTION
### Resolves

- Part of https://github.com/LLK/scratch-gui/issues/2861

### Proposed Changes

Pop the stack.

### Reason for Changes

When the resolving promise is the last operation in series of a reporter block that has been stack clicked, handle it like it was the last operation for a command block. If we don't pop the stack, the block will try to store the reported value to a parent argument values. But that parent does not (and should not) exist. As such it will throw an error and the vm will run the same block again next frame.
