### PR TITLE
Fix dynamic menus for string arrays

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -316,13 +316,17 @@ class ExtensionManager {
         const menuItems = menuFunc.call(extensionObject, editingTargetID).map(
             item => {
                 item = maybeFormatMessage(item, extensionMessageContext);
-                if (typeof item === 'object') {
+                switch (typeof item) {
+                case 'object':
                     return [
                         maybeFormatMessage(item.text, extensionMessageContext),
                         item.value
                     ];
+                case 'string':
+                    return [item, item];
+                default:
+                    return item;
                 }
-                return item;
             });
 
         if (!menuItems || menuItems.length < 1) {


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-gui/issues/2891

### Proposed Changes

Fix the display of dynamic menus that return arrays of strings.

That is, with a function:
```
_initMenu() { return ['THIS', 'IS', 'A', 'TEST']; }
```
and a menu:
```
menus: { menu: '_initMenu' }
```
this PR makes this:
![test_fail](https://user-images.githubusercontent.com/20625381/50443196-8b8a4980-0945-11e9-8b2f-af59c269507e.png)

look like this:
![test_suceed](https://user-images.githubusercontent.com/20625381/50443206-9644de80-0945-11e9-833f-bea957ef9cc7.png)

