### PR TITLE
update text-encoding to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12222,13 +12222,6 @@
         "js-md5": "0.7.3",
         "minilog": "3.1.0",
         "text-encoding": "^0.7.0"
-      },
-      "dependencies": {
-        "text-encoding": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-          "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
-        }
       }
     },
     "scratch-storage": {
@@ -12249,12 +12242,6 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
           "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==",
-          "dev": true
-        },
-        "text-encoding": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-          "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
           "dev": true
         }
       }
@@ -13492,9 +13479,9 @@
       "dev": true
     },
     "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "scratch-sb1-converter": "0.2.7",
     "scratch-translate-extension-languages": "0.0.20181205140428",
     "socket.io-client": "2.0.4",
-    "text-encoding": "0.6.4",
+    "text-encoding": "0.7.0",
     "worker-loader": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Resolves

Faster project loading and less memory usage.

### Proposed Changes

Update to latest text-encoding.

### Reason for Changes

scratch-gui depends on text-encoding@0.7.0. If scratch-vm depends on 0.6.4, gui has to build an extra copy of text-encoding, one for gui (and other modules using 0.7.0, like scratch-storage) and another for scratch-vm, and one for scratch-sb1-converter. This increases the size of the JS build and if text-encoding is used on a system that needs it, it will be evaluated twice and split up the work decreasing the change the JS VM optimizes the text-encoding implementation.
