### PR TITLE
Prevent text to speech kitten voice from speaking names of punctuation

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -465,7 +465,7 @@ class Scratch3Text2SpeechBlocks {
 
         // @todo localize this?
         if (state.voiceId === KITTEN_ID) {
-            words = words.replace(/\w+/g, 'meow');
+            words = words.replace(/\S+/g, 'meow');
         }
 
         // Build up URL


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/3425

### Proposed Changes

Previously, the kitten voice used a regex with `\w+` to replace each stretch of "word" characters with a "meow". These word characters do not include punctuation, or non-english language characters. As a result, there were several ways to get the kitten voice to say things other than meow, such as "exclamation point". These included inserting punctuation marks at the beginning or in the middle of words.  

This change uses `\S+`to replace each stretch of non-space characters with a "meow". The kitten should now only speak meows. 

Known issues:
- Japanese does not use space characters to separate words, so you will generally get a single meow for a Japanese phrase, but I think that is an acceptable compromise.
- The kitten voice will no longer use sentence punctuation for speech prosody (e.g. prior to this change it could speak a question like "meow meow?").
- The kitten voice uses the extension's language setting, so the meow sounds different in each language (and not very good in some of them).  

### Testing

Try e.g. the examples in file in the issue linked above
