### PR TITLE
Update, re-order and clean up Vernier Force & Accel extension blocks

### DIFF
--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -44,6 +44,12 @@ const MOVED_THRESHOLD = 3;
 const SHAKEN_THRESHOLD = 30;
 
 /**
+ * Threshold for acceleration magnitude, to check if we are facing up.
+ * @type {number}
+ */
+const FACING_THRESHOLD = 9;
+
+/**
  * Acceleration due to gravity, in m/s^2.
  * @type {number}
  */
@@ -754,9 +760,9 @@ class Scratch3GdxForBlocks {
     isFacing (args) {
         switch (args.FACING) {
         case FaceValues.UP:
-            return this._peripheral.getAccelerationZ() > GRAVITY;
+            return this._peripheral.getAccelerationZ() > FACING_THRESHOLD;
         case FaceValues.DOWN:
-            return this._peripheral.getAccelerationZ() < GRAVITY * -1;
+            return this._peripheral.getAccelerationZ() < FACING_THRESHOLD * -1;
         default:
             log.warn(`Unknown direction in isFacing: ${args.FACING}`);
         }

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -50,16 +50,16 @@ const SHAKEN_THRESHOLD = 30;
 const FACING_THRESHOLD = 9;
 
 /**
+ * Threshold for acceleration magnitude, below which we are in freefall.
+ * @type {number}
+ */
+const FREEFALL_THRESHOLD = 0.5;
+
+/**
  * Acceleration due to gravity, in m/s^2.
  * @type {number}
  */
 const GRAVITY = 9.8;
-
-/**
- * Threshold for acceleration magnitude, below which we are in freefall.
- * @type {number}
- */
-const FREEFALL = 0.5;
 
 /**
  * Manage communication with a GDX-FOR peripheral over a Scratch Link client socket.
@@ -769,7 +769,7 @@ class Scratch3GdxForBlocks {
     }
 
     isFreeFalling () {
-        return this.accelMagnitude() < FREEFALL;
+        return this.accelMagnitude() < FREEFALL_THRESHOLD;
     }
 }
 

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -755,14 +755,15 @@ class Scratch3GdxForBlocks {
 
     isFacing (args) {
         switch (args.FACING) {
-        case 'up':
-            return this._peripheral.getAccelerationZ() > 9;
-        case 'down':
-            return this._peripheral.getAccelerationZ() < -9;
+        case FaceValues.UP:
+            return this._peripheral.getAccelerationZ() > GRAVITY;
+        case FaceValues.DOWN:
+            return this._peripheral.getAccelerationZ() < GRAVITY * -1;
         default:
             log.warn(`Unknown direction in isFacing: ${args.FACING}`);
         }
     }
+
     isFreeFalling () {
         return this.accelMagnitude() < FREEFALL;
     }

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -312,8 +312,7 @@ class GdxFor {
 
     _getAcceleration (sensorNum) {
         if (!this._canReadSensors()) return 0;
-        let val = this._device.getSensor(sensorNum).value;
-        val = Math.round(val);
+        const val = this._device.getSensor(sensorNum).value;
         return val;
     }
 
@@ -335,7 +334,6 @@ class GdxFor {
         val = MathUtil.radToDeg(val);
         const framesPerSec = 1000 / this._runtime.currentStepTime;
         val = val / framesPerSec; // convert to from degrees per sec to degrees per frame
-        val = Math.round(val);
         val = val * -1;
         return val;
     }
@@ -708,11 +706,11 @@ class Scratch3GdxForBlocks {
     getSpinSpeed (args) {
         switch (args.DIRECTION) {
         case AxisValues.X:
-            return this._peripheral.getSpinSpeedX();
+            return Math.round(this._peripheral.getSpinSpeedX());
         case AxisValues.Y:
-            return this._peripheral.getSpinSpeedY();
+            return Math.round(this._peripheral.getSpinSpeedY());
         case AxisValues.Z:
-            return this._peripheral.getSpinSpeedZ();
+            return Math.round(this._peripheral.getSpinSpeedZ());
         default:
             log.warn(`Unknown direction in getSpinSpeed: ${args.DIRECTION}`);
         }

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -384,6 +384,16 @@ const AxisValues = {
 };
 
 /**
+ * Enum for face menu options.
+ * @readonly
+ * @enum {string}
+ */
+const FaceValues = {
+    UP: 'up',
+    DOWN: 'down'
+};
+
+/**
  * Scratch 3.0 blocks to interact with a GDX-FOR peripheral.
  */
 class Scratch3GdxForBlocks {
@@ -435,12 +445,20 @@ class Scratch3GdxForBlocks {
     get FACE_MENU () {
         return [
             {
-                text: 'up',
-                value: 'up'
+                text: formatMessage({
+                    id: 'gdxfor.up',
+                    default: 'up',
+                    description: 'the sensor is facing up'
+                }),
+                value: FaceValues.UP
             },
             {
-                text: 'down',
-                value: 'down'
+                text: formatMessage({
+                    id: 'gdxfor.down',
+                    default: 'down',
+                    description: 'the sensor is facing down'
+                }),
+                value: FaceValues.DOWN
             }
         ];
     }
@@ -621,7 +639,7 @@ class Scratch3GdxForBlocks {
                         FACING: {
                             type: ArgumentType.STRING,
                             menu: 'faceOptions',
-                            defaultValue: 'up'
+                            defaultValue: FaceValues.UP
                         }
                     }
                 },

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -318,24 +318,26 @@ class GdxFor {
     }
 
     getSpinSpeedX () {
-        if (this._canReadSensors()) {
-            return this._device.getSensor(5).value * (180 / Math.PI);
-        }
-        return 0;
+        return this._getSpinSpeed(5);
     }
 
     getSpinSpeedY () {
-        if (this._canReadSensors()) {
-            return this._device.getSensor(6).value * (180 / Math.PI);
-        }
-        return 0;
+        return this._getSpinSpeed(6);
     }
 
     getSpinSpeedZ () {
-        if (this._canReadSensors()) {
-            return this._device.getSensor(7).value * (180 / Math.PI);
-        }
-        return 0;
+        return this._getSpinSpeed(7);
+    }
+
+    _getSpinSpeed (sensorNum) {
+        if (!this._canReadSensors()) return 0;
+        let val = this._device.getSensor(sensorNum).value;
+        val = MathUtil.radToDeg(val);
+        const framesPerSec = 1000 / this._runtime.currentStepTime;
+        val = val / framesPerSec; // convert to from degrees per sec to degrees per frame
+        val = Math.round(val);
+        val = val * -1;
+        return val;
     }
 }
 


### PR DESCRIPTION
- Use constants for gesture thresholds and gravity
- Swap tilt x and y calculations
- Re-factor logic in the peripheral for scaling accel and spin speed values 
- Report spin speed in degrees per frame
- Use enums for all string menu values
- Localize menu text where appropriate
- Re-order blocks