### PR TITLE
Change legacy pen color block's behavior

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -675,7 +675,6 @@ class Scratch3PenBlocks {
         const hueValue = Cast.toNumber(args.HUE);
         const colorValue = hueValue / 2;
         this._setOrChangeColorParam(ColorParam.COLOR, colorValue, penState, false);
-        penState = this._getPenState(util.target);
         this._setOrChangeColorParam(ColorParam.TRANSPARENCY, 0, penState, false);
         this._legacyUpdatePenColor(penState);
     }

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -671,7 +671,7 @@ class Scratch3PenBlocks {
      * @param {object} util - utility object provided by the runtime.
      */
     setPenHueToNumber (args, util) {
-        let penState = this._getPenState(util.target);
+        const penState = this._getPenState(util.target);
         const hueValue = Cast.toNumber(args.HUE);
         const colorValue = hueValue / 2;
         this._setOrChangeColorParam(ColorParam.COLOR, colorValue, penState, false);

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -671,11 +671,12 @@ class Scratch3PenBlocks {
      * @param {object} util - utility object provided by the runtime.
      */
     setPenHueToNumber (args, util) {
-        const penState = this._getPenState(util.target);
+        let penState = this._getPenState(util.target);
         const hueValue = Cast.toNumber(args.HUE);
         const colorValue = hueValue / 2;
         this._setOrChangeColorParam(ColorParam.COLOR, colorValue, penState, false);
-
+        penState = this._getPenState(util.target);
+        this._setOrChangeColorParam(ColorParam.TRANSPARENCY, 0, penState, false);
         this._legacyUpdatePenColor(penState);
     }
 


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-render#382

### Proposed Changes
The old `set pen color to ()` block makes the transparency to 0.

### Reason for Changes
Compatibility issues.

### Test Coverage
Project 272543304 should make two different circles