### PR TITLE
Load Vernier force and accel extensions

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -19,7 +19,7 @@ const Scratch3Ev3Blocks = require('../extensions/scratch3_ev3');
 const Scratch3MakeyMakeyBlocks = require('../extensions/scratch3_makeymakey');
 // todo: only load this extension once we have a compatible way to load its
 // Vernier module dependency.
-// const Scratch3GdxForBlocks = require('../extensions/scratch3_gdx_for');
+const Scratch3GdxForBlocks = require('../extensions/scratch3_gdx_for');
 
 const builtinExtensions = {
     pen: Scratch3PenBlocks,
@@ -31,8 +31,8 @@ const builtinExtensions = {
     videoSensing: Scratch3VideoSensingBlocks,
     speech2text: Scratch3Speech2TextBlocks,
     ev3: Scratch3Ev3Blocks,
-    makeymakey: Scratch3MakeyMakeyBlocks
-    // gdxfor: Scratch3GdxForBlocks
+    makeymakey: Scratch3MakeyMakeyBlocks,
+    gdxfor: Scratch3GdxForBlocks
 };
 
 /**

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -17,8 +17,6 @@ const Scratch3VideoSensingBlocks = require('../extensions/scratch3_video_sensing
 const Scratch3Speech2TextBlocks = require('../extensions/scratch3_speech2text');
 const Scratch3Ev3Blocks = require('../extensions/scratch3_ev3');
 const Scratch3MakeyMakeyBlocks = require('../extensions/scratch3_makeymakey');
-// todo: only load this extension once we have a compatible way to load its
-// Vernier module dependency.
 const Scratch3GdxForBlocks = require('../extensions/scratch3_gdx_for');
 
 const builtinExtensions = {


### PR DESCRIPTION
Previously, we had commented out the extension manager lines that loaded the Vernier gdxfor extension, due to a problem building GUI into WWW. This was due to an incompatibility with the Vernier GoDirect node module required by the extension which has now been resolved.

@rschamp and I tested this change by deploying to staging and confirming that the extension loads.

We verified that staging loads the editor and can load the extension without problems on:

- [x] Mac Chrome 
- [x] Mac Safari
- [x] Mac Firefox
- [x] Windows Chrome
- [ ] Windows Edge
- [x] Windows Firefox
- [x] iOS safari
- [x] Android Chrome