### PR TITLE
Stub timer to fix flaky test

### DIFF
--- a/test/unit/util_timer.js
+++ b/test/unit/util_timer.js
@@ -1,8 +1,18 @@
 const test = require('tap').test;
 const Timer = require('../../src/util/timer');
 
+// Stubbed current time
+let NOW = 0;
+
+const testNow = {
+    now: () => {
+        NOW += 100;
+        return NOW;
+    }
+};
+
 test('spec', t => {
-    const timer = new Timer();
+    const timer = new Timer(testNow);
 
     t.type(Timer, 'function');
     t.type(timer, 'object');
@@ -18,33 +28,31 @@ test('spec', t => {
 });
 
 test('time', t => {
-    const timer = new Timer();
+    const timer = new Timer(testNow);
     const time = timer.time();
 
-    t.ok(Date.now() >= time);
+    t.ok(testNow.now() >= time);
     t.end();
 });
 
 test('start / timeElapsed', t => {
-    const timer = new Timer();
+    const timer = new Timer(testNow);
     const delay = 100;
     const threshold = 1000 / 60; // 60 hz
 
     // Start timer
     timer.start();
 
-    // Wait and measure timer
-    timer.setTimeout(() => {
-        const timeElapsed = timer.timeElapsed();
-        t.ok(timeElapsed >= 0);
-        t.ok(timeElapsed >= (delay - threshold) &&
-             timeElapsed <= (delay + threshold));
-        t.end();
-    }, delay);
+    // Measure timer
+    const timeElapsed = timer.timeElapsed();
+    t.ok(timeElapsed >= 0);
+    t.ok(timeElapsed >= (delay - threshold) &&
+         timeElapsed <= (delay + threshold));
+    t.end();
 });
 
 test('setTimeout / clearTimeout', t => new Promise((resolve, reject) => {
-    const timer = new Timer();
+    const timer = new Timer(testNow);
     const cancelId = timer.setTimeout(() => {
         reject(new Error('Canceled task ran'));
     }, 1);


### PR DESCRIPTION
Hopefully this will prevent some of the CI failures on the test for util_timer. @rschamp figured out a way to stub out the internal timer.