### PR TITLE
Fix #4573 by using an existing utitlity that re-ids blocks when we du…

### DIFF
--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -2,6 +2,7 @@ const RenderedTarget = require('./rendered-target');
 const Blocks = require('../engine/blocks');
 const {loadSoundFromAsset} = require('../import/load-sound');
 const {loadCostumeFromAsset} = require('../import/load-costume');
+const newBlockIds = require('../util/new-block-ids');
 const StringUtil = require('../util/string-util');
 const StageLayering = require('../engine/stage-layering');
 
@@ -136,8 +137,12 @@ class Sprite {
 
     duplicate () {
         const newSprite = new Sprite(null, this.runtime);
+        const copiedBlocks = JSON.parse(JSON.stringify(Object.values(this.blocks._blocks)));
+        newBlockIds(copiedBlocks);
+        copiedBlocks.forEach(block => {
+            newSprite.blocks.createBlock(block);
+        });
 
-        newSprite.blocks = this.blocks.duplicate();
 
         const allNames = this.runtime.targets.map(t => t.sprite.name);
         newSprite.name = StringUtil.unusedName(this.name, allNames);

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -137,7 +137,9 @@ class Sprite {
 
     duplicate () {
         const newSprite = new Sprite(null, this.runtime);
-        const copiedBlocks = JSON.parse(JSON.stringify(Object.values(this.blocks._blocks)));
+        const blocksContainer = this.blocks._blocks;
+        const originalBlocks = Object.keys(blocksContainer).map(key => blocksContainer[key]);
+        const copiedBlocks = JSON.parse(JSON.stringify(originalBlocks));
         newBlockIds(copiedBlocks);
         copiedBlocks.forEach(block => {
             newSprite.blocks.createBlock(block);

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -1,5 +1,4 @@
 const test = require('tap').test;
-const Blocks = require('../../src/engine/blocks');
 const RenderedTarget = require('../../src/sprites/rendered-target');
 const Sprite = require('../../src/sprites/sprite');
 const Runtime = require('../../src/engine/runtime');

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -1,4 +1,5 @@
 const test = require('tap').test;
+const Blocks = require('../../src/engine/blocks');
 const RenderedTarget = require('../../src/sprites/rendered-target');
 const Sprite = require('../../src/sprites/sprite');
 const Runtime = require('../../src/engine/runtime');
@@ -25,6 +26,24 @@ test('setxy', t => {
     t.equals(a.x, 123);
     t.equals(a.y, 321);
     t.end();
+});
+
+test('blocks get new id on duplicate', t => {
+    const r = new Runtime();
+    const s = new Sprite(null, r);
+    const rt = new RenderedTarget(s, r);
+    const block = {
+        id: 'id1',
+        topLevel: true,
+        fields: {}
+    };
+
+    rt.blocks.createBlock(block);
+
+    return rt.duplicate().then(duplicate => {
+        t.notOk(duplicate.blocks._blocks.hasOwnProperty(block.id));
+        t.end();
+    });
 });
 
 test('direction', t => {


### PR DESCRIPTION
…plicate a sprite.

### Resolves

Fixes https://github.com/LLK/scratch-gui/issues/4573

### Proposed Changes

Use the util that share the love does to give blocks new ids when duplicating a sprite.  


### Test Coverage

Added a unit test for duplicate that checks that a duplicated block has a different id from the original.