### PR TITLE
Fix BOOST whenColor hat

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1925,7 +1925,7 @@ class Scratch3BoostBlocks {
      * @return {boolean} - true if the tilt sensor is tilted past a threshold in the specified direction.
      */
     whenColor (args) {
-        return this._isColor(args.COLOR);
+        return this._isColor(args);
     }
 
     /**
@@ -1944,7 +1944,7 @@ class Scratch3BoostBlocks {
      * @private
      */
     _isColor (args) {
-        switch (args) {
+        switch (args.COLOR) {
         case BoostColorLabel.ANY:
             if (Object.keys(BoostColor).find(key => BoostColor[key])
                 .toLowerCase() !== this.getColor()) {
@@ -1956,7 +1956,7 @@ class Scratch3BoostBlocks {
             }
             break;
         default:
-            return this.getColor() === color;
+            return this.getColor() === args.COLOR;
         }
     }
 


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/2091

### Proposed Changes

This is a quick fix to make the BOOST "when color seen" hat work for the options other than "any".

### Reason for Changes

This line looks like it was a typo: `return this.getColor() === color;` That definitely never worked, because `color` is the color utility object. 

The "any" option is handled separately, and seems to work. 


