### PR TITLE
Device scan discovery fix

### DIFF
--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -73,7 +73,7 @@ class BLE extends JSONRPCWebSocket {
      * Close the websocket.
      */
     disconnect () {
-        if (!this._connected) return;
+        if (this._ws.readyState !== this._ws.OPEN) return;
 
         this._ws.close();
         this._connected = false;

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -75,7 +75,7 @@ class BT extends JSONRPCWebSocket {
      * Close the websocket.
      */
     disconnect () {
-        if (!this._connected) return;
+        if (this._ws.readyState !== this._ws.OPEN) return;
 
         this._ws.close();
         this._connected = false;


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/2636

### Proposed Changes

Previously, `BLE.disconnect` and `BT.disconnect` were guarding against disconnection and web socket closure if a previous peripheral connection hadn't been established.  Instead, `BLE.disconnect` and `BT.disconnect` should guard against disconnection if the web socket hadn't been opened at all, whether or not a peripheral had been previously connected to.

(There is a confusion with the `this._connected` flag referring to peripheral connection, not web socket connection.)

### Test Coverage

I tested this by discovering a BLE device and then attempting discovery of a BT device, and vice versa.  Further testing may be necessary...
