### PR TITLE
For order of Makey Makey extension's key pressed menu

### DIFF
--- a/src/extensions/scratch3_makeymakey/index.js
+++ b/src/extensions/scratch3_makeymakey/index.js
@@ -210,19 +210,11 @@ class Scratch3MakeyMakeyBlocks {
                     },
                     {
                         text: formatMessage({
-                            id: 'makeymakey.leftArrow',
-                            default: 'left arrow',
-                            description: 'The left arrow key on a computer keyboard.'
+                            id: 'makeymakey.upArrow',
+                            default: 'up arrow',
+                            description: 'The up arrow key on a computer keyboard.'
                         }),
-                        value: KEY_ID_LEFT
-                    },
-                    {
-                        text: formatMessage({
-                            id: 'makeymakey.rightArrow',
-                            default: 'right arrow',
-                            description: 'The right arrow key on a computer keyboard.'
-                        }),
-                        value: KEY_ID_RIGHT
+                        value: KEY_ID_UP
                     },
                     {
                         text: formatMessage({
@@ -234,11 +226,19 @@ class Scratch3MakeyMakeyBlocks {
                     },
                     {
                         text: formatMessage({
-                            id: 'makeymakey.upArrow',
-                            default: 'up arrow',
-                            description: 'The up arrow key on a computer keyboard.'
+                            id: 'makeymakey.rightArrow',
+                            default: 'right arrow',
+                            description: 'The right arrow key on a computer keyboard.'
                         }),
-                        value: KEY_ID_UP
+                        value: KEY_ID_RIGHT
+                    },
+                    {
+                        text: formatMessage({
+                            id: 'makeymakey.leftArrow',
+                            default: 'left arrow',
+                            description: 'The left arrow key on a computer keyboard.'
+                        }),
+                        value: KEY_ID_LEFT
                     },
                     {text: 'w', value: 'w'},
                     {text: 'a', value: 'a'},


### PR DESCRIPTION
The Makey Makey extension's menu listing the keys had the arrow keys in a different order from the core "when key pressed" block. This change fixes the extension so that the arrow keys are in the same order in both:

<img width="275" alt="screen shot 2018-12-17 at 6 26 43 pm" src="https://user-images.githubusercontent.com/567844/50122268-a6fca280-0229-11e9-941a-bbf0eaf805af.png">

<img width="255" alt="screen shot 2018-12-17 at 6 27 04 pm" src="https://user-images.githubusercontent.com/567844/50122276-ab28c000-0229-11e9-99a0-e40f39bee291.png">

