### PR TITLE
Prevent Boost turnOnForDegrees jittering on power set

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1800,8 +1800,8 @@ class Scratch3BoostBlocks {
                         motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
                         break;
                     case BoostMotorState.ON_FOR_ROTATION: {
-                        const p = Math.abs(motor.pendingPositionDestination - motor.position);
-                        motor.turnOnForDegrees(p, Math.sign(p), false);
+                        const p = Math.abs(motor.pendingPositionDestination - motor.position, false);
+                        motor.turnOnForDegrees(p, Math.sign(p));
                         break;
                     }
                     }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1788,23 +1788,14 @@ class Scratch3BoostBlocks {
         this._forEachMotor(args.MOTOR_ID, motorIndex => {
             const motor = this._peripheral.motor(motorIndex);
             if (motor) {
-                const power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
-                // if motor power is already equal to the scaled input power, don't do anything
-                if (motor.power !== MathUtil.scale(power, 1, 100, 10, 100)) {
-                    motor.power = power;
-                    switch (motor.status) {
-                    case BoostMotorState.ON_FOREVER:
-                        motor.turnOnForever(false);
-                        break;
-                    case BoostMotorState.ON_FOR_TIME:
-                        motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
-                        break;
-                    case BoostMotorState.ON_FOR_ROTATION: {
-                        const p = Math.abs(motor.pendingPositionDestination - motor.position, false);
-                        motor.turnOnForDegrees(p, Math.sign(p));
-                        break;
-                    }
-                    }
+                motor.power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
+                switch (motor.status) {
+                case BoostMotorState.ON_FOREVER:
+                    motor.turnOnForever(false);
+                    break;
+                case BoostMotorState.ON_FOR_TIME:
+                    motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
+                    break;
                 }
             }
         });
@@ -1851,11 +1842,6 @@ class Scratch3BoostBlocks {
                     case BoostMotorState.ON_FOR_TIME:
                         motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
                         break;
-                    case BoostMotorState.ON_FOR_ROTATION: {
-                        const p = Math.abs(motor.pendingPositionDestination - motor.position);
-                        motor.turnOnForDegrees(p, Math.sign(p), false);
-                        break;
-                    }
                     }
                 }
             }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1788,19 +1788,23 @@ class Scratch3BoostBlocks {
         this._forEachMotor(args.MOTOR_ID, motorIndex => {
             const motor = this._peripheral.motor(motorIndex);
             if (motor) {
-                motor.power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
-                switch (motor.status) {
-                case BoostMotorState.ON_FOREVER:
-                    motor.turnOnForever(false);
-                    break;
-                case BoostMotorState.ON_FOR_TIME:
-                    motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
-                    break;
-                case BoostMotorState.ON_FOR_ROTATION: {
-                    const p = Math.abs(motor.pendingPositionDestination - motor.position);
-                    motor.turnOnForDegrees(p, Math.sign(p), false);
-                    break;
-                }
+                const power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
+                // if motor power is already equal to the scaled input power, don't do anything
+                if (motor.power !== MathUtil.scale(power, 1, 100, 10, 100)) {
+                    motor.power = power;
+                    switch (motor.status) {
+                    case BoostMotorState.ON_FOREVER:
+                        motor.turnOnForever(false);
+                        break;
+                    case BoostMotorState.ON_FOR_TIME:
+                        motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
+                        break;
+                    case BoostMotorState.ON_FOR_ROTATION: {
+                        const p = Math.abs(motor.pendingPositionDestination - motor.position);
+                        motor.turnOnForDegrees(p, Math.sign(p), false);
+                        break;
+                    }
+                    }
                 }
             }
         });

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1797,8 +1797,8 @@ class Scratch3BoostBlocks {
                     motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
                     break;
                 case BoostMotorState.ON_FOR_ROTATION: {
-                    const p = Math.abs(motor.pendingPositionDestination - motor.position, false);
-                    motor.turnOnForDegrees(p, Math.sign(p));
+                    const p = Math.abs(motor.pendingPositionDestination - motor.position);
+                    motor.turnOnForDegrees(p, Math.sign(p), false);
                     break;
                 }
                 }


### PR DESCRIPTION
### Resolves

- Resolves #2125 BOOST extension: setting speed continuously interferes with "turn for rotations"
- Also resolves potential issues with setting direction during "turn for rotations", as per comment: https://github.com/LLK/scratch-vm/issues/2125#issuecomment-487614200

### Proposed Changes

Prevent setting motor power and direction if it's already in rotation state.

### Testing

Trying to change direction or power during motor rotations now has no effect:

<img width="502" alt="Screen Shot 2019-04-29 at 12 00 25 PM" src="https://user-images.githubusercontent.com/699840/56909512-641fc680-6a76-11e9-9f5d-6cfdb9ff7ffb.png">

