### PR TITLE
Fix #2086 by resolving pending promise even when power set to 0%

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -471,7 +471,7 @@ class BoostMotor {
      * @param {number} direction - rotate in this direction
      */
     turnOnForDegrees (degrees, direction) {
-        if (this._power === 0) {
+        if (this.power === 0) {
             this.pendingPromiseFunction();
             return;
         }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -471,7 +471,11 @@ class BoostMotor {
      * @param {number} direction - rotate in this direction
      */
     turnOnForDegrees (degrees, direction) {
-        if (this._power === 0) return;
+        if (this._power === 0) {
+            this.pendingPromiseFunction();
+            return;
+        }
+        
         degrees = Math.max(0, degrees);
 
         const cmd = this._parent.generateOutputCommand(
@@ -1642,8 +1646,8 @@ class Scratch3BoostBlocks {
             const motor = this._peripheral.motor(portID);
             if (motor) {
                 return new Promise(resolve => {
-                    motor.turnOnForDegrees(degrees, sign);
                     motor.pendingPromiseFunction = resolve;
+                    motor.turnOnForDegrees(degrees, sign);
                 });
             }
             return null;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -372,9 +372,11 @@ class BoostMotor {
          * Scale the motor power to a range between 10 and 100,
          * to make sure the motors will run with something built onto them.
          */
-        const p = MathUtil.scale(value, 0, 100, 10, 100);
-        
-        this._power = p;
+        if (value === 0) {
+            this._power = 0;
+        } else {
+            this._power = MathUtil.scale(value, 1, 100, 10, 100);
+        }
     }
 
     /**


### PR DESCRIPTION
Resolves #2086: rotation-based motor-commands hang when power set to 0%