### PR TITLE
Fix issue with uploading default vector image 

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -219,6 +219,7 @@ const loadCostumeFromAsset = function (costume, runtime, optVersion) {
                 // Use default asset if original fails to load
                 costume.assetId = runtime.storage.defaultAssetId.ImageVector;
                 costume.asset = runtime.storage.get(costume.assetId);
+                costume.md5 = `${costume.assetId}.${AssetType.ImageVector.runtimeFormat}`;
                 return loadVector_(costume, runtime);
             });
     }


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-www#2534

### Proposed Changes

Fix issue introduced by #1840 where replacing a broken image with the default vector image from storage was not updating the costume's md5. This causes an error for subsequent project loads when trying to load a project with this fix that was saved on the server. 

### Test Coverage

Tested #2534

cc/ @benjiwheeler, @ktbee 