### PR TITLE
Allow primitives to have "cancel" behavior; cancel "play sound until done" on thread retire

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -143,6 +143,16 @@ class Scratch3SoundBlocks {
         };
     }
 
+    /**
+     * Retrieve the cancel block primitives implemented by this package.
+     * @return {object.<string, FUnction>} Mapping of opcode to Function.
+     */
+    getCancelPrimitives () {
+        return {
+            sound_playuntildone: this.cancelPlaySoundAndWait
+        };
+    }
+
     getMonitored () {
         return {
             sound_volume: {
@@ -162,11 +172,10 @@ class Scratch3SoundBlocks {
     }
 
     _playSound (args, util, storeWaiting) {
-        const index = this._getSoundIndex(args.SOUND_MENU, util);
-        if (index >= 0) {
+        const soundId = this._getSoundId(args.SOUND_MENU, util);
+        if (soundId) {
             const {target} = util;
             const {sprite} = target;
-            const {soundId} = sprite.sounds[index];
             if (sprite.soundBank) {
                 if (storeWaiting === STORE_WAITING) {
                     this._addWaitingSound(target.id, soundId);
@@ -176,6 +185,26 @@ class Scratch3SoundBlocks {
                 return sprite.soundBank.playSound(target, soundId);
             }
         }
+    }
+
+    cancelPlaySoundAndWait (args, util) {
+        const soundId = this._getSoundId(args.SOUND_MENU, util);
+        const {target} = util;
+        const {sprite} = target;
+        if (sprite.soundBank) {
+            sprite.soundBank.stop(target, soundId);
+        }
+    }
+
+    _getSoundId (indexArg, util) {
+        const index = this._getSoundIndex(indexArg, util);
+        if (index >= 0) {
+            const {target} = util;
+            const {sprite} = target;
+            const {soundId} = sprite.sounds[index];
+            return soundId;
+        }
+        return null;
     }
 
     _addWaitingSound (targetId, soundId) {

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -593,6 +593,10 @@ const cancelExecution = function (sequencer, thread) {
     const currentBlockId = thread.peekStack();
     const {blockCached} = getBlockCached(currentBlockId, thread, runtime);
 
+    if (!blockCached) {
+        return;
+    }
+
     // Only the last op is actually a block and not an input; it is the one
     // that may have a cancel implementation.
     const ops = blockCached._ops;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -208,6 +208,12 @@ class Runtime extends EventEmitter {
         this._primitives = {};
 
         /**
+         * Map to look up a block primitive's "cancel" implementation function by its opcode.
+         * @type {Object.<string, Function>}
+         */
+        this._cancelPrimitives = {};
+
+        /**
          * Map to look up all block information by extended opcode.
          * @type {Array.<CategoryInfo>}
          * @private
@@ -723,6 +729,15 @@ class Runtime extends EventEmitter {
                     for (const op in packagePrimitives) {
                         if (packagePrimitives.hasOwnProperty(op)) {
                             this._primitives[op] =
+                                packagePrimitives[op].bind(packageObject);
+                        }
+                    }
+                }
+                if (packageObject.getCancelPrimitives) {
+                    const packagePrimitives = packageObject.getCancelPrimitives();
+                    for (const op in packagePrimitives) {
+                        if (packagePrimitives.hasOwnProperty(op)) {
+                            this._cancelPrimitives[op] =
                                 packagePrimitives[op].bind(packageObject);
                         }
                     }
@@ -1312,6 +1327,15 @@ class Runtime extends EventEmitter {
      */
     getOpcodeFunction (opcode) {
         return this._primitives[opcode];
+    }
+
+    /**
+     * Retrieve the function associated with cancelling a call to the given opcode.
+     * @param {!string} opcode The opcode to look up.
+     * @return {Function} The function which implements cancelling the opcode.
+     */
+    getCancelOpcodeFunction (opcode) {
+        return this._cancelPrimitives[opcode];
     }
 
     /**

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -350,6 +350,11 @@ class Sequencer {
      * @param {!Thread} thread Thread object to retire.
      */
     retireThread (thread) {
+        // Run the currently executing block's "cancel" function if present.
+        // This is used to cancel actions that have not yet finished, such as
+        // playing a sound or spinning a motor.
+        execute.cancelExecution(this, thread);
+
         thread.stack = [];
         thread.stackFrame = [];
         thread.requestScriptGlowInFrame = false;


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-audio#7. Closes #40 (as this PR provides an implementation).

### Proposed Changes

At a high level, this PR allows classes such as `Scratch3SoundBlocks` to specify behavior that "cancels" an actively executing block. These functions are called when you click a script that is already running, and its active block is one of that opcode. The "play sound until done" block makes use of this; if you retire a thread where it is the active block, the sound it started will be stopped.

Internally, instances of `BlockCached` now keep track of their "cancel block" function alongside the main block function. This is referred to when a thread is retired; if present, it's called just like the normal block function.

### Reason for Changes

When a script is executing, it is highlighted with a yellow "glow" bordering its outline. If you click a script while it's executing, it will lose this glow and stop running further blocks in the script. The implication, to the user, is that the script is stopped. Internally, this is what is happening. But, before this PR, "stopping" a thread did not also mean stopping active side-effects. Intuitively, side-effects should be stopped when a script is stopped; otherwise it does not seem so much like you are *stopping* the the script.

This PR doesn't (currently) implement "cancel" blocks into extensions, but it provides the basic code. Once it's implemented, blocks like "play note for beats" and "turn motor on for (N) seconds" can be changed so that their side-effects are cancelled as soon as the thread is retired.

### Test Coverage

I tested this manually. I'm not certain if unit tests are wanted here? I saw that there don't seem to be any for `execute.js` so far, only the higher-level classes (e.g. Thread, Sequencer); this PR doesn't add much behavior to those classes.