### PR TITLE
Improve the performance of the timer utilitiy

### DIFF
--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -23,7 +23,7 @@ class BlockUtility {
         this.thread = thread;
 
         this._nowObj = {
-            now: () => this.runtime.currentMSecs
+            now: () => this.sequencer.runtime.currentMSecs
         };
     }
 

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -21,6 +21,10 @@ class BlockUtility {
          * @type {?Thread}
          */
         this.thread = thread;
+
+        this._nowObj = {
+            now: () => this.runtime.currentMSecs
+        };
     }
 
     /**
@@ -46,9 +50,7 @@ class BlockUtility {
      */
     get nowObj () {
         if (this.runtime) {
-            return {
-                now: () => this.runtime.currentMSecs
-            };
+            return this._nowObj;
         }
         return null;
     }


### PR DESCRIPTION
### Proposed Changes

Timer utility was creating a new object every time it was trying to calculate the amount of time that hat elapsed when running as part of a wait block (multiple times per frame). This was causing a minor GC.

Save the nowObj in an instance property in the block-utility so that it does not return a new object every time the getter is called.

### Reason for Changes

Performance improvement for the wait block.

### Test Coverage

Benchmark suite comparison on Mac Chrome (numbers on the left are after improvements, numbers on the right are develop):

![image](https://user-images.githubusercontent.com/1786240/51265354-9d7c6c80-1986-11e9-8627-40e8d6a1490d.png)
