### PR TITLE
Localize name of Text to Speech extension

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -405,7 +405,11 @@ class Scratch3Text2SpeechBlocks {
 
         return {
             id: 'text2speech',
-            name: 'Text to Speech',
+            name: formatMessage({
+                id: 'text2speech.categoryName',
+                default: 'Text to Speech',
+                description: 'Name of the Text to Speech extension.'
+            }),
             blockIconURI: blockIconURI,
             menuIconURI: menuIconURI,
             blocks: [


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1997

### Proposed Changes

Use a formatMessage to localize the name of the Text to Speech extension 

### Reason for Changes

Generally, strings should be localized. Some extension names that are brand names are not localized (such as "micro:bit"), but this is not one of those.