### PR TITLE
Add internal use only virtual machine blocks

### DIFF
--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -20,34 +20,32 @@ class Scratch3ProcedureBlocks {
     }
 
     call (args, util) {
-        if (!util.stackFrame.executed) {
-            const procedureCode = args.mutation.proccode;
-            const paramNamesIdsAndDefaults = util.getProcedureParamNamesIdsAndDefaults(procedureCode);
+        const procedureCode = args.mutation.proccode;
+        const paramNamesIdsAndDefaults = util.getProcedureParamNamesIdsAndDefaults(procedureCode);
 
-            // If null, procedure could not be found, which can happen if custom
-            // block is dragged between sprites without the definition.
-            // Match Scratch 2.0 behavior and noop.
-            if (paramNamesIdsAndDefaults === null) {
-                return;
-            }
-
-            const [paramNames, paramIds, paramDefaults] = paramNamesIdsAndDefaults;
-
-            // Initialize params for the current stackFrame to {}, even if the procedure does
-            // not take any arguments. This is so that `getParam` down the line does not look
-            // at earlier stack frames for the values of a given parameter (#1729)
-            util.initParams();
-            for (let i = 0; i < paramIds.length; i++) {
-                if (args.hasOwnProperty(paramIds[i])) {
-                    util.pushParam(paramNames[i], args[paramIds[i]]);
-                } else {
-                    util.pushParam(paramNames[i], paramDefaults[i]);
-                }
-            }
-
-            util.stackFrame.executed = true;
-            util.startProcedure(procedureCode);
+        // If null, procedure could not be found, which can happen if custom
+        // block is dragged between sprites without the definition.
+        // Match Scratch 2.0 behavior and noop.
+        if (paramNamesIdsAndDefaults === null) {
+            return;
         }
+
+        const [paramNames, paramIds, paramDefaults] = paramNamesIdsAndDefaults;
+
+        util.startProcedure(procedureCode);
+
+        // Initialize params for the current stackFrame to {}, even if the procedure does
+        // not take any arguments. This is so that `getParam` down the line does not look
+        // at earlier stack frames for the values of a given parameter (#1729)
+        util.initParams();
+        for (let i = 0; i < paramIds.length; i++) {
+            if (args.hasOwnProperty(paramIds[i])) {
+                util.pushParam(paramNames[i], args[paramIds[i]]);
+            } else {
+                util.pushParam(paramNames[i], paramDefaults[i]);
+            }
+        }
+
     }
 
     argumentReporterStringNumber (args, util) {

--- a/src/blocks/scratch3_procedures.js
+++ b/src/blocks/scratch3_procedures.js
@@ -13,15 +13,10 @@ class Scratch3ProcedureBlocks {
      */
     getPrimitives () {
         return {
-            procedures_definition: this.definition,
             procedures_call: this.call,
             argument_reporter_string_number: this.argumentReporterStringNumber,
             argument_reporter_boolean: this.argumentReporterBoolean
         };
-    }
-
-    definition () {
-        // No-op: execute the blocks.
     }
 
     call (args, util) {

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -60,11 +60,7 @@ class BlockUtility {
      * @type {object}
      */
     get stackFrame () {
-        const frame = this.thread.peekStackFrame();
-        if (frame.executionContext === null) {
-            frame.executionContext = {};
-        }
-        return frame.executionContext;
+        return this.thread.getExecutionContext();
     }
 
     /**

--- a/src/engine/engine-blocks.js
+++ b/src/engine/engine-blocks.js
@@ -1,0 +1,237 @@
+const {Map} = require('immutable');
+
+const Cast = require('../util/cast');
+const execute = require('../engine/execute');
+const Thread = require('../engine/thread');
+const BlocksExecuteCache = require('../engine/blocks-execute-cache');
+
+class Scratch3VMBlocks {
+    constructor (runtime) {
+        /**
+         * The runtime instantiating this block package.
+         * @type {Runtime}
+         */
+        this.runtime = runtime;
+    }
+
+    /**
+     * Retrieve the block primitives implemented by this package.
+     * @return {object.<string, Function>} Mapping of opcode to Function.
+     */
+    getPrimitives () {
+        return {
+            vm_end_of_thread: this.endOfThread,
+            vm_end_of_procedure: this.endOfProcedure,
+            vm_end_of_loop_branch: this.endOfLoopBranch,
+            vm_end_of_branch: this.endOfBranch,
+            vm_reenter_promise: this.reenterFromPromise,
+            vm_report_hat: this.reportHat,
+            vm_report_stack_click: this.reportStackClick,
+            vm_report_monitor: this.reportMonitor
+        };
+    }
+
+    getHats () {
+        return {
+        };
+    }
+
+    endOfThread (args, {thread}) {
+        thread.popStack();
+        thread.status = Thread.STATUS_DONE;
+    }
+
+    endOfProcedure (args, {thread}) {
+        thread.popStack();
+        thread.goToNextBlock();
+    }
+
+    endOfLoopBranch (args, {thread}) {
+        thread.popStack();
+        thread.status = Thread.STATUS_YIELD;
+    }
+
+    endOfBranch (args, {thread}) {
+        thread.popStack();
+        thread.goToNextBlock();
+    }
+
+    _getBlockCached (sequencer, thread, currentBlockId) {
+        const blockCached = (
+            BlocksExecuteCache.getCached(thread.blockContainer, currentBlockId) ||
+            BlocksExecuteCache.getCached(sequencer.blocks, currentBlockId) ||
+            BlocksExecuteCache.getCached(sequencer.runtime.flyoutBlocks, currentBlockId)
+        );
+        if (blockCached === null) {
+            // No block found: stop the thread; script no longer exists.
+            sequencer.retireThread(thread);
+        }
+        return blockCached;
+    }
+
+    reenterFromPromise (args, {sequencer, thread}) {
+        thread.popStack();
+
+        // Current block to execute is the one on the top of the stack.
+        const currentBlockId = thread.peekStack();
+
+        const blockCached = this._getBlockCached(sequencer, thread, currentBlockId);
+        if (blockCached === null) return;
+
+        const ops = blockCached._ops;
+        let i = 0;
+
+        const reported = thread.reported;
+        // Reinstate all the previous values.
+        for (; i < reported.length; i++) {
+            const {opCached: oldOpCached, inputValue} = reported[i];
+
+            const opCached = ops.find(op => op.id === oldOpCached);
+
+            if (opCached) {
+                const inputName = opCached._parentKey;
+                const argValues = opCached._parentValues;
+                argValues[inputName] = inputValue;
+            }
+        }
+
+        // Find the last reported block that is still in the set of operations.
+        // This way if the last operation was removed, we'll find the next
+        // candidate. If an earlier block that was performed was removed then
+        // we'll find the index where the last operation is now.
+        if (reported.length > 0) {
+            const lastExisting = reported.reverse().find(report => ops.find(op => op.id === report.opCached));
+            if (lastExisting) {
+                i = ops.findIndex(opCached => opCached.id === lastExisting.opCached) + 1;
+            } else {
+                i = 0;
+            }
+        }
+
+        // The reporting block must exist and must be the next one in the
+        // sequence of operations.
+        if (
+            thread.justReported !== null &&
+            ops[i] && ops[i].id === thread.reporting
+        ) {
+            const opCached = ops[i];
+            const inputValue = thread.justReported;
+
+            thread.justReported = null;
+
+            const inputName = opCached._parentKey;
+            const argValues = opCached._parentValues;
+            argValues[inputName] = inputValue;
+        }
+
+        i += 1;
+
+        thread.reporting = null;
+        thread.reported = null;
+
+        const allOps = blockCached._allOps;
+        blockCached._ops = ops.slice(i);
+        blockCached._allOps = allOps.slice(i);
+
+        const continuous = thread.continuous;
+        thread.continuous = false;
+        execute(sequencer, thread);
+        thread.continuous = continuous;
+
+        blockCached._ops = ops;
+        blockCached._allOps = allOps;
+
+        if (thread.reported) {
+            thread.reported = reported.concat(thread.reported);
+        }
+
+        if (
+            thread.status === Thread.STATUS_RUNNING &&
+            thread.peekStack() === currentBlockId
+        ) {
+            thread.goToNextBlock();
+        }
+    }
+
+    reportHat (args, {sequencer, thread}) {
+        // reportHat is injected as the final operation to the actual hat block
+        // id by execute.js. So looking at the top of the stack will get us the
+        const currentBlockId = thread.peekStack();
+
+        const blockCached = this._getBlockCached(sequencer, thread, currentBlockId);
+        if (blockCached === null) return;
+
+        const opcode = blockCached.opcode;
+
+        const resolvedValue = args.VALUE;
+
+        // Hat predicate was evaluated.
+        if (sequencer.runtime.getIsEdgeActivatedHat(opcode)) {
+            // If this is an edge-activated hat, only proceed if the value is
+            // true and used to be false, or the stack was activated explicitly
+            // via stack click
+            if (!thread.stackClick) {
+                const hasOldEdgeValue = thread.target.hasEdgeActivatedValue(currentBlockId);
+                const oldEdgeValue = thread.target.updateEdgeActivatedValue(
+                    currentBlockId,
+                    resolvedValue
+                );
+
+                const edgeWasActivated = hasOldEdgeValue ? (!oldEdgeValue && resolvedValue) : resolvedValue;
+                if (!edgeWasActivated) {
+                    sequencer.retireThread(thread);
+                }
+            }
+        } else if (!resolvedValue) {
+            // Not an edge-activated hat: retire the thread
+            // if predicate was false.
+            sequencer.retireThread(thread);
+        }
+    }
+
+    reportStackClick (args, {sequencer, thread}) {
+        // Current block to execute is the one on the top of the stack.
+        const currentBlockId = thread.topBlock;
+
+        const blockCached = this._getBlockCached(sequencer, thread, currentBlockId);
+        if (blockCached === null) return;
+
+        const isHat = blockCached._isHat;
+        const resolvedValue = blockCached._parentValues[blockCached._parentKey];
+
+        if (!isHat && typeof resolvedValue !== 'undefined') {
+            sequencer.runtime.visualReport(currentBlockId, resolvedValue);
+        }
+
+        thread.popStack();
+        thread.status = Thread.STATUS_DONE;
+    }
+
+    reportMonitor (args, {sequencer, thread}) {
+        // Current block to execute is the one on the top of the stack.
+        const currentBlockId = thread.topBlock;
+
+        const blockCached = this._getBlockCached(sequencer, thread, currentBlockId);
+        if (blockCached === null) return;
+
+        const resolvedValue = blockCached._parentValues[blockCached._parentKey];
+
+        if (typeof resolvedValue !== 'undefined') {
+            const targetId = sequencer.runtime.monitorBlocks.getBlock(currentBlockId).targetId;
+            if (targetId && !sequencer.runtime.getTargetById(targetId)) {
+                // Target no longer exists
+                return;
+            }
+            sequencer.runtime.requestUpdateMonitor(Map({
+                id: currentBlockId,
+                spriteName: targetId ? sequencer.runtime.getTargetById(targetId).getName() : null,
+                value: resolvedValue
+            }));
+        }
+
+        thread.popStack();
+        thread.status = Thread.STATUS_DONE;
+    }
+}
+
+module.exports = Scratch3VMBlocks;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -385,7 +385,6 @@ const execute = function (sequencer, thread) {
 
     // Current block to execute is the one on the top of the stack.
     const currentBlockId = thread.peekStack();
-    const currentStackFrame = thread.peekStackFrame();
 
     let blockContainer = thread.blockContainer;
     let blockCached = BlocksExecuteCache.getCached(blockContainer, currentBlockId, BlockCached);
@@ -404,8 +403,8 @@ const execute = function (sequencer, thread) {
     const length = ops.length;
     let i = 0;
 
-    if (currentStackFrame.reported !== null) {
-        const reported = currentStackFrame.reported;
+    if (thread.reported !== null) {
+        const reported = thread.reported;
         // Reinstate all the previous values.
         for (; i < reported.length; i++) {
             const {opCached: oldOpCached, inputValue} = reported[i];
@@ -441,7 +440,7 @@ const execute = function (sequencer, thread) {
         }
 
         // The reporting block must exist and must be the next one in the sequence of operations.
-        if (thread.justReported !== null && ops[i] && ops[i].id === currentStackFrame.reporting) {
+        if (thread.justReported !== null && ops[i] && ops[i].id === thread.reporting) {
             const opCached = ops[i];
             const inputValue = thread.justReported;
 
@@ -462,8 +461,8 @@ const execute = function (sequencer, thread) {
             i += 1;
         }
 
-        currentStackFrame.reporting = null;
-        currentStackFrame.reported = null;
+        thread.reporting = null;
+        thread.reported = null;
     }
 
     for (; i < length; i++) {
@@ -518,8 +517,8 @@ const execute = function (sequencer, thread) {
             // operation if it is promise waiting will set its parent value at
             // that time.
             thread.justReported = null;
-            currentStackFrame.reporting = ops[i].id;
-            currentStackFrame.reported = ops.slice(0, i).map(reportedCached => {
+            thread.reporting = ops[i].id;
+            thread.reported = ops.slice(0, i).map(reportedCached => {
                 const inputName = reportedCached._parentKey;
                 const reportedValues = reportedCached._parentValues;
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -716,6 +716,8 @@ class Runtime extends EventEmitter {
                         if (packagePrimitives.hasOwnProperty(op)) {
                             this._primitives[op] =
                                 packagePrimitives[op].bind(packageObject);
+                            this._primitives[op]._function = packagePrimitives[op];
+                            this._primitives[op]._context = packageObject;
                         }
                     }
                 }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -37,7 +37,8 @@ const defaultBlockPackages = {
     scratch3_sound: require('../blocks/scratch3_sound'),
     scratch3_sensing: require('../blocks/scratch3_sensing'),
     scratch3_data: require('../blocks/scratch3_data'),
-    scratch3_procedures: require('../blocks/scratch3_procedures')
+    scratch3_procedures: require('../blocks/scratch3_procedures'),
+    scratch3_vm: require('./engine-blocks')
 };
 
 /**
@@ -1447,7 +1448,14 @@ class Runtime extends EventEmitter {
             this.monitorBlocks :
             target.blocks;
 
-        thread.pushStack(id);
+        if (opts.stackClick) {
+            thread.pushStack(id, 'vm_report_stack_click');
+        } else if (opts.updateMonitor) {
+            thread.pushStack(id, 'vm_report_monitor');
+        } else {
+            thread.pushStack(id, 'vm_end_of_thread');
+        }
+
         this.threads.push(thread);
         return thread;
     }
@@ -1493,9 +1501,7 @@ class Runtime extends EventEmitter {
      */
     isActiveThread (thread) {
         return (
-            (
-                thread.stack.length > 0 &&
-                thread.status !== Thread.STATUS_DONE) &&
+            (thread.status !== Thread.STATUS_DONE) &&
             this.threads.indexOf(thread) > -1);
     }
 

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -350,7 +350,7 @@ class Sequencer {
      */
     retireThread (thread) {
         thread.stack = [];
-        thread.stackFrame = [];
+        thread.stackFrames = [];
         thread.requestScriptGlowInFrame = false;
         thread.status = Thread.STATUS_DONE;
     }

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -264,7 +264,9 @@ class Sequencer {
 
             // Execute the current block.
             if (this.runtime.profiler === null) {
+                thread.continuous = true;
                 execute(this, thread);
+                thread.continuous = false;
             } else {
                 if (executeProfilerId === -1) {
                     executeProfilerId = this.runtime.profiler.idByName(executeProfilerFrame);
@@ -278,12 +280,14 @@ class Sequencer {
                 this.runtime.profiler.records.push(
                     this.runtime.profiler.START, executeProfilerId, null, 0);
 
+                thread.continuous = true;
                 execute(this, thread);
+                thread.continuous = false;
 
                 // this.runtime.profiler.stop();
                 this.runtime.profiler.records.push(this.runtime.profiler.STOP, 0);
             }
-            thread.blockGlowInFrame = currentBlockId;
+
             // If the thread has yielded or is waiting, yield to other threads.
             if (
                 thread.status === Thread.STATUS_YIELD &&
@@ -305,6 +309,8 @@ class Sequencer {
             // Mark as running for next iteration.
             thread.status = Thread.STATUS_RUNNING;
         }
+
+        thread.warpTimer = null;
     }
 
     /**

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -116,6 +116,13 @@ class Thread {
         this.topBlock = firstBlock;
 
         /**
+         * Signal to execute that it may execute blocks continuously until the
+         * thread status is in a non-running state.
+         * @type {boolean}
+         */
+        this.continuous = false;
+
+        /**
          * Stack for the thread. When the sequencer enters a control structure,
          * the block is pushed onto the stack so we know where to exit.
          * @type {Array.<string>}
@@ -203,6 +210,17 @@ class Thread {
          * @type {Array.<*>}
          */
         this.reported = null;
+    }
+
+    /**
+     * Thread status for interrupting executing thread.
+     * This is for breaking out of a block execution loop because an assumption
+     * was broken during execution. Breaking the assumption is ok but means
+     * that the assumptions need to be rebuilt to new values.
+     * @const
+     */
+    static get STATUS_INTERRUPT () {
+        return -1;
     }
 
     /**


### PR DESCRIPTION
### Resolves

Performance switching between blocks in Sequencer.stepThread and execute.

### Proposed Changes

Depends on https://github.com/LLK/scratch-vm/pull/2145.
Related to https://github.com/LLK/scratch-vm/pull/2148.

- Build a block operation set with all next blocks using a virtual machine block to step to the next one
- Add for internal use only virtual machine blocks
- Add Thread.STATUS_INTERRUPT
- Add Thread.continuous
- Store and call unbound block primitives with their context if available
- Add a virtual machine block to handle the end of a stack frame for procedures, loop branches, non-loop branches, and threads
- Add StackFrame.endBlockId
- Skip profiling some opcodes (vm_*)
- Use a virtual machine block to support the BROADCAST_INPUT block special case
- Use a virtual machine block to report hat values
- Use a virtual machine block to report stack click visual reports
- Use a virtual machine block to report monitor results
- Push vm_reenter_promise after the Promise resolves
- Store reported values in execute.js:handlePromise
- Collectively through other changes reduce the required branching around executing a block function

### Reason for Changes

> - Build a block operation set with all next blocks using a virtual machine block to step to the next one

This is where this whole change set is heading so let's start here. Back in June/July we made a change to reporter execution by creating a set of all reporters and their final command block (optional for stack clicks) and executing that set in a for loop instead of the recursive walk through the reporters. This change is of the same idea, applied to command blocks.

With this a command block and each following block build a set of `_ops` we can use for promise thawing and `_allOps` inlining all of the `_ops` of the block and each next block. When the conditions are met this set of block operations can be performed in one `for` loop. If the conditions fail we safely fallback the `do-while` loop containing `for` the loop. And if we still fail there we can fall back to Sequencer.stepThread and ultimately Sequencer.stepThreads. In most cases we should be able to stay in execute and quickly execute a thread.
 
> - Add for internal use only virtual machine blocks

To make this possible some of the virtual machine behaviour need to be blocks. We can determine the block functions to perform ahead of time and execute them without have to passively test when we do that virtual machine work.

Effectively at this point execute uses this and the block operation sets to compile the current block state for a target on demand (or just-in-time). And with the compiled sets in the blocks cache, they will continue to be disposed of when a block is changed on the target.

> - Add Thread.STATUS_INTERRUPT

To support fall back from the inner execution loops, we make use of Thread.status and a new value Thread.STATUS_INTERRUPT. We already need to test status in case it becomes YIELD, YIELD_TICK, PROMISE_WAIT, or DONE. Using that fact we can use INTERRUPT in the internal use only blocks to signal the inner loop to break and return to outer code paths.

Using INTERRUPT, internal blocks can indicate to execute to reconsider the block operation set to execute if say for example another block a new branch. The branch blocks are not in the current execution set so execute should break out of the inner loop and retrieve the new block operation set to execute.

> - Add Thread.continuous

One more new member and value works with Thread.status to control the execute loops. Thread.continuous indicates if a thread should continue to execute after a command block or operate one block at a time. The default is `false` for one at a time. Sequencer will set it temporarily to `true` to enable the fast execute loop.

> - Store and call unbound block primitives with their context if available

A bound function has to be two function calls. The produced bound function calls the original function. A non-bound function called with Function.call is one function call. The difference of one function call can improve performance in the inner execution loop since many reporters (operator_*) are fairly cheap.

> - Add a virtual machine block to handle the end of a stack frame for procedures, loop branches, non-loop branches, and threads
> - Add StackFrame.endBlockId

We can move the branching for popping stacks from Sequencer and execute into virtual machine blocks. We can determine the blocks to be used ahead of time when a stack frame is pushed.

This lets us reduce the passive branch tests related to stack popping. I think popping with virtual machine blocks will follow easily as it mirrors the blocks that push the stack frames.

> - Skip profiling some opcodes (vm_*)

Profiling itself takes time away from executing more blocks. For internal behaviour I think skipping these blocks will help us make normal blocks perform better.

> - Use a virtual machine block to support the BROADCAST_INPUT block special case

BROADCAST_INPUT block inputs have a different behaviour when they store their value. This is currently supported by testing every block if its output will be stored as BROADCAST_INPUT. Making this the needed behaviour (casting to a string) a block behaviour we can determine to use that ahead of time after the block that produces its value. As such we'll remove a branching point from our inner loop.

This also lets us remove BROADCAST_INPUT special case logic when freezing and thawing thread execution for promises.

> - Use a virtual machine block to report hat values
> - Use a virtual machine block to report stack click visual reports
> - Use a virtual machine block to report monitor results

Like BROADCAST_INPUT, we currently test every reporter and command block if it is the lastOperation which may need to report to one of these behaviours. Then for command blocks (who for lastOperation is always true) or some reporters (who for lastOperation may be true if they are returning a stack click or monitor value) test the possible ways they need to report.

We can determine when these behaviours are needed ahead of time and turn the passive branching into planned actions. Hats can be determine when the operation is cached. Stack click reports and monitors can be determined when the thread is created and be set as the end block for the thread.

Though stack click is a bit weird in this. This version tries to report the topBlock when the last block executed in the therad was the topBlock or not. This likely isn't an issue as the case where we report is stack clicking a reporter. That'll still function here. The weird part is stack clicking on command blocks or a series of command blocks. We'll currently try to report the topBlock's value (which could be wrong if there was any non-running status) but this probably won't be an issue either as command blocks only return promises that resolve to undefined or undefined directly. And hat's which do return values are explicitly excluded in this change set.

> - Push vm_reenter_promise after the Promise resolves

Most of the thread from-a-promise-reentry logic is moved into a block. Most of this is the existing thread thawing behaviour with an added twist that temporarily modifies the operations set and sets continuous to false.

If the promise was for a command block we'll have the same thread popping behaviour. Just later when the thread would normally be executed. This is thanks to the vm_end_of_ virtual blocks. Those let us represent the popping behaviour in one place and promise reentry doesn't need to know it.

> - Store reported values in execute.js:handlePromise

This is a small change. Its the same block we already have but in handlePromise itself.

> - Collectively through other changes reduce the required branching around executing a block function

The inner execute loop at this point is very small. Which lets us execute blocks faster.

The remaining bit is profiling ... I want to move that, but the best case would be to split the execute function and call the right one from a newly exported execute function, or call the right inner function from sequencer.
