### PR TITLE
Cache hat block information for the runtime

### DIFF
--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview
+ * The BlocksRuntimeCache caches data about the top block of scripts so that
+ * Runtime can iterate a targeted opcode and iterate the returned set faster.
+ * Many top blocks need to match fields as well as opcode, since that matching
+ * compares strings in uppercase we can go ahead and uppercase the cached value
+ * so we don't need to in the future.
+ */
+
+/**
+ * A set of cached data about the top block of a script.
+ * @param {Blocks} container - Container holding the block and related data
+ * @param {string} blockId - Id for whose block data is cached in this instance
+ */
+class RuntimeScriptCache {
+    constructor (container, blockId) {
+        /**
+         * Container with block data for blockId.
+         * @type {Blocks}
+         */
+        this.container = container;
+
+        /**
+         * ID for block this instance caches.
+         * @type {string}
+         */
+        this.blockId = blockId;
+
+        const block = container.getBlock(blockId);
+        const fields = container.getFields(block);
+
+        /**
+         * Formatted fields or fields of input blocks ready for comparison in
+         * runtime.
+         *
+         * This is a clone of parts of the targeted blocks. Changes to these
+         * clones are limited to copies under RuntimeScriptCache and will not
+         * appear in the original blocks in their container. This copy is
+         * modified changing the case of strings to uppercase. These uppercase
+         * values will be compared later by the VM.
+         * @type {object}
+         */
+        this.fieldsOfInputs = Object.assign({}, fields);
+        if (Object.keys(fields).length === 0) {
+            const inputs = container.getInputs(block);
+            for (const input in inputs) {
+                if (!inputs.hasOwnProperty(input)) continue;
+                const id = inputs[input].block;
+                const inputBlock = container.getBlock(id);
+                const inputFields = container.getFields(inputBlock);
+                Object.assign(this.fieldsOfInputs, inputFields);
+            }
+        }
+        for (const key in this.fieldsOfInputs) {
+            const field = this.fieldsOfInputs[key] = Object.assign({}, this.fieldsOfInputs[key]);
+            if (field.value.toUpperCase) {
+                field.value = field.value.toUpperCase();
+            }
+        }
+    }
+}
+
+/**
+ * Get an array of scripts from a block container prefiltered to match opcode.
+ * @param {Blocks} container - Container of blocks
+ * @param {string} opcode - Opcode to filter top blocks by
+ */
+exports.getScripts = function () {
+    throw new Error('blocks.js has not initialized BlocksRuntimeCache');
+};
+
+/**
+ * Exposed RuntimeScriptCache class used by integration in blocks.js.
+ * @private
+ */
+exports._RuntimeScriptCache = RuntimeScriptCache;
+
+require('./blocks');

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -5,6 +5,7 @@ const MonitorRecord = require('./monitor-record');
 const Clone = require('../util/clone');
 const {Map} = require('immutable');
 const BlocksExecuteCache = require('./blocks-execute-cache');
+const BlocksRuntimeCache = require('./blocks-runtime-cache');
 const log = require('../util/log');
 const Variable = require('./variable');
 const getMonitorIdForBlockWithArgs = require('../util/get-monitor-id');
@@ -71,7 +72,13 @@ class Blocks {
              * actively monitored.
              * @type {Array<{blockId: string, target: Target}>}
              */
-            _monitored: null
+            _monitored: null,
+
+            /**
+             * A cache of hat opcodes to collection of theads to execute.
+             * @type {object.<string, object>}
+             */
+            scripts: {}
         };
 
         /**
@@ -504,6 +511,7 @@ class Blocks {
         this._cache.procedureDefinitions = {};
         this._cache._executeCached = {};
         this._cache._monitored = null;
+        this._cache.scripts = {};
     }
 
     /**
@@ -1176,6 +1184,37 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
 
     blocks._cache._executeCached[blockId] = cached;
     return cached;
+};
+
+/**
+ * Cache class constructor for runtime. Used to consider what threads should
+ * start based on hat data.
+ * @type {function}
+ */
+const RuntimeScriptCache = BlocksRuntimeCache._RuntimeScriptCache;
+
+/**
+ * Get an array of scripts from a block container prefiltered to match opcode.
+ * @param {Blocks} blocks - Container of blocks
+ * @param {string} opcode - Opcode to filter top blocks by
+ * @returns {Array.<RuntimeScriptCache>} - Array of RuntimeScriptCache cache
+ *   objects
+ */
+BlocksRuntimeCache.getScripts = function (blocks, opcode) {
+    let scripts = blocks._cache.scripts[opcode];
+    if (!scripts) {
+        scripts = blocks._cache.scripts[opcode] = [];
+
+        const allScripts = blocks._scripts;
+        for (let i = 0; i < allScripts.length; i++) {
+            const topBlockId = allScripts[i];
+            const block = blocks.getBlock(topBlockId);
+            if (block.opcode === opcode) {
+                scripts.push(new RuntimeScriptCache(blocks, topBlockId));
+            }
+        }
+    }
+    return scripts;
 };
 
 module.exports = Blocks;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1279,16 +1279,11 @@ class Runtime extends EventEmitter {
      * @return {!Thread} The newly created thread.
      */
     _pushThread (id, target, opts) {
-        opts = Object.assign({
-            stackClick: false,
-            updateMonitor: false
-        }, opts);
-
         const thread = new Thread(id);
         thread.target = target;
-        thread.stackClick = opts.stackClick;
-        thread.updateMonitor = opts.updateMonitor;
-        thread.blockContainer = opts.updateMonitor ?
+        thread.stackClick = Boolean(opts && opts.stackClick);
+        thread.updateMonitor = Boolean(opts && opts.updateMonitor);
+        thread.blockContainer = thread.updateMonitor ?
             this.monitorBlocks :
             target.blocks;
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -4,6 +4,7 @@ const escapeHtml = require('escape-html');
 
 const ArgumentType = require('../extension-support/argument-type');
 const Blocks = require('./blocks');
+const BlocksRuntimeCache = require('./blocks-runtime-cache');
 const BlockType = require('../extension-support/block-type');
 const Profiler = require('./profiler');
 const Sequencer = require('./sequencer');
@@ -1426,6 +1427,20 @@ class Runtime extends EventEmitter {
         }
     }
 
+    allScriptsByOpcodeDo (opcode, f, optTarget) {
+        let targets = this.executableTargets;
+        if (optTarget) {
+            targets = [optTarget];
+        }
+        for (let t = targets.length - 1; t >= 0; t--) {
+            const target = targets[t];
+            const scripts = BlocksRuntimeCache.getScripts(target.blocks, opcode);
+            for (let j = 0; j < scripts.length; j++) {
+                f(scripts[j], target);
+            }
+        }
+    }
+
     /**
      * Start all relevant hats.
      * @param {!string} requestedHatOpcode Opcode of hats to start.
@@ -1448,42 +1463,21 @@ class Runtime extends EventEmitter {
         }
 
         // Consider all scripts, looking for hats with opcode `requestedHatOpcode`.
-        this.allScriptsDo((topBlockId, target) => {
-            const blocks = target.blocks;
-            const block = blocks.getBlock(topBlockId);
-            const potentialHatOpcode = block.opcode;
-            if (potentialHatOpcode !== requestedHatOpcode) {
-                // Not the right hat.
-                return;
-            }
+        this.allScriptsByOpcodeDo(requestedHatOpcode, (script, target) => {
+            const {
+                blockId: topBlockId,
+                fieldsOfInputs: hatFields
+            } = script;
 
             // Match any requested fields.
             // For example: ensures that broadcasts match.
             // This needs to happen before the block is evaluated
             // (i.e., before the predicate can be run) because "broadcast and wait"
             // needs to have a precise collection of started threads.
-            let hatFields = blocks.getFields(block);
-
-            // If no fields are present, check inputs (horizontal blocks)
-            if (Object.keys(hatFields).length === 0) {
-                hatFields = {}; // don't overwrite the block's actual fields list
-                const hatInputs = blocks.getInputs(block);
-                for (const input in hatInputs) {
-                    if (!hatInputs.hasOwnProperty(input)) continue;
-                    const id = hatInputs[input].block;
-                    const inpBlock = blocks.getBlock(id);
-                    const fields = blocks.getFields(inpBlock);
-                    Object.assign(hatFields, fields);
-                }
-            }
-
-            if (optMatchFields) {
-                for (const matchField in optMatchFields) {
-                    if (hatFields[matchField].value.toUpperCase() !==
-                        optMatchFields[matchField]) {
-                        // Field mismatch.
-                        return;
-                    }
+            for (const matchField in optMatchFields) {
+                if (hatFields[matchField].value !== optMatchFields[matchField]) {
+                    // Field mismatch.
+                    return;
                 }
             }
 
@@ -1492,29 +1486,31 @@ class Runtime extends EventEmitter {
             if (hatMeta.restartExistingThreads) {
                 // If `restartExistingThreads` is true, we should stop
                 // any existing threads starting with the top block.
-                for (let i = 0; i < instance.threads.length; i++) {
-                    if (instance.threads[i].topBlock === topBlockId &&
-                        !instance.threads[i].stackClick && // stack click threads and hat threads can coexist
-                        instance.threads[i].target === target) {
-                        newThreads.push(instance._restartThread(instance.threads[i]));
+                for (let i = 0; i < this.threads.length; i++) {
+                    if (this.threads[i].target === target &&
+                        this.threads[i].topBlock === topBlockId &&
+                        // stack click threads and hat threads can coexist
+                        !this.threads[i].stackClick) {
+                        newThreads.push(this._restartThread(this.threads[i]));
                         return;
                     }
                 }
             } else {
                 // If `restartExistingThreads` is false, we should
                 // give up if any threads with the top block are running.
-                for (let j = 0; j < instance.threads.length; j++) {
-                    if (instance.threads[j].topBlock === topBlockId &&
-                        instance.threads[j].target === target &&
-                        !instance.threads[j].stackClick && // stack click threads and hat threads can coexist
-                        instance.threads[j].status !== Thread.STATUS_DONE) {
+                for (let j = 0; j < this.threads.length; j++) {
+                    if (this.threads[j].target === target &&
+                        this.threads[j].topBlock === topBlockId &&
+                        // stack click threads and hat threads can coexist
+                        !this.threads[j].stackClick &&
+                        this.threads[j].status !== Thread.STATUS_DONE) {
                         // Some thread is already running.
                         return;
                     }
                 }
             }
             // Start the thread with this top block.
-            newThreads.push(instance._pushThread(topBlockId, target));
+            newThreads.push(this._pushThread(topBlockId, target));
         }, optTarget);
         return newThreads;
     }


### PR DESCRIPTION
### Resolves

#1707 

### Proposed Changes

- Add BlocksRuntimeCache to cache data about block scripts, their hats, and their data (like broadcast option)
- <del>Group threads on their target in addition to runtime.targets and loop those target to determine if a thread should be started or restarted for a hat</del>
- Remove Object.assign use in _pushThreads

### Reason for Changes

Edge activated hats are started every frame and broadcasts are a feature that may be used a lot in a project. Starting hats currently loops all scripts in all targets in most cases. With that scripts are checked that are not the right hat/opcode. This information can easily be grouped and cached so every second iteration for a hat/opcode only needs to loop over the desired hats and test if the fields match any optional fields.

### Benchmark Results

In general all platforms normally experience an improvement with this change on projects.

Here are some exceptions:
- Safari (2017 MBP 15") has a general issue with this change for 155128646 (stacky towers). It experiences a small decrease in performance.
- Chrome (2017 MBP 15") starting 89811578 (solar system) seems to be the only one negatively effected in a large way.
- Firefox (2017 MBP 15") experiences a minor degradation in 130041250 (floating blocks).

Raspberry PI data could not be collected for 89811578 (solar system). The PI stalled on this project likely due to needing too much memory or too much memory thrashing.

<details>
<summary>Benchmark Results Table</summary>

Platform | Project ID | Warm Up | Recording | develop | after change | difference
-------- | ---------- | ------- | --------- | ------: | -----------: | ---------:
raspberrypi | 130041250 | 0 | 2000 | 3187 | 3321 | +4.2
book | 130041250 | 0 | 2000 | 169252 | 169119 | -0.1
chrome | 130041250 | 0 | 2000 | 1093599 | 1140890 | +4.3
firefox | 130041250 | 0 | 2000 | 773011 | 754854 | -2.3
safari | 130041250 | 0 | 2000 | 1797192 | 2052938 | +14.2
raspberrypi | 130041250 | 4000 | 6000 | 41998 | 39521 | -5.9
book | 130041250 | 4000 | 6000 | 278924 | 285923 | +2.5
chrome | 130041250 | 4000 | 6000 | 1338833 | 1352135 | +1.0
firefox | 130041250 | 4000 | 6000 | 961047 | 933778 | -2.8
safari | 130041250 | 4000 | 6000 | 2067681 | 2100278 | +1.6
raspberrypi | 14844969 | 0 | 2000 | 8528 | 14097 | +65.3
book | 14844969 | 0 | 2000 | 255686 | 329475 | +28.9
chrome | 14844969 | 0 | 2000 | 1093788 | 1142420 | +4.4
firefox | 14844969 | 0 | 2000 | 830292 | 898024 | +8.2
safari | 14844969 | 0 | 2000 | 2425291 | 2864760 | +18.1
raspberrypi | 14844969 | 1000 | 6000 | 61521 | 72142 | +17.3
book | 14844969 | 1000 | 6000 | 409130 | 455599 | +11.4
chrome | 14844969 | 1000 | 6000 | 1147805 | 1219053 | +6.2
firefox | 14844969 | 1000 | 6000 | 937069 | 1077716 | +15.0
safari | 14844969 | 1000 | 6000 | 2789899 | 3138463 | +12.5
raspberrypi | 173918262 | 0 | 5000 | 25746 | 32022 | +24.4
book | 173918262 | 0 | 5000 | 313615 | 333111 | +6.2
chrome | 173918262 | 0 | 5000 | 1071776 | 1073457 | +0.2
firefox | 173918262 | 0 | 5000 | 717066 | 756411 | +5.5
safari | 173918262 | 0 | 5000 | 2117538 | 2363462 | +11.6
raspberrypi | 173918262 | 5000 | 5000 | 57276 | 61210 | +6.9
book | 173918262 | 5000 | 5000 | 409647 | 419373 | +2.4
chrome | 173918262 | 5000 | 5000 | 1107828 | 1131176 | +2.1
firefox | 173918262 | 5000 | 5000 | 699914 | 818517 | +16.9
safari | 173918262 | 5000 | 5000 | 1609219 | 1870705 | +16.2
raspberrypi | 155128646 | 0 | 5000 | 18827 | 21581 | +14.6
book | 155128646 | 0 | 5000 | 195730 | 205951 | +5.2
chrome | 155128646 | 0 | 5000 | 1059996 | 1082332 | +2.1
firefox | 155128646 | 0 | 5000 | 563900 | 584788 | +3.7
safari | 155128646 | 0 | 5000 | 2414075 | 2287622 | -5.2
raspberrypi | 155128646 | 5000 | 5000 | 30147 | 34159 | +13.3
book | 155128646 | 5000 | 5000 | 260194 | 265460 | +2.0
chrome | 155128646 | 5000 | 5000 | 841821 | 909526 | +8.0
firefox | 155128646 | 5000 | 5000 | 455500 | 479676 | +5.3
safari | 155128646 | 5000 | 5000 | 600826 | 567534 | -5.5
chrome | 89811578 | 0 | 5000 | 1082200 | 817461 | -24.5
firefox | 89811578 | 0 | 5000 | 911832 | 1009328 | +10.7
book | 89811578 | 0 | 5000 | 498503 | 501233 | +0.5
safari | 89811578 | 0 | 5000 | 2857443 | 2871101 | +0.5
chrome | 89811578 | 5000 | 5000 | 1091999 | 1116591 | +2.3
firefox | 89811578 | 5000 | 5000 | 1030964 | 1112638 | +7.9
book | 89811578 | 5000 | 5000 | 553632 | 562060 | +1.5
safari | 89811578 | 5000 | 5000 | 3251637 | 3173566 | -2.4

</details>
