### PR TITLE
Reverse the sign on Boost Motor A position reporter

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1016,10 +1016,7 @@ class Boost {
                 break;
             case BoostIO.MOTOREXT:
             case BoostIO.MOTORINT:
-                // The motor position in port A is reversed by design, so we need
-                // to reverse it here so that all motors match
-                this.motor(portID).position = ((portID === BoostPort.A) ? -1 : 1) *
-                    int32ArrayToNumber(data.slice(4, 8));
+                this.motor(portID).position = int32ArrayToNumber(data.slice(4, 8));
                 break;
             case BoostIO.CURRENT:
             case BoostIO.VOLTAGE:
@@ -1891,7 +1888,13 @@ class Scratch3BoostBlocks {
             return false;
         }
         if (portID && this._peripheral.motor(portID)) {
-            return MathUtil.wrapClamp(this._peripheral.motor(portID).position, 0, 360);
+            let val = this._peripheral.motor(portID).position;
+            // Boost motor A position direction is reversed by design
+            // so we have to reverse the position here
+            if (portID === BoostPort.A) {
+                val *= -1;
+            }
+            return MathUtil.wrapClamp(val, 0, 360);
         }
         return 0;
     }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1888,7 +1888,11 @@ class Scratch3BoostBlocks {
             return false;
         }
         if (portID && this._peripheral.motor(portID)) {
-            return MathUtil.wrapClamp(this._peripheral.motor(portID).position, 0, 360);
+            let val = MathUtil.wrapClamp(this._peripheral.motor(portID).position, 0, 360);
+            if (portID === BoostPort.A) {
+                val *= -1;
+            }
+            return val;
         }
         return 0;
     }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1893,6 +1893,7 @@ class Scratch3BoostBlocks {
         if (portID && this._peripheral.motor(portID)) {
             return MathUtil.wrapClamp(this._peripheral.motor(portID).position, 0, 360);
         }
+        return 0;
     }
 
     /**

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1016,7 +1016,10 @@ class Boost {
                 break;
             case BoostIO.MOTOREXT:
             case BoostIO.MOTORINT:
-                this.motor(portID).position = int32ArrayToNumber(data.slice(4, 8));
+                // The motor position in port A is reversed by design, so we need
+                // to reverse it here so that all motors match
+                this.motor(portID).position = ((portID === BoostPort.A) ? -1 : 1) *
+                    int32ArrayToNumber(data.slice(4, 8));
                 break;
             case BoostIO.CURRENT:
             case BoostIO.VOLTAGE:
@@ -1888,13 +1891,8 @@ class Scratch3BoostBlocks {
             return false;
         }
         if (portID && this._peripheral.motor(portID)) {
-            let val = MathUtil.wrapClamp(this._peripheral.motor(portID).position, 0, 360);
-            if (portID === BoostPort.A) {
-                val *= -1;
-            }
-            return val;
+            return MathUtil.wrapClamp(this._peripheral.motor(portID).position, 0, 360);
         }
-        return 0;
     }
 
     /**


### PR DESCRIPTION
- Resolves #2135: BOOST extension: motor A position reporter seems reversed

### Proposed Fix

The motor in Boost port A is reversed by design, so this PR proposes to reverse its value in the reporter so it matches polarity with the other motor port reported values.