### PR TITLE
use xmlEscape instead of escape-html for extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,7 +3865,8 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "canvas-toBlob": "1.0.0",
     "decode-html": "2.0.0",
     "diff-match-patch": "1.0.4",
-    "escape-html": "1.0.3",
     "format-message": "6.2.1",
     "htmlparser2": "3.10.0",
     "immutable": "3.8.1",

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1,6 +1,5 @@
 const EventEmitter = require('events');
 const {OrderedMap} = require('immutable');
-const escapeHtml = require('escape-html');
 
 const ArgumentType = require('../extension-support/argument-type');
 const Blocks = require('./blocks');
@@ -15,6 +14,7 @@ const log = require('../util/log');
 const maybeFormatMessage = require('../util/maybe-format-message');
 const StageLayering = require('./stage-layering');
 const Variable = require('./variable');
+const xmlEscape = require('../util/xml-escape');
 
 // Virtual I/O devices.
 const Clock = require('../io/clock');
@@ -747,7 +747,7 @@ class Runtime extends EventEmitter {
      * @private
      */
     _makeExtensionMenuId (menuName, extensionId) {
-        return `${extensionId}_menu_${escapeHtml(menuName)}`;
+        return `${extensionId}_menu_${xmlEscape(menuName)}`;
     }
 
     /**
@@ -1207,7 +1207,7 @@ class Runtime extends EventEmitter {
 
         const defaultValue =
             typeof argInfo.defaultValue === 'undefined' ? '' :
-                escapeHtml(maybeFormatMessage(argInfo.defaultValue, this.makeMessageContextForTarget()).toString());
+                xmlEscape(maybeFormatMessage(argInfo.defaultValue, this.makeMessageContextForTarget()).toString());
 
         if (argTypeInfo.check) {
             argJSON.check = argTypeInfo.check;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,6 @@ module.exports = [
         },
         externals: {
             'decode-html': true,
-            'escape-html': true,
             'format-message': true,
             'htmlparser2': true,
             'immutable': true,


### PR DESCRIPTION
### Proposed Changes

Remove `escape-html` from our dependency list in favor of the `xmlEscape` function that we have in `util/xml-scape.js`.

### Reason for Changes

The data being escaped is XML intended for scratch-blocks, so escaping all HTML entities is excessive. Since this is the only place where we use `escape-html` the presence of the dependency is unnecessary.

I'm about to add another place where we need to escape some text in XML intended for scratch-blocks, so this seems like a good time to make the switch proposed in this PR.

Note that `escape-html` is still listed in our `package-lock.json` since it's a dependency of `webpack-dev-server`. That said, `webpack-dev-server` is only a development dependency, which means that `escape-html` is also now only a development dependency and is no longer part of our build output.

### Test Coverage

Existing extension tests cover this change.
