### PR TITLE
Depend on uglifyjs-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "stats.js": "^0.17.0",
     "tap": "^12.0.1",
     "tiny-worker": "^2.1.1",
+    "uglifyjs-webpack-plugin": "1.2.7",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5"


### PR DESCRIPTION
### Resolves

uglifyjs-webpack-plugin is used in webpack.config.js but does not appear in package.json.

### Proposed Changes

Depend on uglifyjs-webpack-plugin in package.json.

### Reason for Changes

uglifyjs-webpack-plugin is used in webpack.config.js. Builds on travis in and local development environments work because package-lock.json has uglifyjs-webpack-plugin raised to the root dependency level of the hierarchy. Something vm depends on depends on uglifyjs-webpack-plugin but vm uses uglifyjs-webpack-plugin directly. If the something stops depending and uglifyjs-webpack-plugin and package-lock.json is updated that top level uglifyjs-webpack-plugin will depart. Or something else starts depending on uglifyjs-webpack-plugin with a different version, and the root version will move to local level for its dependent.

Anyways, just avoiding uglifyjs-webpack-plugin disappearing from node_modules.

### Test Coverage

VM builds.
