### PR TITLE
Fix Text to Speech extension default input localization

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -265,7 +265,7 @@ class Scratch3Text2SpeechBlocks {
         if (this.isSupportedLanguage(this.getEditorLanguage())) {
             defaultTextToSpeak = formatMessage({
                 id: 'text2speech.defaultTextToSpeak',
-                default: defaultTextToSpeak,
+                default: 'hello',
                 description: 'hello: the default text to speak'
             });
         }


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1733

### Proposed Changes

Don’t use a variable in formatMessage! 

@chrisgarrity I'm not certain this is enough to make this work- lets look at this together. 