### PR TITLE
Load Vernier extension code

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -18,10 +18,8 @@ const builtinExtensions = {
     videoSensing: () => require('../extensions/scratch3_video_sensing'),
     speech2text: () => require('../extensions/scratch3_speech2text'),
     ev3: () => require('../extensions/scratch3_ev3'),
-    makeymakey: () => require('../extensions/scratch3_makeymakey')
-    // todo: only load this extension once we have a compatible way to load its
-    // Vernier module dependency.
-    // gdxfor: () => require('../extensions/scratch3_gdx_for')
+    makeymakey: () => require('../extensions/scratch3_makeymakey'),
+    gdxfor: () => require('../extensions/scratch3_gdx_for')
 };
 
 /**


### PR DESCRIPTION
Now that we have updated the Vernier GoDirect module to 1.5.0, it should be safe to load the Vernier extension code on WWW, and it should work on Microsoft Edge.  

This change requires an update to GUI's webpack config. 