### PR TITLE
Populate executable targets when runtime.targets is populated 

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -165,8 +165,7 @@ class Scratch3ControlBlocks {
         // Create clone
         const newClone = cloneTarget.makeClone();
         if (newClone) {
-            this.runtime.targets.push(newClone);
-            this.runtime.addExecutable(newClone);
+            this.runtime.addTarget(newClone);
 
             // Place behind the original target.
             newClone.goBehindOther(cloneTarget);

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -166,6 +166,10 @@ class Scratch3ControlBlocks {
         const newClone = cloneTarget.makeClone();
         if (newClone) {
             this.runtime.targets.push(newClone);
+            this.runtime.addExecutable(newClone);
+
+            // Place behind the original target.
+            newClone.goBehindOther(cloneTarget);
         }
     }
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1560,11 +1560,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Add a target to the execution order.
-     * @param {Target} executableTarget target to add
+     * Add a target to the runtime. This tracks the sprite pane
+     * ordering of the target. The target still needs to be put
+     * into the correct execution order after calling this function.
+     * @param {Target} target target to add
      */
-    addExecutable (executableTarget) {
-        this.executableTargets.push(executableTarget);
+    addTarget (target) {
+        this.targets.push(target);
+        this.executableTargets.push(target);
     }
 
     /**

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -69,10 +69,6 @@ class Target extends EventEmitter {
          * @type {Object.<string, *>}
          */
         this._edgeActivatedHatValues = {};
-
-        if (this.runtime) {
-            this.runtime.addExecutable(this);
-        }
     }
 
     /**

--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -781,14 +781,17 @@ const reorderParsedTargets = function (targets) {
     // Reorder parsed targets based on the temporary targetPaneOrder property
     // and then delete it.
 
-    targets.sort((a, b) => a.targetPaneOrder - b.targetPaneOrder);
+    const reordered = targets.map((t, index) => {
+        t.layerOrder = index;
+        return t;
+    }).sort((a, b) => a.targetPaneOrder - b.targetPaneOrder);
 
     // Delete the temporary target pane ordering since we shouldn't need it anymore.
-    targets.forEach(t => {
+    reordered.forEach(t => {
         delete t.targetPaneOrder;
     });
 
-    return targets;
+    return reordered;
 };
 
 

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -1157,12 +1157,18 @@ const deserialize = function (json, runtime, zip, isSingleSprite) {
             parseScratchObject(target, runtime, extensions, zip))
     )
         .then(targets => targets // Re-sort targets back into original sprite-pane ordering
+            .map((t, i) => {
+                // Add layer order property to deserialized targets.
+                // This property is used to initialize executable targets in
+                // the correct order and is deleted in VM's installTargets function
+                t.layerOrder = i;
+                return t;
+            })
             .sort((a, b) => a.targetPaneOrder - b.targetPaneOrder)
             .map(t => {
                 // Delete the temporary properties used for
                 // sprite pane ordering and stage layer ordering
                 delete t.targetPaneOrder;
-                delete t.layerOrder;
                 return t;
             }))
         .then(targets => {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1021,8 +1021,6 @@ class RenderedTarget extends Target {
         newClone._edgeActivatedHatValues = Clone.simple(this._edgeActivatedHatValues);
         newClone.initDrawable(StageLayering.SPRITE_LAYER);
         newClone.updateAllDrawableProperties();
-        // Place behind the current target.
-        newClone.goBehindOther(this);
         return newClone;
     }
 
@@ -1046,7 +1044,6 @@ class RenderedTarget extends Target {
             newTarget.effects = JSON.parse(JSON.stringify(this.effects));
             newTarget.variables = this.duplicateVariables(newTarget.blocks);
             newTarget.updateAllDrawableProperties();
-            newTarget.goBehindOther(this);
             return newTarget;
         });
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -500,6 +500,15 @@ class VirtualMachine extends EventEmitter {
                 // Ensure unique sprite name
                 if (target.isSprite()) this.renameSprite(target.id, target.getName());
             });
+            // Initialize executable targets sorted by the layerOrder.
+            // Remove layerOrder property after use.
+            const executableTargets = targets.slice()
+                .sort((a, b) => a.layerOrder - b.layerOrder);
+            executableTargets.forEach(target => {
+                this.runtime.addExecutable(target);
+                delete target.layerOrder;
+            });
+
             // Select the first target for editing, e.g., the first sprite.
             if (wholeProject && (targets.length > 1)) {
                 this.editingTarget = targets[1];
@@ -1017,6 +1026,8 @@ class VirtualMachine extends EventEmitter {
         }
         return target.duplicate().then(newTarget => {
             this.runtime.targets.push(newTarget);
+            this.runtime.addExecutable(newTarget);
+            newTarget.goBehindOther(target);
             this.setEditingTarget(newTarget.id);
         });
     }

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -495,17 +495,15 @@ class VirtualMachine extends EventEmitter {
 
         return Promise.all(extensionPromises).then(() => {
             targets.forEach(target => {
-                this.runtime.targets.push(target);
+                this.runtime.addTarget(target);
                 (/** @type RenderedTarget */ target).updateAllDrawableProperties();
                 // Ensure unique sprite name
                 if (target.isSprite()) this.renameSprite(target.id, target.getName());
             });
-            // Initialize executable targets sorted by the layerOrder.
+            // Sort the executable targets by layerOrder.
             // Remove layerOrder property after use.
-            const executableTargets = targets.slice()
-                .sort((a, b) => a.layerOrder - b.layerOrder);
-            executableTargets.forEach(target => {
-                this.runtime.addExecutable(target);
+            this.runtime.executableTargets.sort((a, b) => a.layerOrder - b.layerOrder);
+            targets.forEach(target => {
                 delete target.layerOrder;
             });
 
@@ -1025,8 +1023,7 @@ class VirtualMachine extends EventEmitter {
             throw new Error('No sprite associated with this target.');
         }
         return target.duplicate().then(newTarget => {
-            this.runtime.targets.push(newTarget);
-            this.runtime.addExecutable(newTarget);
+            this.runtime.addTarget(newTarget);
             newTarget.goBehindOther(target);
             this.setEditingTarget(newTarget.id);
         });

--- a/test/integration/hat-threads-run-every-frame.js
+++ b/test/integration/hat-threads-run-every-frame.js
@@ -193,8 +193,7 @@ test('edge activated hat should trigger for both sprites when sprite is cloned',
             t.equal(numTargetEdgeHats, 1);
 
             const cloneTarget = vm.runtime.targets[1].makeClone();
-            vm.runtime.targets.push(cloneTarget);
-            vm.runtime.addExecutable(cloneTarget);
+            vm.runtime.addTarget(cloneTarget);
 
             vm.runtime._step();
             // Check that the runtime's _edgeActivatedHatValues object has two separate keys

--- a/test/integration/hat-threads-run-every-frame.js
+++ b/test/integration/hat-threads-run-every-frame.js
@@ -192,7 +192,9 @@ test('edge activated hat should trigger for both sprites when sprite is cloned',
                 val + Object.keys(target._edgeActivatedHatValues).length, 0);
             t.equal(numTargetEdgeHats, 1);
 
-            vm.runtime.targets.push(vm.runtime.targets[1].makeClone());
+            const cloneTarget = vm.runtime.targets[1].makeClone();
+            vm.runtime.targets.push(cloneTarget);
+            vm.runtime.addExecutable(cloneTarget);
 
             vm.runtime._step();
             // Check that the runtime's _edgeActivatedHatValues object has two separate keys

--- a/test/unit/blocks_event.js
+++ b/test/unit/blocks_event.js
@@ -54,9 +54,8 @@ test('#760 - broadcastAndWait', t => {
     const tgt = new Target(rt, b);
     tgt.isStage = true;
     tgt.createVariable('testBroadcastID', 'message', Variable.BROADCAST_MESSAGE_TYPE);
-    // Need to add to both runtime.targets as well as runtime.executableTargets here
-    rt.targets.push(tgt);
-    rt.executableTargets.push(tgt);
+
+    rt.addTarget(tgt);
 
     let th = rt._pushThread('broadcastAndWaitBlock', t);
     const util = new BlockUtility();

--- a/test/unit/blocks_event.js
+++ b/test/unit/blocks_event.js
@@ -54,7 +54,9 @@ test('#760 - broadcastAndWait', t => {
     const tgt = new Target(rt, b);
     tgt.isStage = true;
     tgt.createVariable('testBroadcastID', 'message', Variable.BROADCAST_MESSAGE_TYPE);
+    // Need to add to both runtime.targets as well as runtime.executableTargets here
     rt.targets.push(tgt);
+    rt.executableTargets.push(tgt);
 
     let th = rt._pushThread('broadcastAndWaitBlock', t);
     const util = new BlockUtility();

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -48,7 +48,7 @@ const testCostume = (costumes, arg, currentCostume = 1, isStage = false) => {
 
     if (isStage) {
         target.isStage = true;
-        rt.targets.push(target);
+        rt.addTarget(target);
         looks.switchBackdrop({BACKDROP: arg}, {target});
     } else {
         looks.switchCostume({COSTUME: arg}, {target});

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -188,7 +188,7 @@ test('renameVariable calls cloud io device\'s requestRenameVariable function', t
     target.isStage = true;
     const mockCloudVar = new Variable('foo', 'bar', Variable.SCALAR_TYPE, true);
     target.variables[mockCloudVar.id] = mockCloudVar;
-    runtime.targets.push(target);
+    runtime.addTarget(target);
 
     target.renameVariable('foo', 'bar2');
 
@@ -215,7 +215,7 @@ test('renameVariable does not call cloud io device\'s requestRenameVariable func
     const target = new Target(runtime);
     const mockCloudVar = new Variable('foo', 'bar', Variable.SCALAR_TYPE, true);
     target.variables[mockCloudVar.id] = mockCloudVar;
-    runtime.targets.push(target);
+    runtime.addTarget(target);
 
     target.renameVariable('foo', 'bar2');
 
@@ -266,7 +266,7 @@ test('deleteVariable calls cloud io device\'s requestRenameVariable function', t
     target.isStage = true;
     const mockCloudVar = new Variable('foo', 'bar', Variable.SCALAR_TYPE, true);
     target.variables[mockCloudVar.id] = mockCloudVar;
-    runtime.targets.push(target);
+    runtime.addTarget(target);
 
     target.deleteVariable('foo');
 
@@ -288,7 +288,7 @@ test('deleteVariable calls cloud io device\'s requestRenameVariable function', t
     const target = new Target(runtime);
     const mockCloudVar = new Variable('foo', 'bar', Variable.SCALAR_TYPE, true);
     target.variables[mockCloudVar.id] = mockCloudVar;
-    runtime.targets.push(target);
+    runtime.addTarget(target);
 
     target.deleteVariable('foo');
 


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-gui#4257. Also possibly LLK/scratch-gui#4302...

### Proposed Changes

Don't populate executable targets before targets are finished installing. This ensures that scripts don't run before a project is done loading.

### Reason for Changes

Without these changes it was possible to start running blocks  in a project before targets were fully installed. This was causing some uncaught exceptions like the one described in LLK/scratch-gui#4257, but also behavioral changes in the projects like turning global variables into local variables.

### Test Coverage

Added to a unit test which ensures that the layer order produced by deserialization is correct. This layer order is then used when targets are getting installed to populate executableTargets in the correct order. Previously executableTargets were getting populated when the target was created (which was pre-sorted by this same property).

Manually tested with some example projects that use the 'when timer > 0; broadcast message' construct as well as with some test cases that were previously turning global variables into local ones.


Thanks @picklesrus for working through this with me!