### PR TITLE
Properly disconnect BLE socket in GDX-FOR scan/disconnect

### DIFF
--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -75,8 +75,8 @@ class GdxFor {
      * Called by the runtime when user wants to scan for a peripheral.
      */
     scan () {
-        if (this._device) {
-            this._device.close();
+        if (this._scratchLinkSocket) {
+            this._scratchLinkSocket.disconnect();
         }
 
         this._scratchLinkSocket = new BLE(this._runtime, this._extensionId, {
@@ -104,8 +104,8 @@ class GdxFor {
      * Disconnect from the GDX FOR.
      */
     disconnect () {
-        if (this._device) {
-            this._device.close();
+        if (this._scratchLinkSocket) {
+            this._scratchLinkSocket.disconnect();
         }
     }
 

--- a/src/extensions/scratch3_gdx_for/scratch-link-device-adapter.js
+++ b/src/extensions/scratch3_gdx_for/scratch-link-device-adapter.js
@@ -39,10 +39,6 @@ class ScratchLinkDeviceAdapter {
         const response = new DataView(array.buffer);
         return this._deviceOnResponse(response);
     }
-
-    close () {
-        return this.scratchLinkSocket.disconnect();
-    }
 }
 
 module.exports = ScratchLinkDeviceAdapter;


### PR DESCRIPTION
### Resolves

- Resolves #1919: GDX-FOR extension doesn't disconnect properly on scan
- Resolves #1921: GDX-FOR extension doesn't properly disconnect when user disconnects

### Proposed Changes

- Changes from `_device.close` to `scratchLinkSocket.disconnect` since _device is null in the discovery/scan case