### PR TITLE
Fix hardware extension disconnect behavior

### DIFF
--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -73,14 +73,19 @@ class BLE extends JSONRPCWebSocket {
      * Close the websocket.
      */
     disconnect () {
-        if (this._ws.readyState !== this._ws.OPEN) return;
+        if (this._ws.readyState === this._ws.OPEN) {
+            this._ws.close();
+        }
 
-        this._ws.close();
-        this._connected = false;
+        if (this._connected) {
+            this._connected = false;
+        }
+        
         if (this._discoverTimeoutID) {
             window.clearTimeout(this._discoverTimeoutID);
         }
 
+        // Sets connection status icon to orange
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_DISCONNECTED);
     }
 

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -75,14 +75,19 @@ class BT extends JSONRPCWebSocket {
      * Close the websocket.
      */
     disconnect () {
-        if (this._ws.readyState !== this._ws.OPEN) return;
+        if (this._ws.readyState === this._ws.OPEN) {
+            this._ws.close();
+        }
 
-        this._ws.close();
-        this._connected = false;
+        if (this._connected) {
+            this._connected = false;
+        }
+
         if (this._discoverTimeoutID) {
             window.clearTimeout(this._discoverTimeoutID);
         }
 
+        // Sets connection status icon to orange
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_DISCONNECTED);
     }
 


### PR DESCRIPTION
### Resolves

- Resolves #2054: Hardware extension status icon doesn't update correctly on some disconnects

### Proposed Changes

Instead of using a 'guard pattern' in the `disconnect` method of `BLE` and `BT`, use multiple branches to handle the different cases differently.

### Reason for Changes

Disconnection happens in different ways and needs tailored handling.

### Test Coverage

It's good to test four different scenarios:

**TEST QUITTING SCRATCH LINK**
BLE:
1. Load 'microbit' extension and connect
2. Quit ScratchLink
3. Disconnect alert should appear and microbit status icon should turn orange

BT:
1. Load 'ev3' extension and connect
2. Quit ScratchLink
3. Disconnect alert should appear and ev3 status icon should turn orange

**TEST DISCOVERY OF MULTIPLE PERIPHERALS**
BLE:
1. Load 'microbit' extension and wait for device list
2. Close connection modal
3. Load 'ev3' extension
4. No ev3 device with a microbit name should show up

BT:
1. Load 'ev3' extension and wait for device list
2. Close connection modal
3. Load 'microbit' extension
4. No microbit device with a ev3 name should show up