### PR TITLE
Limit join result length to 10240

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -91,7 +91,9 @@ class Scratch3OperatorsBlocks {
     }
 
     join (args) {
-        return Cast.toString(args.STRING1) + Cast.toString(args.STRING2);
+        // Limit result to 10240 characters: https://github.com/LLK/scratch-vm/issues/922
+        return (Cast.toString(args.STRING1) + Cast.toString(args.STRING2))
+            .slice(0, 10240);
     }
 
     letterOf (args) {

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -122,6 +122,18 @@ test('random - reverse', t => {
 test('join', t => {
     t.strictEqual(blocks.join({STRING1: 'foo', STRING2: 'bar'}), 'foobar');
     t.strictEqual(blocks.join({STRING1: '1', STRING2: '2'}), '12');
+    t.strictEqual(blocks.join({STRING1: '1', STRING2: '2'}), '12');
+    t.end();
+});
+
+test('join result length does not exceed 10240', t => {
+    const sixThousandCharacterString = Array(6000)
+        .fill('a')
+        .join('');
+    t.strictEqual(blocks.join({
+        STRING1: sixThousandCharacterString,
+        STRING2: sixThousandCharacterString
+    }).length, 10240);
     t.end();
 });
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-vm/issues/922

### Proposed Changes

_Describe what this Pull Request does_

Limit the result of join the same way scratch-flash did.

### Reason for Changes

_Explain why these changes should be made_

https://github.com/LLK/scratch-vm/issues/922

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test for it.