### PR TITLE
Remove Hindi from text2speech extension

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -84,7 +84,6 @@ const DUTCH_ID = 'nl';
 const ENGLISH_ID = 'en';
 const FRENCH_ID = 'fr';
 const GERMAN_ID = 'de';
-const HINDI_ID = 'hi';
 const ICELANDIC_ID = 'is';
 const ITALIAN_ID = 'it';
 const JAPANESE_ID = 'ja';
@@ -241,12 +240,6 @@ class Scratch3Text2SpeechBlocks {
                 name: 'German',
                 locales: ['de'],
                 speechSynthLocale: 'de-DE'
-            },
-            [HINDI_ID]: {
-                name: 'Hindi',
-                locales: ['hi'],
-                speechSynthLocale: 'en-IN',
-                singleGender: true
             },
             [ICELANDIC_ID]: {
                 name: 'Icelandic',


### PR DESCRIPTION
Amazon's Hindi language speech synthesis has very low quality- needs investigation, so we will remove it for now.