### PR TITLE
Vernier gdxfor tilt values 0 when disconnected

### DIFF
--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -775,6 +775,13 @@ class Scratch3GdxForBlocks {
     }
 
     getTilt (args) {
+        // When the peripheral is not connected, the acceleration magnitude
+        // is 0 instead of ~9.8, which ends up registering a tilt value; so
+        // we need to return 0 here to prevent returning a tilt value.
+        if (!this._peripheral.isConnected()) {
+            return 0;
+        }
+
         switch (args.TILT) {
         case TiltAxisValues.FRONT:
             return Math.round(this._peripheral.getTiltFrontBack(false));

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -775,9 +775,8 @@ class Scratch3GdxForBlocks {
     }
 
     getTilt (args) {
-        // When the peripheral is not connected, the acceleration magnitude
-        // is 0 instead of ~9.8, which ends up registering a tilt value; so
-        // we need to return 0 here to prevent returning a tilt value.
+        // Tilt values are calculated using acceleration due to gravity,
+        // so we need to return 0 when the peripheral is not connected.
         if (!this._peripheral.isConnected()) {
             return 0;
         }


### PR DESCRIPTION
### Resolves

Resolves #1988: Vernier gdxfor tilt values should be 0 when disconnected
