### PR TITLE
Pass block info to extension methods

### DIFF
--- a/src/engine/mutation-adapter.js
+++ b/src/engine/mutation-adapter.js
@@ -13,6 +13,10 @@ const mutatorTagToObject = function (dom) {
     for (const prop in dom.attribs) {
         if (prop === 'xmlns') continue;
         obj[prop] = decodeHtml(dom.attribs[prop]);
+        if (prop === 'blockinfo') {
+            obj.blockInfo = JSON.parse(obj.blockinfo);
+            delete obj.blockinfo;
+        }
     }
     for (let i = 0; i < dom.children.length; i++) {
         obj.children.push(

--- a/test/integration/internal-extension.js
+++ b/test/integration/internal-extension.js
@@ -1,6 +1,8 @@
 const test = require('tap').test;
 const Worker = require('tiny-worker');
 
+const BlockType = require('../../src/extension-support/block-type');
+
 const dispatch = require('../../src/dispatch/central-dispatch');
 const VirtualMachine = require('../../src/virtual-machine');
 
@@ -33,8 +35,9 @@ class TestInternalExtension {
         };
     }
 
-    go () {
+    go (args, util, blockInfo) {
         this.status.goCalled = true;
+        return blockInfo;
     }
 
     _buildAMenu () {
@@ -62,8 +65,21 @@ test('internal extension', t => {
     t.type(func, 'function');
 
     t.notOk(extension.status.goCalled);
-    func();
+    const goBlockInfo = func();
     t.ok(extension.status.goCalled);
+
+    // The 'go' block returns its own blockInfo. Make sure it matches the expected info.
+    // Note that the extension parser fills in missing fields so there are more fields here than in `getInfo`.
+    const expectedBlockInfo = {
+        arguments: {},
+        blockAllThreads: false,
+        blockType: BlockType.COMMAND,
+        func: goBlockInfo.func, // Cheat since we don't have a good way to ensure we generate the same function
+        opcode: 'go',
+        terminal: false,
+        text: 'go'
+    };
+    t.deepEqual(goBlockInfo, expectedBlockInfo);
 
     // There should be 2 menus - one is an array, one is the function to call.
     t.equal(vm.runtime._blockInfo[0].menus.length, 2);


### PR DESCRIPTION
### Resolves

This is a supporting change for the extensionification project.

### Proposed Changes

Extension methods now receive a third argument which contains the section of the `getInfo` results which the extension provided for the block being executed.

### Reason for Changes

Sometimes a single extension method needs to service several different instances of the same opcode. This can happen with variables or custom procedures, for example. This change allows the extension method to inspect the `blockInfo` for instance data, including arbitrary extension-specific properties if necessary.

### Test Coverage

There is now a check check for correct `blockInfo` being passed into an extension method in `test/integration/internal-extension.js`.