### PR TITLE
Fix #2085 by handling discarded hub commands

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -943,8 +943,9 @@ class Boost {
             const motor = this.motor(portID);
             if (motor) {
                 motor._status = feedback;
-                if (feedback === (BoostPortFeedback.COMPLETED ^ BoostPortFeedback.IDLE) &&
-                    motor.pendingPromiseFunction) {
+                // Makes sure that commands resolve both when they actually complete and when they fail
+                const commandCompleted = feedback & (BoostPortFeedback.COMPLETED ^ BoostPortFeedback.DISCARDED);
+                if (commandCompleted && motor.pendingPromiseFunction) {
                     motor.pendingPromiseFunction();
                 }
             }


### PR DESCRIPTION
This was caused because the case for BoostMessage.PORT_FEEDBACK didn't handle the BoostPortFeedback.DISCARDED type, which corresponds to a command failing on the Boost hub.

Resolves

#2085

Proposed Changes

the case now declares a commandCompleted constant that has a truthy value if a command has either been completed or discarded.

Reason for Changes

Stalling motor-commands were causing blocks to hang.