### PR TITLE
Remove Unicode Backspace from XML to prevent broken SVG

### DIFF
--- a/src/util/xml-escape.js
+++ b/src/util/xml-escape.js
@@ -7,13 +7,15 @@
  * @return {string} XML-escaped string, for use within an XML tag.
  */
 const xmlEscape = function (unsafe) {
-    return unsafe.replace(/[<>&'"]/g, c => {
+    // eslint-disable-next-line no-control-regex
+    return unsafe.replace(/[<>&'"\u0008]/g, c => {
         switch (c) {
         case '<': return '&lt;';
         case '>': return '&gt;';
         case '&': return '&amp;';
         case '\'': return '&apos;';
         case '"': return '&quot;';
+        case '\u0008': return '';
         }
     });
 };

--- a/test/unit/util_xml.js
+++ b/test/unit/util_xml.js
@@ -7,3 +7,10 @@ test('escape', t => {
     t.strictEqual(xml(input), output);
     t.end();
 });
+
+test('remove unicode backspace', t => {
+    const input = '\u0008';
+    const output = '';
+    t.strictEqual(xml(input), output);
+    t.end();
+});


### PR DESCRIPTION
### Resolves

Fix of #1873 Unicode 'BACKSPACE' stop to read project

### Proposed Changes

Remove the problematic character at the process to make XML source that build SVG graphics.

### Reason for Changes

The character '\0008' breaks SVG so that it should not be used but it will input in any text field accidentally by users. V2.0 accept the char and no probrem to read and convert to V3.0 which project including it. Removing the char at the last process to make SVG will fix the both problems.  The escape XML will good place to do this. 

### Test Coverage

New unit-test was added for xmlEscape().

