### PR TITLE
Escape variable name in XML

### DIFF
--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -4,6 +4,7 @@
  */
 
 const uid = require('../util/uid');
+const xmlEscape = require('../util/xml-escape');
 
 class Variable {
     /**
@@ -36,7 +37,7 @@ class Variable {
     toXML (isLocal) {
         isLocal = (isLocal === true);
         return `<variable type="${this.type}" id="${this.id}" islocal="${isLocal
-        }" iscloud="${this.isCloud}">${this.name}</variable>`;
+        }" iscloud="${this.isCloud}">${xmlEscape(this.name)}</variable>`;
     }
 
     /**

--- a/test/unit/engine_variable.js
+++ b/test/unit/engine_variable.js
@@ -1,0 +1,110 @@
+const test = require('tap').test;
+const Variable = require('../../src/engine/variable');
+const htmlparser = require('htmlparser2');
+
+test('spec', t => {
+    t.type(typeof Variable.SCALAR_TYPE, typeof Variable.LIST_TYPE);
+    t.type(typeof Variable.SCALAR_TYPE, typeof Variable.BROADCAST_MESSAGE_TYPE);
+
+    const varId = 'varId';
+    const varName = 'varName';
+    const varIsCloud = false;
+    let v = new Variable(
+        varId,
+        varName,
+        Variable.SCALAR_TYPE,
+        varIsCloud
+    );
+
+    t.type(Variable, 'function');
+    t.type(v, 'object');
+    t.ok(v instanceof Variable);
+
+    t.equal(v.id, varId);
+    t.equal(v.name, varName);
+    t.equal(v.type, Variable.SCALAR_TYPE);
+    t.type(v.value, 'number');
+    t.equal(v.isCloud, varIsCloud);
+
+    t.type(v.toXML, 'function');
+
+    v = new Variable(
+        varId,
+        varName,
+        Variable.LIST_TYPE,
+        varIsCloud
+    );
+    t.ok(Array.isArray(v.value));
+
+    v = new Variable(
+        varId,
+        varName,
+        Variable.BROADCAST_MESSAGE_TYPE,
+        varIsCloud
+    );
+    t.equal(v.value, 'varName');
+
+    t.end();
+});
+
+test('toXML', t => {
+    const varId = 'varId';
+    const varName = 'varName';
+    const varIsCloud = false;
+    const varIsLocal = false;
+    const v = new Variable(
+        varId,
+        varName,
+        Variable.SCALAR_TYPE,
+        varIsCloud
+    );
+
+    const parser = new htmlparser.Parser({
+        onopentag: function (name, attribs){
+            if (name === 'variable'){
+                t.equal(attribs.type, Variable.SCALAR_TYPE);
+                t.equal(attribs.id, varId);
+                t.equal(attribs.iscloud, varIsCloud.toString());
+                t.equal(attribs.islocal, varIsLocal.toString());
+            }
+        },
+        ontext: function (text){
+            t.equal(text, varName);
+        }
+    }, {decodeEntities: false});
+    parser.write(v.toXML(false));
+    parser.end();
+
+    t.end();
+});
+
+test('escape variable name for XML', t => {
+    const varId = 'varId';
+    const varName = '<>&\'"';
+    const varIsCloud = false;
+    const varIsLocal = false;
+    const v = new Variable(
+        varId,
+        varName,
+        Variable.SCALAR_TYPE,
+        varIsCloud
+    );
+
+    const parser = new htmlparser.Parser({
+        onopentag: function (name, attribs){
+            if (name === 'variable'){
+                t.equal(attribs.type, Variable.SCALAR_TYPE);
+                t.equal(attribs.id, varId);
+                t.equal(attribs.iscloud, varIsCloud.toString());
+                t.equal(attribs.islocal, varIsLocal.toString());
+            }
+        },
+        ontext: function (text){
+            t.equal(text, '&lt;&gt;&amp;&apos;&quot;');
+        }
+    }, {decodeEntities: false});
+    parser.write(v.toXML(false));
+    parser.end();
+
+    t.end();
+});


### PR DESCRIPTION
### Resolves

Fix for #1939 and partially #1077 .
Special characters '<>&\'"' can be used in variable and message name. 

### Proposed Changes

aVariable.toXML() escapes special characters in the name. 

### Reason for Changes

Blocks in pallet and code pane build SVG string from XML presentation of variables. Variable name is used in blocks, so that the name of variables should be escaped special character in its XML. 

Broadcast messages is a kind of variable in block presentation. Then this code fix the problem of broadcast message including special characters too. 

### Test Coverage

Added new unit test cases for engine/variable. It validates that toXML() returns escaped special characters '<>&\'"'. 
It contains tests for default specification too. 

Integration test was not included, because these special characters are no harm in scratch-vm. This fix can be checked only on scratch-gui. 

