### PR TITLE
Rate limiting for WeDo2 using TaskQueue

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1282,7 +1282,7 @@ class Scratch3WeDo2Blocks {
                 // Run for some time even when no motor is connected
                 setTimeout(resolve, durationMS);
             });
-        }).catch(e => {
+        }).catch(() => {
             // console.log('*** CATCH MOTOR_ON_FOR REJECTION');
             // console.log(e);
         });
@@ -1304,7 +1304,7 @@ class Scratch3WeDo2Blocks {
                     motor.turnOn();
                 }
             });
-        }).catch(e => {
+        }).catch(() => {
             // console.log('*** CATCH MOTOR_ON REJECTION');
             // console.log(e);
         });
@@ -1326,7 +1326,7 @@ class Scratch3WeDo2Blocks {
                     motor.turnOff();
                 }
             });
-        }).catch(e => {
+        }).catch(() => {
             // console.log('*** CATCH MOTOR_OFF REJECTION');
             // console.log(e);
         });
@@ -1351,7 +1351,7 @@ class Scratch3WeDo2Blocks {
                     motor.turnOn();
                 }
             });
-        }).catch(e => {
+        }).catch(() => {
             // console.log('*** CATCH START_MOTOR_POWER REJECTION');
             // console.log(e);
         });
@@ -1397,7 +1397,7 @@ class Scratch3WeDo2Blocks {
                     }
                 }
             });
-        }).catch(e => {
+        }).catch(() => {
             // console.log('*** CATCH SET_MOTOR_DIRECTION REJECTION');
             // console.log(e);
         });
@@ -1421,7 +1421,7 @@ class Scratch3WeDo2Blocks {
 
         return this._peripheral._queue.do(() => {
             this._peripheral.setLED(rgbDecimal);
-        }).catch(e => {
+        }).catch(() => {
             // console.log('*** CATCH SET_LIGHT_HUE REJECTION');
             // console.log(e);
         });
@@ -1451,7 +1451,7 @@ class Scratch3WeDo2Blocks {
                 // Run for some time even when no piezo is connected
                 setTimeout(resolve, durationMS);
             });
-        }).catch(e => {
+        }).catch(() => {
             // console.log('*** CATCH PLAY_NOTE_FOR REJECTION');
             // console.log(e);
         });

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1299,7 +1299,6 @@ class Scratch3WeDo2Blocks {
                     motor.turnOn();
                 }
             });
-
         }).catch(e => {
             console.log('*** CATCH MOTOR_ON REJECTION');
             // console.log(e);
@@ -1322,7 +1321,6 @@ class Scratch3WeDo2Blocks {
                     motor.turnOff();
                 }
             });
-
         }).catch(e => {
             console.log('*** CATCH MOTOR_OFF REJECTION');
             // console.log(e);
@@ -1348,7 +1346,6 @@ class Scratch3WeDo2Blocks {
                     motor.turnOn();
                 }
             });
-
         }).catch(e => {
             console.log('*** CATCH START_MOTOR_POWER REJECTION');
             // console.log(e);
@@ -1395,7 +1392,6 @@ class Scratch3WeDo2Blocks {
                     }
                 }
             });
-
         }).catch(e => {
             console.log('*** CATCH SET_MOTOR_DIRECTION REJECTION');
             // console.log(e);

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1400,8 +1400,9 @@ class Scratch3WeDo2Blocks {
         let inputHue = Cast.toNumber(args.HUE);
         inputHue = MathUtil.wrapClamp(inputHue, 0, 100);
         const hue = inputHue * 360 / 100;
-        
+
         const rgbObject = color.hsvToRgb({h: hue, s: 1, v: 1});
+
         const rgbDecimal = color.rgbToDecimal(rgbObject);
 
         return this._peripheral._queue.do(() => {

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1278,7 +1278,7 @@ class Scratch3WeDo2Blocks {
                 setTimeout(resolve, durationMS);
             });
         }).catch(e => {
-            console.log('*** CATCH MOTOR_ON_FOR REJECTION');
+            // console.log('*** CATCH MOTOR_ON_FOR REJECTION');
             // console.log(e);
         });
     }
@@ -1300,7 +1300,7 @@ class Scratch3WeDo2Blocks {
                 }
             });
         }).catch(e => {
-            console.log('*** CATCH MOTOR_ON REJECTION');
+            // console.log('*** CATCH MOTOR_ON REJECTION');
             // console.log(e);
         });
     }
@@ -1322,7 +1322,7 @@ class Scratch3WeDo2Blocks {
                 }
             });
         }).catch(e => {
-            console.log('*** CATCH MOTOR_OFF REJECTION');
+            // console.log('*** CATCH MOTOR_OFF REJECTION');
             // console.log(e);
         });
     }
@@ -1347,7 +1347,7 @@ class Scratch3WeDo2Blocks {
                 }
             });
         }).catch(e => {
-            console.log('*** CATCH START_MOTOR_POWER REJECTION');
+            // console.log('*** CATCH START_MOTOR_POWER REJECTION');
             // console.log(e);
         });
     }
@@ -1393,7 +1393,7 @@ class Scratch3WeDo2Blocks {
                 }
             });
         }).catch(e => {
-            console.log('*** CATCH SET_MOTOR_DIRECTION REJECTION');
+            // console.log('*** CATCH SET_MOTOR_DIRECTION REJECTION');
             // console.log(e);
         });
     }
@@ -1417,7 +1417,7 @@ class Scratch3WeDo2Blocks {
         return this._peripheral._queue.do(() => {
             this._peripheral.setLED(rgbDecimal);
         }).catch(e => {
-            console.log('*** CATCH SET_LIGHT_HUE REJECTION');
+            // console.log('*** CATCH SET_LIGHT_HUE REJECTION');
             // console.log(e);
         });
     }
@@ -1447,7 +1447,7 @@ class Scratch3WeDo2Blocks {
                 setTimeout(resolve, durationMS);
             });
         }).catch(e => {
-            console.log('*** CATCH PLAY_NOTE_FOR REJECTION');
+            // console.log('*** CATCH PLAY_NOTE_FOR REJECTION');
             // console.log(e);
         });
     }

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1260,12 +1260,14 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a promise which will resolve at the end of the duration.
      */
     motorOnFor (args) {
+        const motorID = Cast.toString(args.MOTOR_ID);
+        const duration = Cast.toNumber(args.DURATION);
+
         return this._peripheral._queue.do(() => {
-            // TODO: cast args.MOTOR_ID?
-            let durationMS = Cast.toNumber(args.DURATION) * 1000;
+            let durationMS = Cast.toNumber(duration) * 1000;
             durationMS = MathUtil.clamp(durationMS, 0, 15000);
             return new Promise(resolve => {
-                this._forEachMotor(args.MOTOR_ID, motorIndex => {
+                this._forEachMotor(motorID, motorIndex => {
                     const motor = this._peripheral.motor(motorIndex);
                     if (motor) {
                         motor.turnOnFor(durationMS);
@@ -1288,9 +1290,10 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a Promise that resolves after some delay.
      */
     motorOn (args) {
+        const motorID = Cast.toString(args.MOTOR_ID);
+
         return this._peripheral._queue.do(() => {
-            // TODO: cast args.MOTOR_ID?
-            this._forEachMotor(args.MOTOR_ID, motorIndex => {
+            this._forEachMotor(motorID, motorIndex => {
                 const motor = this._peripheral.motor(motorIndex);
                 if (motor) {
                     motor.turnOn();
@@ -1310,9 +1313,10 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a Promise that resolves after some delay.
      */
     motorOff (args) {
+        const motorID = Cast.toString(args.MOTOR_ID);
+
         return this._peripheral._queue.do(() => {
-            // TODO: cast args.MOTOR_ID?
-            this._forEachMotor(args.MOTOR_ID, motorIndex => {
+            this._forEachMotor(motorID, motorIndex => {
                 const motor = this._peripheral.motor(motorIndex);
                 if (motor) {
                     motor.turnOff();
@@ -1333,12 +1337,14 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a Promise that resolves after some delay.
      */
     startMotorPower (args) {
+        const motorID = Cast.toString(args.MOTOR_ID);
+        const power = Cast.toNumber(args.POWER);
+
         return this._peripheral._queue.do(() => {
-            // TODO: cast args.MOTOR_ID?
-            this._forEachMotor(args.MOTOR_ID, motorIndex => {
+            this._forEachMotor(motorID, motorIndex => {
                 const motor = this._peripheral.motor(motorIndex);
                 if (motor) {
-                    motor.power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
+                    motor.power = MathUtil.clamp(power, 0, 100);
                     motor.turnOn();
                 }
             });
@@ -1358,12 +1364,14 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a Promise that resolves after some delay.
      */
     setMotorDirection (args) {
+        const motorID = Cast.toString(args.MOTOR_ID);
+        const motorDirection = args.MOTOR_DIRECTION;
+
         return this._peripheral._queue.do(() => {
-            // TODO: cast args.MOTOR_ID?
-            this._forEachMotor(args.MOTOR_ID, motorIndex => {
+            this._forEachMotor(motorID, motorIndex => {
                 const motor = this._peripheral.motor(motorIndex);
                 if (motor) {
-                    switch (args.MOTOR_DIRECTION) {
+                    switch (motorDirection) {
                     case WeDo2MotorDirection.FORWARD:
                         motor.direction = 1;
                         break;
@@ -1374,7 +1382,7 @@ class Scratch3WeDo2Blocks {
                         motor.direction = -motor.direction;
                         break;
                     default:
-                        log.warn(`Unknown motor direction in setMotorDirection: ${args.DIRECTION}`);
+                        log.warn(`Unknown motor direction in setMotorDirection: ${motorDirection}`);
                         break;
                     }
                     // keep the motor on if it's running, and update the pending timeout if needed
@@ -1426,13 +1434,17 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a promise which will resolve at the end of the duration.
      */
     playNoteFor (args) {
+        const duration = Cast.toNumber(args.DURATION);
+        let note = Cast.toNumber(args.NOTE);
+        let durationMS = duration * 1000;
+        durationMS = MathUtil.clamp(durationMS, 0, 3000);
+        note = MathUtil.clamp(note, 25, 125); // valid WeDo 2.0 sounds
+        if (durationMS === 0) return; // WeDo 2.0 plays duration '0' forever
+        
+        const tone = this._noteToTone(note);
+
         return this._peripheral._queue.do(() => {
-            let durationMS = Cast.toNumber(args.DURATION) * 1000;
-            durationMS = MathUtil.clamp(durationMS, 0, 3000);
-            const note = MathUtil.clamp(Cast.toNumber(args.NOTE), 25, 125); // valid WeDo 2.0 sounds
-            if (durationMS === 0) return; // WeDo 2.0 plays duration '0' forever
             return new Promise(resolve => {
-                const tone = this._noteToTone(note);
                 this._peripheral.playTone(tone, durationMS);
 
                 // Run for some time even when no piezo is connected

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -429,6 +429,16 @@ class WeDo2 {
          */
         this._rateLimiter = new RateLimiter(BLESendRateMax);
 
+         /**
+         * A task queue to track communication tasks sent over the socket.
+         * The bucket in this task queue holds 1 task at a time, and refills
+         * at a rate of 10 tasks per second, from a queue that holds at maximum
+         * 30 tasks.  If more than 30 tasks are added to the task queue in a short
+         * period, some tasks may be rejected (ignored) by the task queue.
+         * @type {TaskQueue}
+         */
+        this._queue = new TaskQueue(1, 10, {maxTotalCost: 30});
+
         /**
          * An interval id for the battery check interval.
          * @type {number}

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -407,17 +407,17 @@ class WeDo2 {
         this._ble = null;
         this._runtime.registerPeripheralExtension(extensionId, this);
 
-         /**
+        /**
          * A task queue to limit the rate of Bluetooth message sends by limiting
          * the rate of execution of blocks which send Bluetooth messages.
-         * 
+         *
          * The bucket in this task queue holds 1 task at a time, and refills
          * at a rate of 10 tasks per second, from a queue that holds tasks with
          * a maximum total cost of 30. Since most tasks have a cost of 1 this
          * means the queue will generally have at most 30 tasks. If more than 30
          * tasks are added to the task queue in a short period, some tasks may
          * be rejected (ignored) by the task queue.
-         * 
+         *
          * @type {TaskQueue}
          */
         this._queue = new TaskQueue(1, 10, {maxTotalCost: 30});
@@ -1444,14 +1444,12 @@ class Scratch3WeDo2Blocks {
         
         const tone = this._noteToTone(note);
 
-        return this._peripheral._queue.do(() => {
-            return new Promise(resolve => {
+        return this._peripheral._queue.do(() => new Promise(resolve => {
                 this._peripheral.playTone(tone, durationMS);
 
                 // Run for some time even when no piezo is connected
                 setTimeout(resolve, durationMS);
-            });
-        }).catch(() => {
+        })).catch(() => {
             // console.log('*** CATCH PLAY_NOTE_FOR REJECTION');
             // console.log(e);
         });

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1260,19 +1260,24 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a promise which will resolve at the end of the duration.
      */
     motorOnFor (args) {
-        // TODO: cast args.MOTOR_ID?
-        let durationMS = Cast.toNumber(args.DURATION) * 1000;
-        durationMS = MathUtil.clamp(durationMS, 0, 15000);
-        return new Promise(resolve => {
-            this._forEachMotor(args.MOTOR_ID, motorIndex => {
-                const motor = this._peripheral.motor(motorIndex);
-                if (motor) {
-                    motor.turnOnFor(durationMS);
-                }
-            });
+        return this._peripheral._queue.do(() => {
+            // TODO: cast args.MOTOR_ID?
+            let durationMS = Cast.toNumber(args.DURATION) * 1000;
+            durationMS = MathUtil.clamp(durationMS, 0, 15000);
+            return new Promise(resolve => {
+                this._forEachMotor(args.MOTOR_ID, motorIndex => {
+                    const motor = this._peripheral.motor(motorIndex);
+                    if (motor) {
+                        motor.turnOnFor(durationMS);
+                    }
+                });
 
-            // Run for some time even when no motor is connected
-            setTimeout(resolve, durationMS);
+                // Run for some time even when no motor is connected
+                setTimeout(resolve, durationMS);
+            });
+        }).catch(e => {
+            console.log('*** CATCH MOTOR_ON_FOR REJECTION');
+            // console.log(e);
         });
     }
 
@@ -1421,16 +1426,21 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a promise which will resolve at the end of the duration.
      */
     playNoteFor (args) {
-        let durationMS = Cast.toNumber(args.DURATION) * 1000;
-        durationMS = MathUtil.clamp(durationMS, 0, 3000);
-        const note = MathUtil.clamp(Cast.toNumber(args.NOTE), 25, 125); // valid WeDo 2.0 sounds
-        if (durationMS === 0) return; // WeDo 2.0 plays duration '0' forever
-        return new Promise(resolve => {
-            const tone = this._noteToTone(note);
-            this._peripheral.playTone(tone, durationMS);
+        return this._peripheral._queue.do(() => {
+            let durationMS = Cast.toNumber(args.DURATION) * 1000;
+            durationMS = MathUtil.clamp(durationMS, 0, 3000);
+            const note = MathUtil.clamp(Cast.toNumber(args.NOTE), 25, 125); // valid WeDo 2.0 sounds
+            if (durationMS === 0) return; // WeDo 2.0 plays duration '0' forever
+            return new Promise(resolve => {
+                const tone = this._noteToTone(note);
+                this._peripheral.playTone(tone, durationMS);
 
-            // Run for some time even when no piezo is connected
-            setTimeout(resolve, durationMS);
+                // Run for some time even when no piezo is connected
+                setTimeout(resolve, durationMS);
+            });
+        }).catch(e => {
+            console.log('*** CATCH PLAY_NOTE_FOR REJECTION');
+            // console.log(e);
         });
     }
 

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -7,6 +7,7 @@ const BLE = require('../../io/ble');
 const Base64Util = require('../../util/base64-util');
 const MathUtil = require('../../util/math-util');
 const RateLimiter = require('../../util/rateLimiter.js');
+const TaskQueue = require('../../util/task-queue');
 const log = require('../../util/log');
 
 /**

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1396,16 +1396,15 @@ class Scratch3WeDo2Blocks {
      * @return {Promise} - a Promise that resolves after some delay.
      */
     setLightHue (args) {
+        // Convert from [0,100] to [0,360]
+        let inputHue = Cast.toNumber(args.HUE);
+        inputHue = MathUtil.wrapClamp(inputHue, 0, 100);
+        const hue = inputHue * 360 / 100;
+        
+        const rgbObject = color.hsvToRgb({h: hue, s: 1, v: 1});
+        const rgbDecimal = color.rgbToDecimal(rgbObject);
+
         return this._peripheral._queue.do(() => {
-            // Convert from [0,100] to [0,360]
-            let inputHue = Cast.toNumber(args.HUE);
-            inputHue = MathUtil.wrapClamp(inputHue, 0, 100);
-            const hue = inputHue * 360 / 100;
-
-            const rgbObject = color.hsvToRgb({h: hue, s: 1, v: 1});
-
-            const rgbDecimal = color.rgbToDecimal(rgbObject);
-
             this._peripheral.setLED(rgbDecimal);
         }).catch(e => {
             console.log('*** CATCH SET_LIGHT_HUE REJECTION');

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -408,11 +408,16 @@ class WeDo2 {
         this._runtime.registerPeripheralExtension(extensionId, this);
 
          /**
-         * A task queue to track communication tasks sent over the socket.
+         * A task queue to limit the rate of Bluetooth message sends by limiting
+         * the rate of execution of blocks which send Bluetooth messages.
+         * 
          * The bucket in this task queue holds 1 task at a time, and refills
-         * at a rate of 10 tasks per second, from a queue that holds at maximum
-         * 30 tasks.  If more than 30 tasks are added to the task queue in a short
-         * period, some tasks may be rejected (ignored) by the task queue.
+         * at a rate of 10 tasks per second, from a queue that holds tasks with
+         * a maximum total cost of 30. Since most tasks have a cost of 1 this
+         * means the queue will generally have at most 30 tasks. If more than 30
+         * tasks are added to the task queue in a short period, some tasks may
+         * be rejected (ignored) by the task queue.
+         * 
          * @type {TaskQueue}
          */
         this._queue = new TaskQueue(1, 10, {maxTotalCost: 30});

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1445,10 +1445,10 @@ class Scratch3WeDo2Blocks {
         const tone = this._noteToTone(note);
 
         return this._peripheral._queue.do(() => new Promise(resolve => {
-                this._peripheral.playTone(tone, durationMS);
+            this._peripheral.playTone(tone, durationMS);
 
-                // Run for some time even when no piezo is connected
-                setTimeout(resolve, durationMS);
+            // Run for some time even when no piezo is connected
+            setTimeout(resolve, durationMS);
         })).catch(() => {
             // console.log('*** CATCH PLAY_NOTE_FOR REJECTION');
             // console.log(e);


### PR DESCRIPTION
### Resolves

- Resolves #2016: Hardware Extensions: Add TaskQueue to WeDo2

### Proposed Changes

Use the new TaskQueue utility to rate limit the hardware command sent over the Scratch Link socket to the WeDo2, to prevent trying to send too many commands at once and potentially lock up the peripheral or the browser, etc.

### Test Coverage

Should test stacks that send many commands in a short period of time (e.g. broadcast > when I receive > start motor)