### PR TITLE
Don't update the whole workspace when "of" block's object input changes

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -581,19 +581,6 @@ class Blocks {
             } else {
                 // Changing the value in a dropdown
                 block.fields[args.name].value = args.value;
-
-                // The selected item in the sensing of block menu needs to change based on the
-                // selected target.  Set it to the first item in the menu list.
-                // TODO: (#1787)
-                if (block.opcode === 'sensing_of_object_menu') {
-                    if (block.fields.OBJECT.value === '_stage_') {
-                        this._blocks[block.parent].fields.PROPERTY.value = 'backdrop #';
-                    } else {
-                        this._blocks[block.parent].fields.PROPERTY.value = 'x position';
-                    }
-                    this.runtime.requestBlocksUpdate();
-                }
-
                 const flyoutBlock = block.shadow && block.parent ? this._blocks[block.parent] : block;
                 if (flyoutBlock.isMonitored) {
                     this.runtime.requestUpdateMonitor(Map({


### PR DESCRIPTION
### Resolves

Towards LLK/scratch-gui#4400. Should be merged alongside LLK/scratch-gui#4613!

### Proposed Changes

This PR removes the now-unnecessary code for updating the entire workspace when an `of` block's `OBJECT` input changes.

### Reason for Changes

See LLK/scratch-gui#4613 for information!

### Test Coverage

Tested manually.