### PR TITLE
Vernier gdxfor "falling?" report false when not connected

### DIFF
--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -822,6 +822,13 @@ class Scratch3GdxForBlocks {
     }
 
     isFreeFalling () {
+        // When the peripheral is not connected, the acceleration magnitude
+        // is 0 instead of ~9.8, which ends up calculating as a positive
+        // free fall; so we need to return 'false' here to prevent returning 'true'.
+        if (!this._peripheral.isConnected()) {
+            return false;
+        }
+
         const accelMag = this.accelMagnitude();
         const spinMag = this.spinMagnitude();
 


### PR DESCRIPTION
### Resolves

Resolves #1977: Vernier gdxfor extension "falling?" reports true while hardware disconnected.
