### PR TITLE
Fix #2105 by correctly accessing motor position from BoostMotor-class

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1808,8 +1808,8 @@ class Scratch3BoostBlocks {
             log.warn('Asked for a motor position that doesnt exist!');
             return false;
         }
-        if (portID && this.motor(portID)) {
-            return MathUtil.wrapClamp(this.motor(portID).position, 0, 360);
+        if (portID && this._peripheral.motor(portID)) {
+            return MathUtil.wrapClamp(this._peripheral.motor(portID).position, 0, 360);
         }
         return 0;
     }


### PR DESCRIPTION
Resolves #2105 - motor position reporter is broken.