### PR TITLE
Fixing some translate language menu bugs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12257,9 +12257,9 @@
       }
     },
     "scratch-translate-extension-languages": {
-      "version": "0.0.20181205140428",
-      "resolved": "https://registry.npmjs.org/scratch-translate-extension-languages/-/scratch-translate-extension-languages-0.0.20181205140428.tgz",
-      "integrity": "sha512-vNE8LSIrJl5cCCS1yrR6wivtFhuJmHFhbZnTrkt/E3BfyqMBJgpqJTtYfi+up1sorc7AixhpHTARE6/t3D//MA=="
+      "version": "0.0.20190416132834",
+      "resolved": "https://registry.npmjs.org/scratch-translate-extension-languages/-/scratch-translate-extension-languages-0.0.20190416132834.tgz",
+      "integrity": "sha512-mRDRBqbwf52DSbR9tJLRw2/MIUoFncNaqTKkVjdDJcIRm5niTtKtFDn2BlyQunAAkUVdswncS0t1wpf155lQGw=="
     },
     "script-loader": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "nets": "3.2.0",
     "scratch-parser": "5.0.0",
     "scratch-sb1-converter": "0.2.7",
-    "scratch-translate-extension-languages": "0.0.20181205140428",
+    "scratch-translate-extension-languages": "0.0.20190416132834",
     "socket.io-client": "2.0.4",
     "text-encoding": "0.7.0",
     "worker-loader": "^1.1.1"

--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -171,7 +171,15 @@ class Scratch3TranslateBlocks {
     getViewerLanguage () {
         this._viewerLanguageCode = this.getViewerLanguageCode();
         const names = languageNames.menuMap[this._viewerLanguageCode];
-        const langNameObj = names.find(obj => obj.code === this._viewerLanguageCode);
+        let langNameObj = names.find(obj => obj.code === this._viewerLanguageCode);
+
+        // If we don't have a name entry yet, try looking it up via the Google langauge
+        // code instead of Scratch's (e.g. for es-419 we look up es to get espanol)
+        if (!langNameObj && languageNames.scratchToGoogleMap[this._viewerLanguageCode]) {
+            const lookupCode = languageNames.scratchToGoogleMap[this._viewerLanguageCode];
+            langNameObj = names.find(obj => obj.code === lookupCode);
+        }
+
         let langName = this._viewerLanguageCode;
         if (langNameObj) {
             langName = langNameObj.name;
@@ -193,12 +201,13 @@ class Scratch3TranslateBlocks {
             if (acc) {
                 return acc;
             }
-            if (languageKeys.indexOf(lang) > -1) {
+            if (languageKeys.indexOf(lang.toLowerCase()) > -1) {
                 return lang;
             }
             return acc;
         }, '') || 'en';
-        return languageCode;
+
+        return languageCode.toLowerCase();
     }
 
     /**
@@ -216,6 +225,14 @@ class Scratch3TranslateBlocks {
         // Check for a dropped-in language name, and convert to a language code.
         if (languageNames.nameMap.hasOwnProperty(languageArg)) {
             return languageNames.nameMap[languageArg];
+        }
+
+        // There are some languages we launched in the language menu that Scratch did not
+        // end up launching in. In order to keep projects that may have had that menu item
+        // working, check for those language codes and let them through.
+        // Examples: 'ab', 'hi'.
+        if (languageNames.previouslySupported.indexOf(languageArg) !== -1) {
+            return languageArg;
         }
         // Default to English.
         return 'en';


### PR DESCRIPTION
Use new info in the translate language menu map introduced in
https://github.com/LLK/scratch-translate-extension-languages/pull/9. Once that PR is merged, I'll update the package.json file to point to new map (this is blocked til then but wanted to have all the pieces of the fix visible).

This fixes a bug where there's a mismatch between scratch language codes and google translate's language codes. 

Due to the problem described in https://github.com/LLK/scratch-translate-extension-languages/pull/10 where we we had a mismatched set of launched languages, this also adds some code to allow previously supported languages through to the translate server to keep potential existing projects working.

It also fixes a bug where there was a mismatch between upper and lowercase language codes.  I'd standardized on lowercase in most places, but missed this one.

