### PR TITLE
Change Boost motor turning behavior for '0 speed' case

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -493,44 +493,33 @@ class BoostMotor {
 
     /**
      * Turn this motor on indefinitely
-     * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
-    turnOnForever (resetState = true){
-        // if (this.power === 0) return;
-        if (resetState) this.status = BoostMotorState.ON_FOREVER;
+    turnOnForever (){
+        this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
 
-        console.log('ON_FOREVER');
+        console.log('this.status', this.status);
     }
 
     /**
      * Turn this motor on for a specific duration.
      * @param {number} milliseconds - run the motor for this long.
-     * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
-    turnOnFor (milliseconds, resetState = true) {
-        // if (this.power === 0) return;
-
+    turnOnFor (milliseconds) {
         milliseconds = Math.max(0, milliseconds);
-        if (resetState) this.status = BoostMotorState.ON_FOR_TIME;
+        this.status = BoostMotorState.ON_FOR_TIME;
         this._turnOn();
         this._setNewTimeout(this.turnOff, milliseconds);
 
-        console.log('ON_FOR_TIME');
+        console.log('this.status', this.status);
     }
 
     /**
      * Turn this motor on for a specific rotation in degrees.
      * @param {number} degrees - run the motor for this amount of degrees.
      * @param {number} direction - rotate in this direction
-     * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
-    turnOnForDegrees (degrees, direction, resetState = true) {
-        // if (this.power === 0) {
-        //    this._clearRotationState();
-        //    return;
-        // }
-
+    turnOnForDegrees (degrees, direction) {
         degrees = Math.max(0, degrees);
 
         const cmd = this._parent.generateOutputCommand(
@@ -546,11 +535,11 @@ class BoostMotor {
             ]
         );
         
-        if (resetState) this.status = BoostMotorState.ON_FOR_ROTATION;
+        this.status = BoostMotorState.ON_FOR_ROTATION;
         this._pendingPositionDestination = this.position + (degrees * this.direction * direction);
         this._parent.send(BoostBLE.characteristic, cmd);
 
-        console.log('ON_FOR_ROTATION');
+        console.log('this.status', this.status);
     }
 
     /**
@@ -574,7 +563,7 @@ class BoostMotor {
         this.status = BoostMotorState.OFF;
         this._parent.send(BoostBLE.characteristic, cmd, useLimiter);
 
-        console.log('OFF');
+        console.log('this.status', this.status);
     }
 
     /**
@@ -1799,14 +1788,14 @@ class Scratch3BoostBlocks {
                 motor.power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
                 switch (motor.status) {
                 case BoostMotorState.ON_FOREVER:
-                    motor.turnOnForever(false);
+                    motor.turnOnForever();
                     break;
                 case BoostMotorState.ON_FOR_TIME:
-                    motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
+                    motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now());
                     break;
                 case BoostMotorState.ON_FOR_ROTATION: {
                     const p = Math.abs(motor.pendingPositionDestination - motor.position);
-                    motor.turnOnForDegrees(p, Math.sign(p), false);
+                    motor.turnOnForDegrees(p, Math.sign(p));
                     break;
                 }
                 }
@@ -1850,14 +1839,14 @@ class Scratch3BoostBlocks {
                 if (motor) {
                     switch (motor.status) {
                     case BoostMotorState.ON_FOREVER:
-                        motor.turnOnForever(false);
+                        motor.turnOnForever();
                         break;
                     case BoostMotorState.ON_FOR_TIME:
-                        motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
+                        motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now());
                         break;
                     case BoostMotorState.ON_FOR_ROTATION: {
                         const p = Math.abs(motor.pendingPositionDestination - motor.position);
-                        motor.turnOnForDegrees(p, Math.sign(p), false);
+                        motor.turnOnForDegrees(p, Math.sign(p));
                         break;
                     }
                     }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -522,10 +522,10 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnForDegrees (degrees, direction, resetState = true) {
-        /* if (this.power === 0) {
-            this._clearRotationState();
-            return;
-        }*/
+        // if (this.power === 0) {
+        //    this._clearRotationState();
+        //    return;
+        // }
 
         degrees = Math.max(0, degrees);
 

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -552,6 +552,7 @@ class BoostMotor {
      * @param {boolean} [useLimiter=true] - if true, use the rate limiter
      */
     turnOff (useLimiter = true) {
+        // if (this.power === 0) return;
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -553,6 +553,7 @@ class BoostMotor {
      */
     turnOff (useLimiter = true) {
         // if (this.power === 0) return;
+        
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -498,7 +498,7 @@ class BoostMotor {
     /**
      * Turn this motor on indefinitely
      */
-    turnOnForever() {
+    turnOnForever () {
         this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
     }
@@ -507,7 +507,7 @@ class BoostMotor {
      * Turn this motor on for a specific duration.
      * @param {number} milliseconds - run the motor for this long.
      */
-    turnOnFor(milliseconds) {
+    turnOnFor (milliseconds) {
         milliseconds = Math.max(0, milliseconds);
         this.status = BoostMotorState.ON_FOR_TIME;
         this._turnOn();
@@ -544,7 +544,7 @@ class BoostMotor {
      * Turn this motor off.
      * @param {boolean} [useLimiter=true] - if true, use the rate limiter
      */
-    turnOff(useLimiter = true) {
+    turnOff (useLimiter = true) {
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -432,7 +432,10 @@ class BoostMotor {
      */
     set status (value) {
         // Clear any time- or rotation-related state from motor and set new status.
-        this._clearRotationState();
+        if (value !== BoostMotorState.ON_FOR_ROTATION) {
+            this._clearRotationState();
+            console.log('clearing rotation state');
+        }
         this._clearTimeout();
         this._status = value;
     }
@@ -493,7 +496,8 @@ class BoostMotor {
     /**
      * Turn this motor on indefinitely
      */
-    turnOnForever (){
+    turnOnForever() {
+        console.log('turnOnForever');
         this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
 
@@ -504,7 +508,8 @@ class BoostMotor {
      * Turn this motor on for a specific duration.
      * @param {number} milliseconds - run the motor for this long.
      */
-    turnOnFor (milliseconds) {
+    turnOnFor(milliseconds) {
+        console.log('turnOnFor');
         milliseconds = Math.max(0, milliseconds);
         this.status = BoostMotorState.ON_FOR_TIME;
         this._turnOn();
@@ -519,6 +524,7 @@ class BoostMotor {
      * @param {number} direction - rotate in this direction
      */
     turnOnForDegrees (degrees, direction) {
+        console.log('turnOnForDegrees');
         degrees = Math.max(0, degrees);
 
         const cmd = this._parent.generateOutputCommand(
@@ -545,7 +551,8 @@ class BoostMotor {
      * Turn this motor off.
      * @param {boolean} [useLimiter=true] - if true, use the rate limiter
      */
-    turnOff (useLimiter = true) {
+    turnOff(useLimiter = true) {
+        console.log('turnOff');
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,
@@ -1727,7 +1734,9 @@ class Scratch3BoostBlocks {
          * Make sure all promises are resolved, i.e. all motor-commands have completed.
          * To prevent the block from returning a value, an empty function is added to the .then
          */
-        return Promise.all(promises).then(() => {});
+        return Promise.all(promises).then(() => {
+            console.log('motorOnForRotation resolved');
+        });
     }
 
     /**

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -499,6 +499,8 @@ class BoostMotor {
         // if (this.power === 0) return;
         if (resetState) this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
+
+        console.log('ON_FOREVER');
     }
 
     /**
@@ -513,6 +515,8 @@ class BoostMotor {
         if (resetState) this.status = BoostMotorState.ON_FOR_TIME;
         this._turnOn();
         this._setNewTimeout(this.turnOff, milliseconds);
+
+        console.log('ON_FOR_TIME');
     }
 
     /**
@@ -545,6 +549,8 @@ class BoostMotor {
         if (resetState) this.status = BoostMotorState.ON_FOR_ROTATION;
         this._pendingPositionDestination = this.position + (degrees * this.direction * direction);
         this._parent.send(BoostBLE.characteristic, cmd);
+
+        console.log('ON_FOR_ROTATION');
     }
 
     /**
@@ -567,6 +573,8 @@ class BoostMotor {
 
         this.status = BoostMotorState.OFF;
         this._parent.send(BoostBLE.characteristic, cmd, useLimiter);
+
+        console.log('OFF');
     }
 
     /**
@@ -1797,8 +1805,8 @@ class Scratch3BoostBlocks {
                     motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now(), false);
                     break;
                 case BoostMotorState.ON_FOR_ROTATION: {
-                    const p = Math.abs(motor.pendingPositionDestination - motor.position, false);
-                    motor.turnOnForDegrees(p, Math.sign(p));
+                    const p = Math.abs(motor.pendingPositionDestination - motor.position);
+                    motor.turnOnForDegrees(p, Math.sign(p), false);
                     break;
                 }
                 }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -555,8 +555,6 @@ class BoostMotor {
      * @param {boolean} [useLimiter=true] - if true, use the rate limiter
      */
     turnOff (useLimiter = true) {
-        // if (this.power === 0) return;
-
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -553,7 +553,7 @@ class BoostMotor {
      */
     turnOff (useLimiter = true) {
         // if (this.power === 0) return;
-        
+
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -496,7 +496,10 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnForever (resetState = true){
-        if (this.power === 0) return;
+        if (this.power === 0) {
+            this.turnOff(false);
+        }
+        
         if (resetState) this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
     }
@@ -552,7 +555,7 @@ class BoostMotor {
      * @param {boolean} [useLimiter=true] - if true, use the rate limiter
      */
     turnOff (useLimiter = true) {
-        if (this.power === 0) return;
+        // if (this.power === 0) return;
 
         const cmd = this._parent.generateOutputCommand(
             this._index,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -477,7 +477,7 @@ class BoostMotor {
      * @private
      */
     _turnOn () {
-        //if (this.power === 0) return;
+        // if (this.power === 0) return;
         
         const cmd = this._parent.generateOutputCommand(
             this._index,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -431,14 +431,13 @@ class BoostMotor {
      * @param {BoostMotorState} value - set this motor's state.
      */
     set status (value) {
-        // Clear any time- or rotation-related state from motor and set new status.
         if (value !== BoostMotorState.ON_FOR_ROTATION) {
+            // clear rotation pending promise only if not already in rotation state
             this._clearRotationState();
-            console.log('clearing rotation state');
         }
         if (value !== BoostMotorState.ON_FOR_TIME) {
+            // clear duration pending promise only if not already in duration state
             this._clearTimeout();
-            console.log('clearing for_time state');
         }
         this._status = value;
     }
@@ -500,11 +499,8 @@ class BoostMotor {
      * Turn this motor on indefinitely
      */
     turnOnForever() {
-        console.log('turnOnForever');
         this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
-
-        console.log('this.status', this.status);
     }
 
     /**
@@ -512,13 +508,10 @@ class BoostMotor {
      * @param {number} milliseconds - run the motor for this long.
      */
     turnOnFor(milliseconds) {
-        console.log('turnOnFor');
         milliseconds = Math.max(0, milliseconds);
         this.status = BoostMotorState.ON_FOR_TIME;
         this._turnOn();
         this._setNewTimeout(this.turnOff, milliseconds);
-
-        console.log('this.status', this.status);
     }
 
     /**
@@ -527,7 +520,6 @@ class BoostMotor {
      * @param {number} direction - rotate in this direction
      */
     turnOnForDegrees (degrees, direction) {
-        console.log('turnOnForDegrees');
         degrees = Math.max(0, degrees);
 
         const cmd = this._parent.generateOutputCommand(
@@ -546,8 +538,6 @@ class BoostMotor {
         this.status = BoostMotorState.ON_FOR_ROTATION;
         this._pendingPositionDestination = this.position + (degrees * this.direction * direction);
         this._parent.send(BoostBLE.characteristic, cmd);
-
-        console.log('this.status', this.status);
     }
 
     /**
@@ -555,7 +545,6 @@ class BoostMotor {
      * @param {boolean} [useLimiter=true] - if true, use the rate limiter
      */
     turnOff(useLimiter = true) {
-        console.log('turnOff');
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,
@@ -569,8 +558,6 @@ class BoostMotor {
 
         this.status = BoostMotorState.OFF;
         this._parent.send(BoostBLE.characteristic, cmd, useLimiter);
-
-        console.log('this.status', this.status);
     }
 
     /**
@@ -1737,9 +1724,7 @@ class Scratch3BoostBlocks {
          * Make sure all promises are resolved, i.e. all motor-commands have completed.
          * To prevent the block from returning a value, an empty function is added to the .then
          */
-        return Promise.all(promises).then(() => {
-            console.log('motorOnForRotation resolved');
-        });
+        return Promise.all(promises).then(() => {});
     }
 
     /**

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -477,7 +477,8 @@ class BoostMotor {
      * @private
      */
     _turnOn () {
-        if (this.power === 0) return;
+        //if (this.power === 0) return;
+        
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY,
@@ -496,9 +497,9 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnForever (resetState = true){
-        if (this.power === 0) {
+        /* if (this.power === 0) {
             this.turnOff(false);
-        }
+        } */
         
         if (resetState) this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
@@ -510,9 +511,9 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnFor (milliseconds, resetState = true) {
-        if (this.power === 0) {
+        /* if (this.power === 0) {
             this.turnOff(false);
-        }
+        } */
 
         milliseconds = Math.max(0, milliseconds);
         if (resetState) this.status = BoostMotorState.ON_FOR_TIME;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -436,7 +436,10 @@ class BoostMotor {
             this._clearRotationState();
             console.log('clearing rotation state');
         }
-        this._clearTimeout();
+        if (value !== BoostMotorState.ON_FOR_TIME) {
+            this._clearTimeout();
+            console.log('clearing for_time state');
+        }
         this._status = value;
     }
 

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -478,7 +478,6 @@ class BoostMotor {
      */
     _turnOn () {
         // if (this.power === 0) return;
-        
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY,
@@ -498,7 +497,6 @@ class BoostMotor {
      */
     turnOnForever (resetState = true){
         // if (this.power === 0) return;
-        
         if (resetState) this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
     }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -477,7 +477,6 @@ class BoostMotor {
      * @private
      */
     _turnOn () {
-        // if (this.power === 0) return;
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY,
@@ -547,8 +546,6 @@ class BoostMotor {
      * @param {boolean} [useLimiter=true] - if true, use the rate limiter
      */
     turnOff (useLimiter = true) {
-        // if (this.power === 0) return;
-
         const cmd = this._parent.generateOutputCommand(
             this._index,
             BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -497,9 +497,7 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnForever (resetState = true){
-        /* if (this.power === 0) {
-            this.turnOff(false);
-        } */
+        // if (this.power === 0) return;
         
         if (resetState) this.status = BoostMotorState.ON_FOREVER;
         this._turnOn();
@@ -511,9 +509,7 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnFor (milliseconds, resetState = true) {
-        /* if (this.power === 0) {
-            this.turnOff(false);
-        } */
+        // if (this.power === 0) return;
 
         milliseconds = Math.max(0, milliseconds);
         if (resetState) this.status = BoostMotorState.ON_FOR_TIME;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -510,7 +510,9 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnFor (milliseconds, resetState = true) {
-        if (this.power === 0) return;
+        if (this.power === 0) {
+            this.turnOff(false);
+        }
 
         milliseconds = Math.max(0, milliseconds);
         if (resetState) this.status = BoostMotorState.ON_FOR_TIME;
@@ -525,10 +527,10 @@ class BoostMotor {
      * @param {boolean} [resetState=true] - whether to reset the state of the motor when running this command.
      */
     turnOnForDegrees (degrees, direction, resetState = true) {
-        if (this.power === 0) {
+        /* if (this.power === 0) {
             this._clearRotationState();
             return;
-        }
+        }*/
 
         degrees = Math.max(0, degrees);
 


### PR DESCRIPTION
### Resolves

- Resolves #2136: BOOST extension: setting speed to 0 after motor is on results in it being stuck on

### Proposed Changes

- Remove all the `this.power === 0` checks in the motor turning functions, which were brought over from the WeDo2 extension, and were incompatible with the `BoostMotorState` paradigm.
- Remove all use of `resetState` flag since it didn't seem necessary after removing the `this.power===0` checks.
- Fix the motor `status` setter to not clear rotation promise if in `ON_FOR_ROTATION` and not clear timeout promise if in `ON_FOR_TIME`