### PR TITLE
Declare const once to be reused in for loop

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1461,6 +1461,8 @@ class Runtime extends EventEmitter {
         }
         const instance = this;
         const newThreads = [];
+        // Look up metadata for the relevant hat.
+        const hatMeta = instance._hats[requestedHatOpcode];
 
         for (const opts in optMatchFields) {
             if (!optMatchFields.hasOwnProperty(opts)) continue;
@@ -1507,8 +1509,6 @@ class Runtime extends EventEmitter {
                 }
             }
 
-            // Look up metadata for the relevant hat.
-            const hatMeta = instance._hats[requestedHatOpcode];
             if (hatMeta.restartExistingThreads) {
                 // If `restartExistingThreads` is true, we should stop
                 // any existing threads starting with the top block.


### PR DESCRIPTION
### Resolves

No issues exists for this, but @mzgoddard and I noticed a small potential performance improvement while working on other issues. 

### Proposed Changes

Move declaring `hatMeta` out of a for-loop since its value doesn't need to be set or updated within those loops. 

### Reason for Changes

Performance benefit by avoiding redeclaring a variable more than once. 

