### PR TITLE
Add a runtime event for requesting a toolbox update

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -510,7 +510,7 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Event name for report that a change was made that can be saved
+     * Event name for report that a change was made to an extension in the toolbox.
      * @const {string}
      */
     static get TOOLBOX_EXTENSIONS_NEED_UPDATE () {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -510,6 +510,14 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Event name for report that a change was made that can be saved
+     * @const {string}
+     */
+    static get TOOLBOX_EXTENSIONS_NEED_UPDATE () {
+        return 'TOOLBOX_EXTENSIONS_NEED_UPDATE';
+    }
+
+    /**
      * Event name for targets update report.
      * @const {string}
      */
@@ -1963,10 +1971,15 @@ class Runtime extends EventEmitter {
      * @param {!Target} editingTarget New editing target.
      */
     setEditingTarget (editingTarget) {
+        const oldEditingTarget = this._editingTarget;
         this._editingTarget = editingTarget;
         // Script glows must be cleared.
         this._scriptGlowsPreviousFrame = [];
         this._updateGlows();
+
+        if (oldEditingTarget !== this._editingTarget) {
+            this.requestToolboxExtensionsUpdate();
+        }
     }
 
     /**
@@ -2384,10 +2397,17 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Emit an event that indicate that the blocks on the workspace need updating.
+     * Emit an event that indicates that the blocks on the workspace need updating.
      */
     requestBlocksUpdate () {
         this.emit(Runtime.BLOCKS_NEED_UPDATE);
+    }
+
+    /**
+     * Emit an event that indicates that the toolbox extension blocks need updating.
+     */
+    requestToolboxExtensionsUpdate () {
+        this.emit(Runtime.TOOLBOX_EXTENSIONS_NEED_UPDATE);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -121,6 +121,9 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.BLOCKS_NEED_UPDATE, () => {
             this.emitWorkspaceUpdate();
         });
+        this.runtime.on(Runtime.TOOLBOX_EXTENSIONS_NEED_UPDATE, () => {
+            this.extensionManager.refreshBlocks();
+        });
         this.runtime.on(Runtime.PERIPHERAL_LIST_UPDATE, info => {
             this.emit(Runtime.PERIPHERAL_LIST_UPDATE, info);
         });


### PR DESCRIPTION
Adds a new runtime event which the vm listens for and issues a toolbox update for extension blocks. This event is triggered on switching sprites so that extensions can contain target-dependent blocks. This is necessary for the extensionification of variables and custom procedures (towards #2120).