### PR TITLE
Reject errors from loadCostume instead of logging

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -285,10 +285,7 @@ const loadCostume = function (md5ext, costume, runtime, optVersion) {
             costume.textLayerAsset = assetArray[1];
         }
         return loadCostumeFromAsset(costume, runtime, optVersion);
-    })
-        .catch(e => {
-            log.error(e);
-        });
+    });
 };
 
 module.exports = {


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#4179

### Proposed Changes

Let errors from `loadCostume` bubble up so that we do not attempt to call installTargets on an invalid target (e.g. one that has no costumes).

### Reason for Changes

Because we were logging errors in loadCostume, we were allowing installing a target without any costumes, which was ultimately allowing saving a project in a broken state (one that does not pass validation during project load).

### Test Coverage

Tested the use case in LLK/scratch-gui#4179 manually. `installTarget` does not get called twice when we go offline and try to load a sprite from the sprite library that has not finished loading its assets from storage.