### PR TITLE
Benchmark load time

### DIFF
--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -1,3 +1,6 @@
+const ScratchStorage = require('scratch-storage');
+const VirtualMachine = require('..');
+
 const Scratch = window.Scratch = window.Scratch || {};
 
 const ASSET_SERVER = 'https://cdn.assets.scratch.mit.edu/';
@@ -439,12 +442,12 @@ class ProfilerRun {
 const runBenchmark = function () {
     // Lots of global variables to make debugging easier
     // Instantiate the VM.
-    const vm = new window.VirtualMachine();
+    const vm = new VirtualMachine();
     Scratch.vm = vm;
 
     vm.setTurboMode(true);
 
-    const storage = new ScratchStorage(); /* global ScratchStorage */
+    const storage = new ScratchStorage();
     const AssetType = storage.AssetType;
     storage.addWebSource([AssetType.Project], getProjectUrl);
     storage.addWebSource([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], getAssetUrl);
@@ -481,7 +484,6 @@ const runBenchmark = function () {
     vm.attachRenderer(renderer);
     const audioEngine = new window.AudioEngine();
     vm.attachAudioEngine(audioEngine);
-    /* global ScratchSVGRenderer */
     vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
     vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
 
@@ -555,7 +557,7 @@ const runBenchmark = function () {
  * @param {object} json data from a previous benchmark run.
  */
 const renderBenchmarkData = function (json) {
-    const vm = new window.VirtualMachine();
+    const vm = new VirtualMachine();
     new ProfilerRun({vm}).render(json);
     setShareLink(json);
 };

--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -1,5 +1,19 @@
+// Track loading time with timestamps and if possible the performance api.
+if (window.performance) {
+    // Mark with the performance API when benchmark.js and its dependecies start
+    // evaluation. This can tell us once measured how long the code spends time
+    // turning into execution code for the first time. Skipping evaluation of
+    // some of the code can help us make it faster.
+    performance.mark('Scratch.EvalStart');
+}
+
 const ScratchStorage = require('scratch-storage');
 const VirtualMachine = require('..');
+const Runtime = require('../engine/runtime');
+
+const ScratchRender = require('scratch-render');
+const AudioEngine = require('scratch-audio');
+const ScratchSVGRenderer = require('scratch-svg-renderer');
 
 const Scratch = window.Scratch = window.Scratch || {};
 
@@ -68,19 +82,48 @@ class LoadingProgress {
         this.callback = callback;
     }
 
-    on (storage) {
+    on (storage, vm) {
         const _this = this;
         const _load = storage.webHelper.load;
         storage.webHelper.load = function (...args) {
+            if (_this.complete === 0 && window.performance) {
+                // Mark in browser inspectors how long it takes to load the
+                // projects initial data file.
+                performance.mark('Scratch.LoadDataStart');
+            }
+
             const result = _load.call(this, ...args);
             _this.total += 1;
             _this.callback(_this);
             result.then(() => {
+                if (_this.complete === 0 && window.performance) {
+                    // How long did loading the data file take?
+                    performance.mark('Scratch.LoadDataEnd');
+                    performance.measure('Scratch.LoadData', 'Scratch.LoadDataStart', 'Scratch.LoadDataEnd');
+                }
+
                 _this.complete += 1;
                 _this.callback(_this);
             });
             return result;
         };
+        vm.runtime.on(Runtime.PROJECT_LOADED, () => {
+            // Currently LoadingProgress tracks when the data has been loaded
+            // and not when the data has been decoded. It may be difficult to
+            // track that but it isn't hard to track when its all been decoded.
+            if (window.performance) {
+                // How long did it take to load the html, js, and all the
+                // project assets?
+                performance.mark('Scratch.LoadEnd');
+                performance.measure('Scratch.Load', 'Scratch.LoadStart', 'Scratch.LoadEnd');
+            }
+
+            window.ScratchVMLoadEnd = Date.now();
+
+            // With this event lets update LoadingProgress a final time so its
+            // displayed loading time is accurate.
+            _this.callback(_this);
+        });
     }
 }
 
@@ -458,7 +501,9 @@ const runBenchmark = function () {
             .innerText = progress.total;
         document.getElementsByClassName('loading-complete')[0]
             .innerText = progress.complete;
-    }).on(storage);
+        document.getElementsByClassName('loading-time')[0]
+            .innerText = `(${(window.ScratchVMLoadEnd || Date.now()) - window.ScratchVMLoadStart}ms)`;
+    }).on(storage, vm);
 
     let warmUpTime = 4000;
     let maxRecordedTime = 6000;
@@ -479,10 +524,10 @@ const runBenchmark = function () {
 
     // Instantiate the renderer and connect it to the VM.
     const canvas = document.getElementById('scratch-stage');
-    const renderer = new window.ScratchRender(canvas);
+    const renderer = new ScratchRender(canvas);
     Scratch.renderer = renderer;
     vm.attachRenderer(renderer);
-    const audioEngine = new window.AudioEngine();
+    const audioEngine = new AudioEngine();
     vm.attachAudioEngine(audioEngine);
     vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
     vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
@@ -577,3 +622,10 @@ window.onload = function () {
 window.onhashchange = function () {
     location.reload();
 };
+
+if (window.performance) {
+    performance.mark('Scratch.EvalEnd');
+    performance.measure('Scratch.Eval', 'Scratch.EvalStart', 'Scratch.EvalEnd');
+}
+
+window.ScratchVMEvalEnd = Date.now();

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -79,16 +79,6 @@
 
   <div id="blocks"></div>
 
-  <!-- FPS counter, Blocks, Renderer -->
-  <script src="./vendor.js"></script>
-  <!-- Storage module -->
-  <script src="./scratch-storage.js"></script>
-  <!-- Stage rendering -->
-  <script src="./scratch-render.js"></script>
-  <!-- SVG rendering -->
-  <script src="./scratch-svg-renderer.js"></script>
-  <!-- VM -->
-  <script src="./scratch-vm.js"></script>
   <!-- Playground -->
   <script src="./benchmark.js"></script>
 </body>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -5,6 +5,18 @@
     <meta charset="utf-8">
     <title>Scratch VM Benchmark</title>
     <link rel="stylesheet" href="./benchmark.css" type="text/css" media="screen">
+    <script>
+        // Track loading time with timestamps and if possible the performance
+        // api.
+
+        // Start tracking loading of Scratch before the body dom is evaluated.
+        window.ScratchVMLoadStart = Date.now();
+        if (window.performance) {
+            // Mark for browser performance inspectors and if we want to use
+            // other performance apis.
+            performance.mark('Scratch.LoadStart');
+        }
+    </script>
 </head>
 <body>
   <h2>Scratch VM Benchmark</h2>
@@ -30,7 +42,7 @@
 
   <div class="loading">
     <label>Loading:</label>
-    <span class="loading-complete">0</span> / <span class="loading-total">0</span>
+    <span class="loading-complete">0</span> / <span class="loading-total">0</span> <span class="loading-time">(--ms)</span>
   </div>
   <div class="profile-count-group">
     <div class="profile-count">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,19 +88,7 @@ module.exports = [
     defaultsDeep({}, base, {
         target: 'web',
         entry: {
-            'scratch-vm': './src/index.js',
-            'vendor': [
-                // FPS counter
-                'stats.js/build/stats.min.js',
-                // Scratch Blocks
-                'scratch-blocks/dist/vertical.js',
-                // Audio
-                'scratch-audio',
-                // Storage
-                'scratch-storage',
-                // Renderer
-                'scratch-render'
-            ],
+            'benchmark': './src/playground/benchmark',
             'video-sensing-extension-debug': './src/extensions/scratch3_video_sensing/debug'
         },
         output: {


### PR DESCRIPTION
### Resolves

Benchmark loading Scratch and Scratch Projects so we can make that faster.

### Proposed Changes

- Build benchmark.js
- Store global time values and use the performance API to record some load timing data
- Render the overall load duration in the RunningView area of the benchmark

### Reason for Changes

- Make benchmark loading and execution closer to how other uses of vm operate, as a large javascript file.
- Record and render loading duration so we can compare between changes to the VM and dependencies.
- Changing vm benchmark before gui to get an experimental area up without necessarily negatively impacting the primary users of Scratch.

### Benchmark Data

Instead of being comparison data, so here are some baselines.

project id | platform | run 1 | run 2 | run 3 | run 4 | run 5 | avg
--------- | ------ | ---- | ---- | ---- | ---- | ---- | ----
169401431 | chrome | 9820 | 9715 | 9675 | 10270 | 10323 | 9960.6
169401431 | firefox | 6568 | 5919 | 5348 | 5478 | 5307 | 5724
169401431 | safari | 9048 | 8531 | 7954 | 8368 | 7786 | 8337.4
169401431 | book | 25781 | 19570 | 20712 | 19658 | 19547 | 21053.6
173918262 | chrome | 2086 | 2446 | 1753 | 1796 | 1809 | 1978
173918262 | firefox | 2073 | 1371 | 1558 | 1358 | 1435 | 1559
173918262 | safari | 1943 | 1306 | 1361 | 1246 | 1306 | 1432.4
173918262 | book | 12337 | 6408 | 7018 | 6283 | 6338 | 7676.8
173918262 | pi | 22557 | 18754 | 17990 | 18212 | 19023 | 19307.2
