### PR TITLE
Add legacy drum block to specmap

### DIFF
--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -503,6 +503,21 @@ const specMap = {
             }
         ]
     },
+    'drum:duration:elapsed:from:': {
+        opcode: 'music_midiPlayDrumForBeats',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'DRUM'
+            },
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'BEATS'
+            }
+        ]
+    },
     'rest:elapsed:from:': {
         opcode: 'music_restForBeats',
         argMap: [


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1424

### Proposed Changes

Add the specmap entry to import the legacy midi drum block.

### Reason for Changes

I inadvertently dropped this change when I remade the PR from @towerofnix - sorry about that!

### Test projects

Drum tester: 248475643
Canyon.mid: 115797375
