### PR TITLE
Add Arabic to Text to Speech extension

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -78,6 +78,7 @@ const FEMALE_GIANT_RATE = 0.79; // -4 semitones
 /**
  * Language ids. The value for each language id is a valid Scratch locale.
  */
+const ARABIC_ID = 'ar';
 const CHINESE_ID = 'zh-cn';
 const DANISH_ID = 'da';
 const DUTCH_ID = 'nl';
@@ -211,6 +212,12 @@ class Scratch3Text2SpeechBlocks {
      */
     get LANGUAGE_INFO () {
         return {
+            [ARABIC_ID]: {
+                name: 'Arabic',
+                locales: ['ar'],
+                speechSynthLocale: 'arb',
+                singleGender: true
+            },
             [CHINESE_ID]: {
                 name: 'Chinese (Mandarin)',
                 locales: ['zh-cn', 'zh-tw'],


### PR DESCRIPTION
As of a few days ago, the Amazon Polly service now provides an Arabic speaking voice, so this change adds support for it.

Amazon blog post:
https://aws.amazon.com/blogs/machine-learning/amazon-polly-adds-arabic-language-support/