### PR TITLE
Do not load Vernier extension yet

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -17,7 +17,9 @@ const Scratch3VideoSensingBlocks = require('../extensions/scratch3_video_sensing
 const Scratch3Speech2TextBlocks = require('../extensions/scratch3_speech2text');
 const Scratch3Ev3Blocks = require('../extensions/scratch3_ev3');
 const Scratch3MakeyMakeyBlocks = require('../extensions/scratch3_makeymakey');
-const Scratch3GdxForBlocks = require('../extensions/scratch3_gdx_for');
+// todo: only load this extension once we have a compatible way to load its
+// Vernier module dependency.
+// const Scratch3GdxForBlocks = require('../extensions/scratch3_gdx_for');
 
 const builtinExtensions = {
     pen: Scratch3PenBlocks,
@@ -29,8 +31,8 @@ const builtinExtensions = {
     videoSensing: Scratch3VideoSensingBlocks,
     speech2text: Scratch3Speech2TextBlocks,
     ev3: Scratch3Ev3Blocks,
-    makeymakey: Scratch3MakeyMakeyBlocks,
-    gdxfor: Scratch3GdxForBlocks
+    makeymakey: Scratch3MakeyMakeyBlocks
+    // gdxfor: Scratch3GdxForBlocks
 };
 
 /**


### PR DESCRIPTION
Due to compatibility issues with the Vernier Go Direct module which need investigation, do not load the Vernier extension yet.