### PR TITLE
Lazy eval big dependencies

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -7,32 +7,21 @@ const BlockType = require('./block-type');
 // These extensions are currently built into the VM repository but should not be loaded at startup.
 // TODO: move these out into a separate repository?
 // TODO: change extension spec so that library info, including extension ID, can be collected through static methods
-const Scratch3PenBlocks = require('../extensions/scratch3_pen');
-const Scratch3WeDo2Blocks = require('../extensions/scratch3_wedo2');
-const Scratch3MusicBlocks = require('../extensions/scratch3_music');
-const Scratch3MicroBitBlocks = require('../extensions/scratch3_microbit');
-const Scratch3Text2SpeechBlocks = require('../extensions/scratch3_text2speech');
-const Scratch3TranslateBlocks = require('../extensions/scratch3_translate');
-const Scratch3VideoSensingBlocks = require('../extensions/scratch3_video_sensing');
-const Scratch3Speech2TextBlocks = require('../extensions/scratch3_speech2text');
-const Scratch3Ev3Blocks = require('../extensions/scratch3_ev3');
-const Scratch3MakeyMakeyBlocks = require('../extensions/scratch3_makeymakey');
-// todo: only load this extension once we have a compatible way to load its
-// Vernier module dependency.
-// const Scratch3GdxForBlocks = require('../extensions/scratch3_gdx_for');
 
 const builtinExtensions = {
-    pen: Scratch3PenBlocks,
-    wedo2: Scratch3WeDo2Blocks,
-    music: Scratch3MusicBlocks,
-    microbit: Scratch3MicroBitBlocks,
-    text2speech: Scratch3Text2SpeechBlocks,
-    translate: Scratch3TranslateBlocks,
-    videoSensing: Scratch3VideoSensingBlocks,
-    speech2text: Scratch3Speech2TextBlocks,
-    ev3: Scratch3Ev3Blocks,
-    makeymakey: Scratch3MakeyMakeyBlocks
-    // gdxfor: Scratch3GdxForBlocks
+    pen: () => require('../extensions/scratch3_pen'),
+    wedo2: () => require('../extensions/scratch3_wedo2'),
+    music: () => require('../extensions/scratch3_music'),
+    microbit: () => require('../extensions/scratch3_microbit'),
+    text2speech: () => require('../extensions/scratch3_text2speech'),
+    translate: () => require('../extensions/scratch3_translate'),
+    videoSensing: () => require('../extensions/scratch3_video_sensing'),
+    speech2text: () => require('../extensions/scratch3_speech2text'),
+    ev3: () => require('../extensions/scratch3_ev3'),
+    makeymakey: () => require('../extensions/scratch3_makeymakey')
+    // todo: only load this extension once we have a compatible way to load its
+    // Vernier module dependency.
+    // gdxfor: () => require('../extensions/scratch3_gdx_for')
 };
 
 /**
@@ -133,7 +122,7 @@ class ExtensionManager {
                 return Promise.reject(new Error(message));
             }
 
-            const extension = builtinExtensions[extensionURL];
+            const extension = builtinExtensions[extensionURL]();
             const extensionInstance = new extension(this.runtime);
             return this._registerInternalExtension(extensionInstance).then(serviceName => {
                 this._loadedExtensions.set(extensionURL, serviceName);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -8,12 +8,8 @@ const ExtensionManager = require('./extension-support/extension-manager');
 const log = require('./util/log');
 const MathUtil = require('./util/math-util');
 const Runtime = require('./engine/runtime');
-const {SB1File, ValidationError} = require('scratch-sb1-converter');
-const sb2 = require('./serialization/sb2');
-const sb3 = require('./serialization/sb3');
 const StringUtil = require('./util/string-util');
 const formatMessage = require('format-message');
-const validate = require('scratch-parser');
 
 const Variable = require('./engine/variable');
 const newBlockIds = require('./util/new-block-ids');
@@ -297,6 +293,7 @@ class VirtualMachine extends EventEmitter {
         }
 
         const validationPromise = new Promise((resolve, reject) => {
+            const validate = require('scratch-parser');
             // The second argument of false below indicates to the validator that the
             // input should be parsed/validated as an entire project (and not a single sprite)
             validate(input, false, (error, res) => {
@@ -305,6 +302,8 @@ class VirtualMachine extends EventEmitter {
             });
         })
             .catch(error => {
+                const {SB1File, ValidationError} = require('scratch-sb1-converter');
+
                 try {
                     const sb1 = new SB1File(input);
                     const json = sb1.json;
@@ -410,6 +409,8 @@ class VirtualMachine extends EventEmitter {
      * specified by optZipType or blob by default.
      */
     exportSprite (targetId, optZipType) {
+        const sb3 = require('./serialization/sb3');
+
         const soundDescs = serializeSounds(this.runtime, targetId);
         const costumeDescs = serializeCostumes(this.runtime, targetId);
         const spriteJson = StringUtil.stringify(sb3.serialize(this.runtime, targetId));
@@ -432,6 +433,7 @@ class VirtualMachine extends EventEmitter {
      * @return {string} Serialized state of the runtime.
      */
     toJSON () {
+        const sb3 = require('./serialization/sb3');
         return StringUtil.stringify(sb3.serialize(this.runtime));
     }
 
@@ -461,9 +463,11 @@ class VirtualMachine extends EventEmitter {
         const deserializePromise = function () {
             const projectVersion = projectJSON.projectVersion;
             if (projectVersion === 2) {
+                const sb2 = require('./serialization/sb2');
                 return sb2.deserialize(projectJSON, runtime, false, zip);
             }
             if (projectVersion === 3) {
+                const sb3 = require('./serialization/sb3');
                 return sb3.deserialize(projectJSON, runtime, zip);
             }
             return Promise.reject('Unable to verify Scratch Project version.');
@@ -553,6 +557,7 @@ class VirtualMachine extends EventEmitter {
         }
 
         const validationPromise = new Promise((resolve, reject) => {
+            const validate = require('scratch-parser');
             // The second argument of true below indicates to the parser/validator
             // that the given input should be treated as a single sprite and not
             // an entire project
@@ -592,6 +597,7 @@ class VirtualMachine extends EventEmitter {
     _addSprite2 (sprite, zip) {
         // Validate & parse
 
+        const sb2 = require('./serialization/sb2');
         return sb2.deserialize(sprite, this.runtime, true, zip)
             .then(({targets, extensions}) =>
                 this.installTargets(targets, extensions, false));
@@ -605,7 +611,7 @@ class VirtualMachine extends EventEmitter {
      */
     _addSprite3 (sprite, zip) {
         // Validate & parse
-
+        const sb3 = require('./serialization/sb3');
         return sb3
             .deserialize(sprite, this.runtime, zip, true)
             .then(({targets, extensions}) => this.installTargets(targets, extensions, false));
@@ -1187,6 +1193,8 @@ class VirtualMachine extends EventEmitter {
      * @return {!Promise} Promise that resolves when the extensions and blocks have been added.
      */
     shareBlocksToTarget (blocks, targetId, optFromTargetId) {
+        const sb3 = require('./serialization/sb3');
+
         const copiedBlocks = JSON.parse(JSON.stringify(blocks));
         newBlockIds(copiedBlocks);
         const target = this.runtime.getTargetById(targetId);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1,4 +1,10 @@
-const TextEncoder = require('text-encoding').TextEncoder;
+let _TextEncoder;
+if (typeof TextEncoder === 'undefined') {
+    _TextEncoder = require('text-encoding').TextEncoder;
+} else {
+    /* global TextEncoder */
+    _TextEncoder = TextEncoder;
+}
 const EventEmitter = require('events');
 const JSZip = require('jszip');
 
@@ -918,7 +924,7 @@ class VirtualMachine extends EventEmitter {
         costume.asset = storage.createAsset(
             storage.AssetType.ImageVector,
             costume.dataFormat,
-            (new TextEncoder()).encode(svg),
+            (new _TextEncoder()).encode(svg),
             null,
             true // generate md5
         );


### PR DESCRIPTION
### Resolves

Decrease average time evaluating javascript and data embedded in javascript.

### Proposed Changes

Depends on https://github.com/LLK/scratch-vm/pull/1944.

- Evaluate the following code on demand
  - extensions
  - scratch-parser
  - sb1, sb2, and sb3 (de)serialization
  - text-encoding

### Reason for Changes

Built Scratch javascript files are multiple megabytes in size. To load a Scratch project, that code must be downloaded or fetched from a cache, compiled, and evaluated before a project can starting loading by downloading its data file. If we can start that later download earlier Scratch will seem to load faster. One step we can make do that is to evaluate parts of Scratch later.

The selected elements of Scratch whose evaluation is delayed in this pull request either are not needed by all systems (text-encoding is a polyfill) or not needed by all projects (extensions, sb1, sb2, and sb3 (de)serialization) or not needed to download the data.

The following is the amount of (unminified) code whose parsing is delayed here:
- music extension data: ~1.9MB
- extensions: 355KB
- scratch-parser: 410KB
- text-encoding: 616KB
- sb1, sb2, sb3 (de)serialization: 224KB

Total: ~3.5MB

This work could be taken further by putting the extensions, parser, and serialization code in their own javascript chunk and loading it in a script tag following the main js tag. This would reduce the amount of code that must be downloaded and compiled before the project can initialize loading.

### Benchmark Data

You can compare with baseline numbers from https://github.com/LLK/scratch-vm/pull/1944.


project id | platform | run 1 | run 2 | run 3 | run 4 | run 5 | avg
--------- | ------ | ---- | ---- | ---- | ---- | ---- | ----
169401431 | chrome | 7051 | 6714 | 7551 | 7214 | 7448 | 7195.6
169401431 | firefox | 5041 | 4180 | 4030 | 3783 | 3878 | 4182.4
169401431 | safari | 7687 | 7049 | 7153 | 7498 | 7166 | 7310.6
169401431 | book | 20750 | 19229 | 19645 | 18672 | 18504 | 19360
173918262 | chrome | 1190 | 1032 | 1022 | 967 | 1098 | 1061.8
173918262 | firefox | 1328 | 1092 | 1150 | 1159 | 1199 | 1185.6
173918262 | safari | 1295 | 1199 | 1120 | 1051 | 1111 | 1155.2
173918262 | book | 3291 | 2621 | 2694 | 2610 | 3081 | 2859.4
173918262 | pi | 24826 | 18603 | 18489 | 14952 | 14560 | 18286
