### PR TITLE
Set canvas and costume size to zero if bitmap is empty

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -850,10 +850,13 @@ class VirtualMachine extends EventEmitter {
         costume.rotationCenterX = rotationCenterX;
         costume.rotationCenterY = rotationCenterY;
 
+        // If the bitmap originally had a zero width or height, use that value
+        const bitmapWidth = bitmap.sourceWidth === 0 ? 0 : bitmap.width;
+        const bitmapHeight = bitmap.sourceHeight === 0 ? 0 : bitmap.height;
         // @todo: updateBitmapSkin does not take ImageData
         const canvas = document.createElement('canvas');
-        canvas.width = bitmap.width;
-        canvas.height = bitmap.height;
+        canvas.width = bitmapWidth;
+        canvas.height = bitmapHeight;
         const context = canvas.getContext('2d');
         context.putImageData(bitmap, 0, 0);
 
@@ -873,7 +876,7 @@ class VirtualMachine extends EventEmitter {
                 const storage = this.runtime.storage;
                 costume.dataFormat = storage.DataFormat.PNG;
                 costume.bitmapResolution = bitmapResolution;
-                costume.size = [bitmap.width, bitmap.height];
+                costume.size = [bitmapWidth, bitmapHeight];
                 costume.asset = storage.createAsset(
                     storage.AssetType.ImageBitmap,
                     costume.dataFormat,
@@ -885,7 +888,10 @@ class VirtualMachine extends EventEmitter {
                 costume.md5 = `${costume.assetId}.${costume.dataFormat}`;
                 this.emitTargetsUpdate();
             });
-            reader.readAsArrayBuffer(blob);
+            // Bitmaps with a zero width or height return null for their blob
+            if (blob){
+                reader.readAsArrayBuffer(blob);
+            }
         });
     }
 


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-gui/issues/4409

### Proposed Changes

This PR is part of a fix along with this https://github.com/LLK/scratch-paint/pull/826 PR. The changes in scratch-paint check if a bitmap has a height or width of zero and if it does, it is saved as the sourceHeight or sourceWidth on the imageData object. This gets passed to the VM as "bitmap", and the changes in this PR are to check whether the bitmap has a sourceHeight or sourceWidth of zero. I it does, use that value for the canvas and costume sizes.

### Reason for Changes

Currently, empty bitmaps are set to be the full size of the stage instead of 0x0 because canvas's imageData interface doesn't allow you to have a value of zero for its width or height. [(Paperjs is the specific library that's using the full stage size for imageData)](https://github.com/paperjs/paper.js/blob/6fc1b122d61d85605b4b498557b58fb6ca19be56/src/item/Raster.js#L679-L680). This means empty bitmaps aren't using [empty skin logic to set its rotation center](https://github.com/LLK/scratch-render/blob/4bf233ef361b6d7048d385b0c40bbdc19e4776e3/src/Skin.js#L108-L118) and with an incorrect rotation center, not all of the stage is accessible for this sprite (hence https://github.com/LLK/scratch-gui/issues/4409).
