### PR TITLE
Allow for situation where we get a move event to attach a shadow.

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -735,6 +735,12 @@ class Blocks {
                 if (this._blocks[e.newParent].inputs.hasOwnProperty(e.newInput)) {
                     oldShadow = this._blocks[e.newParent].inputs[e.newInput].shadow;
                 }
+
+                // If the block being attached is itself a shadow, make sure to set
+                // both block and shadow to that blocks ID. This happens when adding
+                // inputs to a custom procedure.
+                if (this._blocks[e.id].shadow) oldShadow = e.id;
+
                 this._blocks[e.newParent].inputs[e.newInput] = {
                     name: e.newInput,
                     block: e.id,

--- a/test/unit/engine_blocks.js
+++ b/test/unit/engine_blocks.js
@@ -358,6 +358,43 @@ test('move no obscure shadow', t => {
     t.end();
 });
 
+test('move - attaching new shadow', t => {
+    const b = new Blocks(new Runtime());
+    // Block/shadow are null to mimic state right after a procedure_call block
+    // is mutated by adding an input. The "move" will attach the new shadow.
+    b.createBlock({
+        id: 'foo',
+        opcode: 'TEST_BLOCK',
+        next: null,
+        fields: {},
+        inputs: {
+            fooInput: {
+                name: 'fooInput',
+                block: null,
+                shadow: null
+            }
+        },
+        topLevel: true
+    });
+    b.createBlock({
+        id: 'bar',
+        opcode: 'TEST_BLOCK',
+        shadow: true,
+        next: null,
+        fields: {},
+        inputs: {},
+        topLevel: true
+    });
+    b.moveBlock({
+        id: 'bar',
+        newInput: 'fooInput',
+        newParent: 'foo'
+    });
+    t.equal(b._blocks.foo.inputs.fooInput.block, 'bar');
+    t.equal(b._blocks.foo.inputs.fooInput.shadow, 'bar');
+    t.end();
+});
+
 test('change', t => {
     const b = new Blocks(new Runtime());
     b.createBlock({


### PR DESCRIPTION
This happens after adding a custom procedure input to an existing custom procedure call block.

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/4610
Fixes https://github.com/LLK/scratch-blocks/issues/1691

### Proposed Changes

_Describe what this Pull Request does_

Allows the `move` block event to attach a shadow to an input. This never happens in the UI directly from the user,  but it happens after changing a custom procedure by adding an input. In that situation, the call block is first mutated to add an input, then a shadow is created, then it is moved to be attached to the call block. That last step was only assigning the block to the `block` attribute, leaving the `shadow` attribute null. But the block is itself a shadow, so should be assigned to both shadow/block attributes. 

### Reason for Changes

_Explain why these changes should be made_

Fix the above bugs.

### Test Coverage

_Please show how you have added tests to cover your changes_

Manually tested with the repro cases on the linked issues, and added a unit test to make sure the code works.