### PR TITLE
add clampEffect for limiting range of brightness and ghost effects

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -77,6 +77,14 @@ class Scratch3LooksBlocks {
     }
 
     /**
+     * Limit for brightness effect
+     * @const {object}
+     */
+    static get EFFECT_BRIGHTNESS_LIMIT (){
+        return {min: -100, max: 100};
+    }
+
+    /**
      * @param {Target} target - collect bubble state for this target. Probably, but not necessarily, a RenderedTarget.
      * @returns {BubbleState} the mutable bubble state associated with that target. This will be created if necessary.
      * @private
@@ -484,27 +492,36 @@ class Scratch3LooksBlocks {
         );
     }
 
+    clampEffect (effect, value) {
+        let clampedValue = value;
+        switch (effect) {
+        case 'ghost':
+            clampedValue = MathUtil.clamp(value,
+                Scratch3LooksBlocks.EFFECT_GHOST_LIMIT.min,
+                Scratch3LooksBlocks.EFFECT_GHOST_LIMIT.max);
+            break;
+        case 'brightness':
+            clampedValue = MathUtil.clamp(value,
+                Scratch3LooksBlocks.EFFECT_BRIGHTNESS_LIMIT.min,
+                Scratch3LooksBlocks.EFFECT_BRIGHTNESS_LIMIT.max);
+            break;
+        }
+        return clampedValue;
+    }
+
     changeEffect (args, util) {
         const effect = Cast.toString(args.EFFECT).toLowerCase();
         const change = Cast.toNumber(args.CHANGE);
         if (!util.target.effects.hasOwnProperty(effect)) return;
         let newValue = change + util.target.effects[effect];
-        if (effect === 'ghost') {
-            newValue = MathUtil.clamp(newValue,
-                Scratch3LooksBlocks.EFFECT_GHOST_LIMIT.min,
-                Scratch3LooksBlocks.EFFECT_GHOST_LIMIT.max);
-        }
+        newValue = this.clampEffect(effect, newValue);
         util.target.setEffect(effect, newValue);
     }
 
     setEffect (args, util) {
         const effect = Cast.toString(args.EFFECT).toLowerCase();
         let value = Cast.toNumber(args.VALUE);
-        if (effect === 'ghost') {
-            value = MathUtil.clamp(value,
-                Scratch3LooksBlocks.EFFECT_GHOST_LIMIT.min,
-                Scratch3LooksBlocks.EFFECT_GHOST_LIMIT.max);
-        }
+        value = this.clampEffect(effect, value);
         util.target.setEffect(effect, value);
     }
 

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -211,3 +211,48 @@ test('numbers should be rounded to two decimals in say', t => {
 
     looks.say(args, util);
 });
+
+test('clamp graphic effects', t => {
+    const rt = new Runtime();
+    const looks = new Looks(rt);
+    const expectedValues = {
+        brightness: {high: 100, low: -100},
+        ghost: {high: 100, low: 0},
+        color: {high: 500, low: -500},
+        fisheye: {high: 500, low: -500},
+        whirl: {high: 500, low: -500},
+        pixelate: {high: 500, low: -500},
+        mosaic: {high: 500, low: -500}
+    };
+    const args = [
+        {EFFECT: 'brightness', VALUE: 500, CLAMP: 'high'},
+        {EFFECT: 'brightness', VALUE: -500, CLAMP: 'low'},
+        {EFFECT: 'ghost', VALUE: 500, CLAMP: 'high'},
+        {EFFECT: 'ghost', VALUE: -500, CLAMP: 'low'},
+        {EFFECT: 'color', VALUE: 500, CLAMP: 'high'},
+        {EFFECT: 'color', VALUE: -500, CLAMP: 'low'},
+        {EFFECT: 'fisheye', VALUE: 500, CLAMP: 'high'},
+        {EFFECT: 'fisheye', VALUE: -500, CLAMP: 'low'},
+        {EFFECT: 'whirl', VALUE: 500, CLAMP: 'high'},
+        {EFFECT: 'whirl', VALUE: -500, CLAMP: 'low'},
+        {EFFECT: 'pixelate', VALUE: 500, CLAMP: 'high'},
+        {EFFECT: 'pixelate', VALUE: -500, CLAMP: 'low'},
+        {EFFECT: 'mosaic', VALUE: 500, CLAMP: 'high'},
+        {EFFECT: 'mosaic', VALUE: -500, CLAMP: 'low'}
+    ];
+
+    util.target.setEffect = function (effectName, actualValue) {
+        const clamp = actualValue > 0 ? 'high' : 'low';
+        rt.emit(effectName + clamp, effectName, actualValue);
+    };
+
+    for (const arg of args) {
+        rt.addListener(arg.EFFECT + arg.CLAMP, (effectName, actualValue) => {
+            const expected = expectedValues[arg.EFFECT][arg.CLAMP];
+            t.strictEqual(actualValue, expected);
+        });
+
+        looks.setEffect(arg, util);
+    }
+    t.end();
+});


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/1283

### Proposed Changes

Add `clampEffect` to limit the range of ghost and brightness effects

### Reason for Changes

[In Scratch 2](https://github.com/LLK/scratch-flash/blob/646523e6846ad0dd993213a38b46fe2ea511d026/src/filters/FilterPack.as#L86-L88) we limited the values for the brightness graphic effect to between -100 and 100. These changes add that limit in a separate function that handles the previously added ghost effect limits as well. This allows us to use the same clamping logic in two blocks (`setEffect` and `clampEffect`). 

### Test Coverage

Added `clamp graphic effects` test in unit/blocks_looks.js
