### PR TITLE
Add early exit for non-existent block

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -990,6 +990,10 @@ class Blocks {
      */
     blockToXML (blockId, comments) {
         const block = this._blocks[blockId];
+        // block should exist, but currently some blocks' next property point
+        // to a blockId for non-existent blocks. Until we track down that behavior,
+        // this early exit allows the project to load.
+        if (!block) return;
         // Encode properties of this block.
         const tagName = (block.shadow) ? 'shadow' : 'block';
         let xmlString =


### PR DESCRIPTION
### Resolves

Projects that fail to load with the error “Cannot read shadow of undefined”. 

A couple of example projects:
- https://scratch.mit.edu/projects/276952854/
- https://scratch.mit.edu/projects/268367485/

### Proposed Changes

This error comes from [`blockToXML`](https://github.com/LLK/scratch-vm/blob/develop/src/engine/blocks.js#L991) when it tries to encode a block that doesn't seem to exist. This PR adds an early exit to `blockToXML` if a certain `blockId` can't be found in the target's blocks. 

### Reason for Changes

In the case of these two example projects, a `blockId` is saved as the `next` property value on blocks in the project.json. However, these child blocks don't exist else where in project.json. This doesn't cause an error in the project loading process until we try to encode all blocks and their children in `blockToXML`. Adding an early exit if the block doesn't exist allows the project to load. We lose whatever block information was in this phantom block, but by the point the project gets to `blockToXML`, there isn't more block information to encode anyways. 

I haven't been able to find the root cause for this issue and recreate a scenario where a project saves a phantom `next` block and deletes the rest of the block information. However, this seems like an okay solution to at least allow affected projects load. 

