### PR TITLE
Add a utility for giving blocks new IDs, use it for sharing blocks.

### DIFF
--- a/src/util/new-block-ids.js
+++ b/src/util/new-block-ids.js
@@ -1,0 +1,33 @@
+const uid = require('./uid');
+
+/**
+ * Mutate the given blocks to have new IDs and update all internal ID references.
+ * Does not return anything to make it clear that the blocks are updated in-place.
+ * @param {array} blocks - blocks to be mutated.
+ */
+module.exports = blocks => {
+    const oldToNew = {};
+
+    // First update all top-level IDs and create old-to-new mapping
+    for (let i = 0; i < blocks.length; i++) {
+        const newId = uid();
+        const oldId = blocks[i].id;
+        blocks[i].id = oldToNew[oldId] = newId;
+    }
+
+    // Then go back through and update inputs (block/shadow)
+    // and next/parent properties
+    for (let i = 0; i < blocks.length; i++) {
+        for (const key in blocks[i].inputs) {
+            const input = blocks[i].inputs[key];
+            input.block = oldToNew[input.block];
+            input.shadow = oldToNew[input.shadow];
+        }
+        if (blocks[i].parent) {
+            blocks[i].parent = oldToNew[blocks[i].parent];
+        }
+        if (blocks[i].next) {
+            blocks[i].next = oldToNew[blocks[i].next];
+        }
+    }
+};

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -16,6 +16,7 @@ const formatMessage = require('format-message');
 const validate = require('scratch-parser');
 
 const Variable = require('./engine/variable');
+const newBlockIds = require('./util/new-block-ids');
 
 const {loadCostume} = require('./import/load-costume.js');
 const {loadSound} = require('./import/load-sound.js');
@@ -1178,6 +1179,7 @@ class VirtualMachine extends EventEmitter {
      */
     shareBlocksToTarget (blocks, targetId, optFromTargetId) {
         const copiedBlocks = JSON.parse(JSON.stringify(blocks));
+        newBlockIds(copiedBlocks);
         const target = this.runtime.getTargetById(targetId);
 
         if (optFromTargetId) {

--- a/test/fixtures/simple-stack.js
+++ b/test/fixtures/simple-stack.js
@@ -1,0 +1,65 @@
+module.exports = [
+    {
+        id: '1ZGd(W8DvU?vI1RN)e0E',
+        opcode: 'motion_goto',
+        inputs: {
+            TO: {
+                name: 'TO',
+                block: 'Ht(rOKMe0@sB3n4(b3;=',
+                shadow: '-C=c-_TI_7d(l3ii2[wh'
+            }
+        },
+        fields: {
+
+        },
+        next: 'l.JBk`WcXE+A@i9y1tCU',
+        topLevel: true,
+        parent: null,
+        shadow: false
+    },
+    {
+        id: 'Ht(rOKMe0@sB3n4(b3;=',
+        opcode: 'looks_size',
+        inputs: {
+
+        },
+        fields: {
+
+        },
+        next: null,
+        topLevel: false,
+        parent: '1ZGd(W8DvU?vI1RN)e0E',
+        shadow: false
+    },
+    {
+        id: '-C=c-_TI_7d(l3ii2[wh',
+        opcode: 'motion_goto_menu',
+        inputs: {
+
+        },
+        fields: {
+            TO: {
+                name: 'TO',
+                value: '_random_'
+            }
+        },
+        next: null,
+        topLevel: false,
+        parent: '1ZGd(W8DvU?vI1RN)e0E',
+        shadow: true
+    },
+    {
+        id: 'l.JBk`WcXE+A@i9y1tCU',
+        opcode: 'sound_stopallsounds',
+        inputs: {
+
+        },
+        fields: {
+
+        },
+        next: null,
+        topLevel: false,
+        parent: '1ZGd(W8DvU?vI1RN)e0E',
+        shadow: false
+    }
+];

--- a/test/unit/util_new-block-ids.js
+++ b/test/unit/util_new-block-ids.js
@@ -23,7 +23,7 @@ tap.beforeEach(done => {
  *      1: looks_size (parent: 0)
  *      2: obscured shadow for moveTo input (parent: 0)
  *      3: stopAllSounds (parent: 0)
- * Inspect fixtures/blocks for the full object.
+ * Inspect fixtures/simple-stack for the full object.
  */
 
 test('top-level block IDs have all changed', t => {

--- a/test/unit/util_new-block-ids.js
+++ b/test/unit/util_new-block-ids.js
@@ -1,0 +1,64 @@
+const newBlockIds = require('../../src/util/new-block-ids');
+const simpleStack = require('../fixtures/simple-stack');
+const tap = require('tap');
+const test = tap.test;
+
+let originals;
+let newBlocks;
+
+tap.beforeEach(done => {
+    originals = simpleStack;
+    // Will be mutated so make a copy first
+    newBlocks = JSON.parse(JSON.stringify(simpleStack));
+    newBlockIds(newBlocks);
+    done();
+});
+
+
+/**
+ * The structure of the simple stack is:
+ *      moveTo (looks_size) -> stopAllSounds
+ * The list of blocks is
+ *      0: moveTo (TO input block: 1, shadow: 2)
+ *      1: looks_size (parent: 0)
+ *      2: obscured shadow for moveTo input (parent: 0)
+ *      3: stopAllSounds (parent: 0)
+ * Inspect fixtures/blocks for the full object.
+ */
+
+test('top-level block IDs have all changed', t => {
+    newBlocks.forEach((block, i) => {
+        t.notEqual(block.id, originals[i].id);
+    });
+    t.end();
+});
+
+test('input reference is maintained on parent for attached block', t => {
+    t.equal(newBlocks[0].inputs.TO.block, newBlocks[1].id);
+    t.end();
+});
+
+test('input reference is maintained on parent for obscured shadow', t => {
+    t.equal(newBlocks[0].inputs.TO.shadow, newBlocks[2].id);
+    t.end();
+});
+
+test('parent reference is maintained for attached input', t => {
+    t.equal(newBlocks[1].parent, newBlocks[0].id);
+    t.end();
+});
+
+test('parent reference is maintained for obscured shadow', t => {
+    t.equal(newBlocks[2].parent, newBlocks[0].id);
+    t.end();
+});
+
+test('parent reference is maintained for next block', t => {
+    t.equal(newBlocks[3].parent, newBlocks[0].id);
+    t.end();
+});
+
+test('next reference is maintained for previous block', t => {
+    t.equal(newBlocks[0].next, newBlocks[3].id);
+    t.end();
+});

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -786,10 +786,14 @@ test('shareBlocksToTarget shares global variables without any name changes', t =
         t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
         t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
 
-        t.type(stage.blocks.getBlock('a block'), 'object');
-        t.type(stage.blocks.getBlock('a block').fields, 'object');
-        t.type(stage.blocks.getBlock('a block').fields.VARIABLE, 'object');
-        t.equal(stage.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+        const newBlockId = Object.keys(stage.blocks._blocks)[0];
+        t.type(stage.blocks.getBlock(newBlockId), 'object');
+        t.type(stage.blocks.getBlock(newBlockId).fields, 'object');
+        t.type(stage.blocks.getBlock(newBlockId).fields.VARIABLE, 'object');
+        t.equal(stage.blocks.getBlock(newBlockId).fields.VARIABLE.id, 'mock var id');
+
+        // Verify the shared block id is different
+        t.notEqual(newBlockId, 'a block');
 
         // Verify that the variables haven't changed, the variable still exists on the
         // stage, it should still have the same name and value, and there should be
@@ -845,10 +849,11 @@ test('shareBlocksToTarget shares a local variable to the stage, creating a globa
         t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
         t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
 
-        t.type(stage.blocks.getBlock('a block'), 'object');
-        t.type(stage.blocks.getBlock('a block').fields, 'object');
-        t.type(stage.blocks.getBlock('a block').fields.VARIABLE, 'object');
-        t.equal(stage.blocks.getBlock('a block').fields.VARIABLE.id, 'StageVarFromLocal_mock var id');
+        const newBlockId = Object.keys(stage.blocks._blocks)[0];
+        t.type(stage.blocks.getBlock(newBlockId), 'object');
+        t.type(stage.blocks.getBlock(newBlockId).fields, 'object');
+        t.type(stage.blocks.getBlock(newBlockId).fields.VARIABLE, 'object');
+        t.equal(stage.blocks.getBlock(newBlockId).fields.VARIABLE.id, 'StageVarFromLocal_mock var id');
 
         // Verify that a new global variable was created, the old one still exists on
         // the target and still has the same name and value, and the new one has
@@ -919,10 +924,11 @@ test('shareBlocksToTarget chooses a fresh name for a new global variable checkin
         t.type(target.blocks.getBlock('a block').fields.VARIABLE, 'object');
         t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
 
-        t.type(stage.blocks.getBlock('a block'), 'object');
-        t.type(stage.blocks.getBlock('a block').fields, 'object');
-        t.type(stage.blocks.getBlock('a block').fields.VARIABLE, 'object');
-        t.equal(stage.blocks.getBlock('a block').fields.VARIABLE.id, 'StageVarFromLocal_mock var id');
+        const newBlockId = Object.keys(stage.blocks._blocks)[0];
+        t.type(stage.blocks.getBlock(newBlockId), 'object');
+        t.type(stage.blocks.getBlock(newBlockId).fields, 'object');
+        t.type(stage.blocks.getBlock(newBlockId).fields.VARIABLE, 'object');
+        t.equal(stage.blocks.getBlock(newBlockId).fields.VARIABLE.id, 'StageVarFromLocal_mock var id');
 
         // Verify that a new global variable was created, the old one still exists on
         // the target and still has the same name and value, and the new one has


### PR DESCRIPTION
This is the VM port of https://github.com/LLK/scratch-gui/pull/4468, see that PR for more description.

@kchadha I thought about whether we want to put this into the block container, but I think this utility is a better place for it.