### PR TITLE
Prevent excess event emitting in Vernier extension

### DIFF
--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -129,6 +129,7 @@ class GdxFor {
         const adapter = new ScratchLinkDeviceAdapter(this._scratchLinkSocket, BLEUUID);
         godirect.createDevice(adapter, {open: true, startMeasurements: false}).then(device => {
             this._device = device;
+            this._device.keepValues = false;
             this._startMeasurements();
         });
     }
@@ -140,16 +141,6 @@ class GdxFor {
     _startMeasurements () {
         this._device.sensors.forEach(sensor => {
             sensor.setEnabled(true);
-
-            // For now, clear the save sensor values. The unlimited saving
-            // will be fixed in a future @vernier/godirect release.
-            sensor.on('value-changed', changedSensor => {
-                if (changedSensor.values.length > 1000) {
-                    const val = changedSensor.value;
-                    changedSensor.clear();
-                    changedSensor.setValue(val);
-                }
-            });
         });
         this._device.start(10); // Set the period to 10 milliseconds
     }

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -129,7 +129,7 @@ class GdxFor {
         const adapter = new ScratchLinkDeviceAdapter(this._scratchLinkSocket, BLEUUID);
         godirect.createDevice(adapter, {open: true, startMeasurements: false}).then(device => {
             this._device = device;
-            this._device.keepValues = false;
+            this._device.keepValues = false; // todo: possibly remove after updating Vernier godirect module
             this._startMeasurements();
         });
     }


### PR DESCRIPTION
Previously we were using a workaround to clear the stored sensor values inside the Vernier module, but this was causing lots of events to be emitted, and possibly causing performance issues.

Instead, set an internal flag to prevent the values from being stored in the first place.