### PR TITLE
Always use English for kitten

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -457,6 +457,7 @@ class Scratch3Text2SpeechBlocks {
     speakAndWait (args, util) {
         // Cast input to string
         let words = Cast.toString(args.WORDS);
+        let locale = this.localeToPolly(this.getCurrentLanguage());
 
         const state = this._getState(util.target);
 
@@ -466,11 +467,12 @@ class Scratch3Text2SpeechBlocks {
         // @todo localize this?
         if (state.voiceId === KITTEN_ID) {
             words = words.replace(/\S+/g, 'meow');
+            locale = 'en-US';
         }
 
         // Build up URL
         let path = `${SERVER_HOST}/synth`;
-        path += `?locale=${this.localeToPolly(this.getCurrentLanguage())}`;
+        path += `?locale=${locale}`;
         path += `&gender=${gender}`;
         path += `&text=${encodeURIComponent(words.substring(0, 128))}`;
 

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -464,7 +464,6 @@ class Scratch3Text2SpeechBlocks {
         const gender = this.VOICE_INFO[state.voiceId].gender;
         const playbackRate = this.VOICE_INFO[state.voiceId].playbackRate;
 
-        // @todo localize this?
         if (state.voiceId === KITTEN_ID) {
             words = words.replace(/\S+/g, 'meow');
             locale = 'en-US';


### PR DESCRIPTION
### Resolves
Resolves #1858 

### Proposed Changes
Always uses English for kitten (A pattern)

### Reason for Changes
`meow` sounds strange in some languages, and translating it is impossible with formatMessage.

