### PR TITLE
Do not deep clone before serializing.

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -14,7 +14,6 @@ const StageLayering = require('../engine/stage-layering');
 const log = require('../util/log');
 const uid = require('../util/uid');
 const MathUtil = require('../util/math-util');
-const StringUtil = require('../util/string-util');
 
 const {loadCostume} = require('../import/load-costume.js');
 const {loadSound} = require('../import/load-sound.js');
@@ -521,7 +520,7 @@ const serialize = function (runtime, targetId) {
 
     const layerOrdering = getSimplifiedLayerOrdering(originalTargetsToSerialize);
 
-    const flattenedOriginalTargets = JSON.parse(StringUtil.stringify(originalTargetsToSerialize));
+    const flattenedOriginalTargets = originalTargetsToSerialize.map(t => t.toJSON());
 
     // If the renderer is attached, and we're serializing a whole project (not a sprite)
     // add a temporary layerOrder property to each target.


### PR DESCRIPTION
This was ok when we did not attach assets, but it is not cool now. With large assets, this made saving extremely slow.

After consulting @kchadha and looking through the history, I believe that the deep cloning was there as a relic of past save/load work, rather than a defensive measure, so I feel confident about making this change. I looked through all the block/asset serializing code and didn't see anywhere that modifications were being made to the data structure.

Fixes https://github.com/LLK/scratch-gui/issues/4256