### PR TITLE
Fix 2087, 2088, and 2089 by properly setting parameters in rotation-commands and not using command feedback when relying on scratch-vm for motor timing

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1719,8 +1719,8 @@ class Scratch3BoostBlocks {
                     if (motor.pendingTimeoutDelay) {
                         motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now());
                     } else if (motor.pendingPositionDestination) {
-                        const p = motor.pendingPositionDestination - motor.position;
-                        motor.turnOnForDegrees(p, Math.sign(p) * motor.direction);
+                        const p = Math.abs(motor.pendingPositionDestination - motor.position);
+                        motor.turnOnForDegrees(p, Math.sign(p));
                     }
                 }
             }
@@ -1758,8 +1758,8 @@ class Scratch3BoostBlocks {
                     if (motor.pendingTimeoutDelay) {
                         motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now());
                     } else if (motor.pendingPositionDestination) {
-                        const p = motor.pendingPositionDestination - motor.position;
-                        motor.turnOnForDegrees(p, Math.sign(p) * motor.direction);
+                        const p = Math.abs(motor.pendingPositionDestination - motor.position);
+                        motor.turnOnForDegrees(p, Math.sign(p));
                     }
                 }
             }


### PR DESCRIPTION
Resolves #2087 - Can't change motor direction while it's running
Resolves #2088 - Can't change motor power while it's running
Resolves #2089 - Default motor speed should be 50%?