### PR TITLE
Fix WeDo2 'motor on for' duration

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1290,8 +1290,9 @@ class Scratch3WeDo2Blocks {
                 }
             });
 
-            // Run for some time even when no motor is connected
-            setTimeout(resolve, durationMS);
+            // Run for some time even when no motor is connected, include
+            // the time needed to brake the motor
+            setTimeout(resolve, durationMS + WeDo2Motor.BRAKE_TIME_MS);
         });
     }
 


### PR DESCRIPTION
### Resolves

Resolves #1616: WeDo2: 'turn motor for 1 sec block' acts strange in forever loop
