### PR TITLE
Add Hindi language to Text to Speech

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -84,6 +84,7 @@ const DUTCH_ID = 'nl';
 const ENGLISH_ID = 'en';
 const FRENCH_ID = 'fr';
 const GERMAN_ID = 'de';
+const HINDI_ID = 'hi';
 const ICELANDIC_ID = 'is';
 const ITALIAN_ID = 'it';
 const JAPANESE_ID = 'ja';
@@ -240,6 +241,12 @@ class Scratch3Text2SpeechBlocks {
                 name: 'German',
                 locales: ['de'],
                 speechSynthLocale: 'de-DE'
+            },
+            [HINDI_ID]: {
+                name: 'Hindi',
+                locales: ['hi'],
+                speechSynthLocale: 'hi-IN',
+                singleGender: true
             },
             [ICELANDIC_ID]: {
                 name: 'Icelandic',


### PR DESCRIPTION
Add support for Hindi to the Text to Speech extension.

We pulled it out due to low quality of the default voice provided for the `en-IN` locale. This PR uses `hi-IN` instead, which requires an update to the synth server.