### PR TITLE
Allow projects with unknown monitors to load.

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -256,6 +256,13 @@ const globalBroadcastMsgStateGenerator = (function () {
  */
 
 const parseMonitorObject = (object, runtime, targets, extensions) => {
+    // If we can't find the block in the spec map, ignore it.
+    // This happens for things like Lego Wedo 1.0 monitors.
+    const mapped = specMap[object.cmd];
+    if (!mapped) {
+        log.warn(`Could not find monitor block with opcode: ${object.cmd}`);
+        return;
+    }
     // In scratch 2.0, there are two monitors that now correspond to extension
     // blocks (tempo and video motion/direction). In the case of the
     // video motion/direction block, this reporter is not monitorable in Scratch 3.0.


### PR DESCRIPTION
### Resolves

Fixes some projects that don't load with the following error:
 TypeError: Cannot read property 'opcode' of undefined

They had 1.0 Lego Wedo monitors in them.
### Proposed Changes

When parsing monitors, ignore opcodes we don't understand.
### Reason for Changes

These monitors weren't visible in 2.0 anyway and now these projects actually load in 3.0.

