### PR TITLE
Add blocks to GDX-FOR extension

### DIFF
--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -367,6 +367,20 @@ class Scratch3GdxForBlocks {
         ];
     }
 
+    get FACE_MENU () {
+        return [
+            {
+                text: 'up',
+                value: 'up'
+            },
+            {
+                text: 'down',
+                value: 'down'
+            }
+        ];
+    }
+
+
     get COMPARE_MENU () {
         return [
             {
@@ -524,12 +538,29 @@ class Scratch3GdxForBlocks {
                         description: 'gets force'
                     }),
                     blockType: BlockType.REPORTER
+                },
+                {
+                    opcode: 'isFacing',
+                    text: formatMessage({
+                        id: 'gdxfor.isFacing',
+                        default: 'facing [FACING]?',
+                        description: 'is the device facing up or down?'
+                    }),
+                    blockType: BlockType.BOOLEAN,
+                    arguments: {
+                        FACING: {
+                            type: ArgumentType.STRING,
+                            menu: 'faceOptions',
+                            defaultValue: 'up'
+                        }
+                    }
                 }
             ],
             menus: {
                 directionOptions: this.DIRECTIONS_MENU,
                 compareOptions: this.COMPARE_MENU,
-                tiltOptions: this.TILT_MENU
+                tiltOptions: this.TILT_MENU,
+                faceOptions: this.FACE_MENU
             }
         };
     }
@@ -622,6 +653,16 @@ class Scratch3GdxForBlocks {
             return this._peripheral.getTiltY();
         default:
             log.warn(`Unknown direction in getTilt: ${args.TILT}`);
+        }
+    }
+    isFacing (args) {
+        switch (args.FACING) {
+        case 'up':
+            return this._peripheral.getAccelerationZ() > 9;
+        case 'down':
+            return this._peripheral.getAccelerationZ() < -9;
+        default:
+            log.warn(`Unknown direction in isFacing: ${args.FACING}`);
         }
     }
     getForce () {

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -491,7 +491,7 @@ class Scratch3GdxForBlocks {
                         default: 'when jumped',
                         description: 'when the device has jumped'
                     }),
-                    blockType: BlockType.HAT,
+                    blockType: BlockType.HAT
                 },
                 {
                     opcode: 'getAcceleration',
@@ -573,7 +573,8 @@ class Scratch3GdxForBlocks {
                         default: 'free falling?',
                         description: 'is the device in freefall?'
                     }),
-                    blockType: BlockType.BOOLEAN,
+                    blockType: BlockType.BOOLEAN
+
                 }
             ],
             menus: {

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -617,12 +617,7 @@ class Scratch3GdxForBlocks {
         }
     }
     whenJumped () {
-        const currentVal = this.magnitude(
-            this._peripheral.getAccelerationX(),
-            this._peripheral.getAccelerationY(),
-            this._peripheral.getAccelerationZ()
-        );
-        return currentVal < .5;
+        return this.isFreeFalling;
     }
     whenSpinSpeedCompare (args) {
         const currentVal = this.magnitude(

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -617,7 +617,7 @@ class Scratch3GdxForBlocks {
         }
     }
     whenJumped () {
-        return this.isFreeFalling;
+        return this.isFreeFalling();
     }
     whenSpinSpeedCompare (args) {
         const currentVal = this.magnitude(

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -596,11 +596,14 @@ class Scratch3GdxForBlocks {
     }
 
     whenAccelerationCompare (args) {
-        const currentVal = this.magnitude(
+        let currentVal = this.magnitude(
             this._peripheral.getAccelerationX(),
             this._peripheral.getAccelerationY(),
             this._peripheral.getAccelerationZ()
         );
+
+        // Remove acceleration due to gravity
+        currentVal = currentVal - 9.8;
 
         switch (args.COMPARE) {
         case ComparisonOptions.LESS_THAN:

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -145,7 +145,9 @@ class GdxFor {
             // will be fixed in a future @vernier/godirect release.
             sensor.on('value-changed', changedSensor => {
                 if (changedSensor.values.length > 1000) {
+                    const val = changedSensor.value;
                     changedSensor.clear();
+                    changedSensor.setValue(val);
                 }
             });
         });
@@ -483,6 +485,15 @@ class Scratch3GdxForBlocks {
                     }
                 },
                 {
+                    opcode: 'whenJumped',
+                    text: formatMessage({
+                        id: 'gdxfor.whenJumped',
+                        default: 'when jumped',
+                        description: 'when the device has jumped'
+                    }),
+                    blockType: BlockType.HAT,
+                },
+                {
                     opcode: 'getAcceleration',
                     text: formatMessage({
                         id: 'gdxfor.getAcceleration',
@@ -554,6 +565,15 @@ class Scratch3GdxForBlocks {
                             defaultValue: 'up'
                         }
                     }
+                },
+                {
+                    opcode: 'isFreeFalling',
+                    text: formatMessage({
+                        id: 'gdxfor.isFreeFalling',
+                        default: 'free falling?',
+                        description: 'is the device in freefall?'
+                    }),
+                    blockType: BlockType.BOOLEAN,
                 }
             ],
             menus: {
@@ -575,7 +595,6 @@ class Scratch3GdxForBlocks {
         return Math.sqrt((x * x) + (y * y) + (z * z));
     }
 
-
     whenAccelerationCompare (args) {
         const currentVal = this.magnitude(
             this._peripheral.getAccelerationX(),
@@ -592,6 +611,14 @@ class Scratch3GdxForBlocks {
             log.warn(`Unknown comparison operator in whenAccelerationCompare: ${args.COMPARE}`);
             return false;
         }
+    }
+    whenJumped () {
+        const currentVal = this.magnitude(
+            this._peripheral.getAccelerationX(),
+            this._peripheral.getAccelerationY(),
+            this._peripheral.getAccelerationZ()
+        );
+        return currentVal < .5;
     }
     whenSpinSpeedCompare (args) {
         const currentVal = this.magnitude(
@@ -655,6 +682,9 @@ class Scratch3GdxForBlocks {
             log.warn(`Unknown direction in getTilt: ${args.TILT}`);
         }
     }
+    getForce () {
+        return this._peripheral.getForce();
+    }
     isFacing (args) {
         switch (args.FACING) {
         case 'up':
@@ -665,8 +695,14 @@ class Scratch3GdxForBlocks {
             log.warn(`Unknown direction in isFacing: ${args.FACING}`);
         }
     }
-    getForce () {
-        return this._peripheral.getForce();
+    isFreeFalling () {
+        const currentVal = this.magnitude(
+            this._peripheral.getAccelerationX(),
+            this._peripheral.getAccelerationY(),
+            this._peripheral.getAccelerationZ()
+        );
+
+        return currentVal < .5;
     }
 }
 


### PR DESCRIPTION
### Proposed Changes

This PR adds three more blocks to the extension and filters acceleration from gravity on the "When acceleration" hat.

### How to test

You can play with the extension here: https://vernierst.github.io/scratch-gui/goforce/

Make sure you have the most recent Scratch-Link (1.1.28) and a vernier GDX-FOR device. To connect to the device, add the extension (it will have a "microbit" image) and click the power button the GDX-FOR device.