### PR TITLE
Make Boost set motor speed opcode yield for send interval duration

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1804,7 +1804,11 @@ class Scratch3BoostBlocks {
                 }
             }
         });
-        return Promise.resolve();
+        return new Promise(resolve => {
+            window.setTimeout(() => {
+                resolve();
+            }, BoostBLE.sendInterval);
+        });
     }
 
     /**

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1856,7 +1856,11 @@ class Scratch3BoostBlocks {
                 }
             }
         });
-        return Promise.resolve();
+        return new Promise(resolve => {
+            window.setTimeout(() => {
+                resolve();
+            }, BoostBLE.sendInterval);
+        });
     }
 
     /**


### PR DESCRIPTION
### Resolves

- Resolves #2127: BOOST extension: setting speed continuously can result in motor being "stuck on"
- Resolves a similar issue to #2127 for setting direction continuously

### Proposed Changes

Have 'set motor speed' and 'set motor direction' opcodes yield for send interval duration instead of a single tick.