### PR TITLE
Thread always done

### DIFF
--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -380,6 +380,15 @@ const execute = function (sequencer, thread) {
         }
     }
 
+    // Blocks should glow when a script is starting, not after it has finished
+    // (see #1404). Only blocks in blockContainers that don't forceNoGlow should
+    // request a glow.
+    if (!blockContainer.forceNoGlow) {
+        thread.requestScriptGlowInFrame = true;
+        // Indicate the block that is executing.
+        thread.blockGlowInFrame = currentBlockId;
+    }
+
     const ops = blockCached._ops;
     const length = ops.length;
     let i = 0;
@@ -456,14 +465,6 @@ const execute = function (sequencer, thread) {
         const argValues = opCached._argValues;
 
         // Fields are set during opCached initialization.
-
-        // Blocks should glow when a script is starting,
-        // not after it has finished (see #1404).
-        // Only blocks in blockContainers that don't forceNoGlow
-        // should request a glow.
-        if (!blockContainer.forceNoGlow) {
-            thread.requestScriptGlowInFrame = true;
-        }
 
         // Inputs are set during previous steps in the loop.
 

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -111,30 +111,10 @@ const handlePromise = (primitiveReportedValue, sequencer, thread, blockCached, l
     }
     // Promise handlers
     primitiveReportedValue.then(resolvedValue => {
+        if (thread.status === Thread.STATUS_DONE) return;
         handleReport(resolvedValue, sequencer, thread, blockCached, lastOperation);
         // If it's a command block or a top level reporter in a stackClick.
-        if (lastOperation) {
-            let stackFrame;
-            let nextBlockId;
-            do {
-                // In the case that the promise is the last block in the current thread stack
-                // We need to pop out repeatedly until we find the next block.
-                const popped = thread.popStack();
-                if (popped === null) {
-                    return;
-                }
-                nextBlockId = thread.target.blocks.getNextBlock(popped);
-                if (nextBlockId !== null) {
-                    // A next block exists so break out this loop
-                    break;
-                }
-                // Investigate the next block and if not in a loop,
-                // then repeat and pop the next item off the stack frame
-                stackFrame = thread.peekStackFrame();
-            } while (stackFrame !== null && !stackFrame.isLoop);
-
-            thread.pushStack(nextBlockId);
-        }
+        if (lastOperation) thread.goToNextBlock();
     }, rejectionReason => {
         // Promise rejected: the primitive had some error.
         // Log it and proceed.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1453,8 +1453,6 @@ class Runtime extends EventEmitter {
      * @param {!Thread} thread Thread object to remove from actives
      */
     _stopThread (thread) {
-        // Mark the thread for later removal
-        thread.isKilled = true;
         // Inform sequencer to stop executing that thread.
         this.sequencer.retireThread(thread);
     }
@@ -1863,9 +1861,6 @@ class Runtime extends EventEmitter {
             }
             this.profiler.start(stepProfilerId);
         }
-
-        // Clean up threads that were told to stop during or since the last step
-        this.threads = this.threads.filter(thread => !thread.isKilled);
 
         // Find all edge-activated hats, and add them to threads to be evaluated.
         for (const hatType in this._hats) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -7,7 +7,6 @@ const BlocksRuntimeCache = require('./blocks-runtime-cache');
 const BlockType = require('../extension-support/block-type');
 const Profiler = require('./profiler');
 const Sequencer = require('./sequencer');
-const execute = require('./execute.js');
 const ScratchBlocksConstants = require('./scratch-blocks-constants');
 const TargetType = require('../extension-support/target-type');
 const Thread = require('./thread');
@@ -1667,10 +1666,7 @@ class Runtime extends EventEmitter {
         }, optTarget);
         // For compatibility with Scratch 2, edge triggered hats need to be processed before
         // threads are stepped. See ScratchRuntime.as for original implementation
-        newThreads.forEach(thread => {
-            execute(this.sequencer, thread);
-            thread.goToNextBlock();
-        });
+        newThreads.forEach(thread => this.sequencer.stepHat(thread));
         return newThreads;
     }
 

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -221,13 +221,10 @@ class Sequencer {
             thread.warpTimer = new Timer();
             thread.warpTimer.start();
         }
-        // Store the current block ID outside of the loop to later set it to
-        // thread.blockGlowInFrame.
-        let currentBlockId = thread.peekStack();
         // The thread entered a null block while outside of stepThreads during a
         // stepHat or promise resolution. We can't unwrap during stepHat or
         // promise resolution if we need to change the thread status.
-        if (currentBlockId === null) {
+        if (thread.peekStack() === null) {
             // Unwrap the stack until we find a loop block, a non-null
             // block, or the top of the stack.
             this.unwrapStack(thread);
@@ -238,7 +235,7 @@ class Sequencer {
         }
         while (thread.status === Thread.STATUS_RUNNING) {
             // Save the current block ID to notice if we did control flow.
-            currentBlockId = thread.peekStack();
+            const currentBlockId = thread.peekStack();
 
             if (this.runtime.profiler === null) {
                 // Execute the current block.
@@ -284,8 +281,6 @@ class Sequencer {
                 thread.status = Thread.STATUS_RUNNING;
             }
         }
-        // Indicate the block that just executed.
-        thread.blockGlowInFrame = currentBlockId;
         // If we yielded out of the thread, set status to RUNNING so stepThreads
         // can count it as an activeThread and possibly step all threads an
         // extra time.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -76,7 +76,7 @@ class Sequencer {
         this.runtime.updateCurrentMSecs();
         // Start counting toward WORK_TIME.
         this.timer.start();
-        // Count of active threads.
+        // Are there active threads?
         let activeThreads = true;
         // Whether `stepThreads` has run through a full single tick.
         let ranFirstTick = false;
@@ -102,8 +102,7 @@ class Sequencer {
             const threads = this.runtime.threads;
             for (let i = 0; i < threads.length; i++) {
                 const activeThread = this.activeThread = threads[i];
-                if (activeThread.status === Thread.STATUS_RUNNING ||
-                    activeThread.status === Thread.STATUS_YIELD) {
+                if (activeThread.status === Thread.STATUS_RUNNING) {
                     // Normal-mode thread: step.
                     if (this.runtime.profiler === null) {
                         this.stepThread(activeThread);
@@ -117,10 +116,11 @@ class Sequencer {
 
                         this.runtime.profiler.stop();
                     }
-                } else if (activeThread.status === Thread.STATUS_YIELD_TICK &&
-                    !ranFirstTick) {
-                    // Clear single-tick yield from the last call of
-                    // `stepThreads`.
+                } else if (activeThread.status === Thread.STATUS_YIELD || (
+                    activeThread.status === Thread.STATUS_YIELD_TICK &&
+                    !ranFirstTick
+                )) {
+                    // Clear yield and yield tick on first outer step loop.
                     activeThread.status = Thread.STATUS_RUNNING;
                     // Run this thread again in the loop. (Since most threads
                     // are RUNNING this second clause will be rarely checked.
@@ -128,12 +128,14 @@ class Sequencer {
                     // loop over this index a second time to get the RUNNING
                     // behaviour.)
                     i--;
-                    // Skip ahead to running this thread again.
+                    // Skip ahead to running this thread again. We don't want
+                    // this to count towards activeThreads until after
+                    // execution.
                     continue;
                 }
-                // Check if the thread is running and step threads again of if
-                // it completed while it just stepped to make sure remove it
-                // before the next iteration of all threads.
+                // If the thread is running allow, loop over the threads again.
+                // If the thread finished make sure it is removed before the
+                // next iteration of all threads.
                 if (activeThread.status === Thread.STATUS_RUNNING) {
                     activeThreads = true;
                 } else if (activeThread.status === Thread.STATUS_DONE) {
@@ -171,114 +173,127 @@ class Sequencer {
     }
 
     /**
+     * Step the requested thread once. The thread must be at a hat block.
+     * @param {!Thread} thread Thread object to step.
+     */
+    stepHat (thread) {
+        execute(this, thread);
+        if (thread.status === Thread.STATUS_RUNNING) thread.goToNextBlock();
+    }
+
+    /**
+     * Pop the stack as long as it is pointing at null.
+     * @param {!Thread} thread Thread to pop.
+     */
+    unwrapStack (thread) {
+        while (
+            thread.status === Thread.STATUS_RUNNING &&
+            thread.peekStack() === null
+        ) {
+            thread.popStack();
+
+            const stackFrame = thread.peekStackFrame();
+            if (stackFrame === null) {
+                // No more stack to run!
+                this.retireThread(thread);
+            } else if (stackFrame.isLoop) {
+                // The current level of the stack is marked as a loop. Yield
+                // this thread so the next thread may run.
+                thread.status = Thread.STATUS_YIELD;
+            } else {
+                // Step to the next block.
+                thread.goToNextBlock();
+            }
+        }
+    }
+
+    /**
      * Step the requested thread for as long as necessary.
      * @param {!Thread} thread Thread object to step.
      */
     stepThread (thread) {
+        // warpMode may be true when we start stepping a thread or become true
+        // when a procedure is pushed. So we only need to check here and in
+        // stepToProcedure.
+        if (thread.peekStackFrame().warpMode && thread.warpTimer === null) {
+            // Initialize warp-mode timer if it hasn't been already. This
+            // will start counting the thread toward `Sequencer.WARP_TIME`.
+            thread.warpTimer = new Timer();
+            thread.warpTimer.start();
+        }
+        // Store the current block ID outside of the loop to later set it to
+        // thread.blockGlowInFrame.
         let currentBlockId = thread.peekStack();
-        if (!currentBlockId) {
-            // A "null block" - empty branch.
-            thread.popStack();
-
-            // Did the null follow a hat block?
-            if (thread.stack.length === 0) {
-                thread.status = Thread.STATUS_DONE;
-                return;
+        // The thread entered a null block while outside of stepThreads during a
+        // stepHat or promise resolution. We can't unwrap during stepHat or
+        // promise resolution if we need to change the thread status.
+        if (currentBlockId === null) {
+            // Unwrap the stack until we find a loop block, a non-null
+            // block, or the top of the stack.
+            this.unwrapStack(thread);
+            // If we unwrapped into a loop block, execute it immediately.
+            if (thread.status === Thread.STATUS_YIELD) {
+                thread.status = Thread.STATUS_RUNNING;
             }
         }
-        // Save the current block ID to notice if we did control flow.
-        while ((currentBlockId = thread.peekStack())) {
-            let isWarpMode = thread.peekStackFrame().warpMode;
-            if (isWarpMode && !thread.warpTimer) {
-                // Initialize warp-mode timer if it hasn't been already.
-                // This will start counting the thread toward `Sequencer.WARP_TIME`.
-                thread.warpTimer = new Timer();
-                thread.warpTimer.start();
-            }
-            // Execute the current block.
-            if (this.runtime.profiler !== null) {
+        while (thread.status === Thread.STATUS_RUNNING) {
+            // Save the current block ID to notice if we did control flow.
+            currentBlockId = thread.peekStack();
+
+            if (this.runtime.profiler === null) {
+                // Execute the current block.
+                execute(this, thread);
+            } else {
                 if (executeProfilerId === -1) {
                     executeProfilerId = this.runtime.profiler.idByName(executeProfilerFrame);
                 }
-                // The method commented below has its code inlined underneath to
-                // reduce the bias recorded for the profiler's calls in this
-                // time sensitive stepThread method.
+
+                // The method commented below has its code inlined
+                // underneath to reduce the bias recorded for the profiler's
+                // calls in this time sensitive stepThread method.
                 //
                 // this.runtime.profiler.start(executeProfilerId, null);
                 this.runtime.profiler.records.push(
                     this.runtime.profiler.START, executeProfilerId, null, 0);
-            }
-            if (thread.target === null) {
-                this.retireThread(thread);
-            } else {
+
+                // Execute the current block.
                 execute(this, thread);
-            }
-            if (this.runtime.profiler !== null) {
+
                 // this.runtime.profiler.stop();
                 this.runtime.profiler.records.push(this.runtime.profiler.STOP, 0);
             }
-            thread.blockGlowInFrame = currentBlockId;
-            // If the thread has yielded or is waiting, yield to other threads.
-            if (thread.status === Thread.STATUS_YIELD) {
-                // Mark as running for next iteration.
-                thread.status = Thread.STATUS_RUNNING;
+
+            if (thread.status === Thread.STATUS_RUNNING) {
+                // If no control flow has happened, switch to next block.
+                if (thread.peekStack() === currentBlockId) {
+                    thread.goToNextBlock();
+                }
+                // A empty branch was pushed or we stepped out of the last block
+                // in a stack.
+                if (thread.peekStack() === null) {
+                    // Unwrap the stack until we find a loop block, a non-null
+                    // block, or the top of the stack.
+                    this.unwrapStack(thread);
+                }
+            }
+
+            if (thread.status === Thread.STATUS_YIELD &&
+                thread.peekStackFrame().warpMode &&
+                thread.warpTimer.timeElapsed() <= Sequencer.WARP_TIME) {
                 // In warp mode, yielded blocks are re-executed immediately.
-                if (isWarpMode &&
-                    thread.warpTimer.timeElapsed() <= Sequencer.WARP_TIME) {
-                    continue;
-                }
-                return;
-            } else if (thread.status === Thread.STATUS_PROMISE_WAIT) {
-                // A promise was returned by the primitive. Yield the thread
-                // until the promise resolves. Promise resolution should reset
-                // thread.status to Thread.STATUS_RUNNING.
-                return;
-            } else if (thread.status === Thread.STATUS_YIELD_TICK) {
-                // stepThreads will reset the thread to Thread.STATUS_RUNNING
-                return;
-            }
-            // If no control flow has happened, switch to next block.
-            if (thread.peekStack() === currentBlockId) {
-                thread.goToNextBlock();
-            }
-            // If no next block has been found at this point, look on the stack.
-            while (!thread.peekStack()) {
-                thread.popStack();
-
-                if (thread.stack.length === 0) {
-                    // No more stack to run!
-                    thread.status = Thread.STATUS_DONE;
-                    return;
-                }
-
-                const stackFrame = thread.peekStackFrame();
-                isWarpMode = stackFrame.warpMode;
-
-                if (stackFrame.isLoop) {
-                    // The current level of the stack is marked as a loop.
-                    // Return to yield for the frame/tick in general.
-                    // Unless we're in warp mode - then only return if the
-                    // warp timer is up.
-                    if (!isWarpMode ||
-                        thread.warpTimer.timeElapsed() > Sequencer.WARP_TIME) {
-                        // Don't do anything to the stack, since loops need
-                        // to be re-executed.
-                        return;
-                    }
-                    // Don't go to the next block for this level of the stack,
-                    // since loops need to be re-executed.
-                    continue;
-
-                } else if (stackFrame.waitingReporter) {
-                    // This level of the stack was waiting for a value.
-                    // This means a reporter has just returned - so don't go
-                    // to the next block for this level of the stack.
-                    return;
-                }
-                // Get next block of existing block on the stack.
-                thread.goToNextBlock();
+                thread.status = Thread.STATUS_RUNNING;
             }
         }
+        // Indicate the block that just executed.
+        thread.blockGlowInFrame = currentBlockId;
+        // If we yielded out of the thread, set status to RUNNING so stepThreads
+        // can count it as an activeThread and possibly step all threads an
+        // extra time.
+        if (thread.status === Thread.STATUS_YIELD) {
+            thread.status = Thread.STATUS_RUNNING;
+        }
+        // Unset warpTimer if it was used so it can be set again next time.
+        thread.warpTimer = null;
     }
 
     /**
@@ -344,6 +359,16 @@ class Sequencer {
                 }
             }
             if (doWarp) {
+                // Going from non warpMode to warpMode, enable the warpTimer.
+                if (!thread.peekStackFrame().warpMode &&
+                    thread.warpTimer === null) {
+                    // Initialize warp-mode timer if it hasn't been already.
+                    // This will start counting the thread toward
+                    // `Sequencer.WARP_TIME`.
+                    thread.warpTimer = new Timer();
+                    thread.warpTimer.start();
+                }
+
                 thread.peekStackFrame().warpMode = true;
             } else if (isRecursive) {
                 // In normal-mode threads, yield any time we have a recursive call.
@@ -358,7 +383,7 @@ class Sequencer {
      */
     retireThread (thread) {
         thread.stack = [];
-        thread.stackFrame = [];
+        thread.stackFrames = [];
         thread.requestScriptGlowInFrame = false;
         thread.status = Thread.STATUS_DONE;
     }

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -150,12 +150,6 @@ class Thread {
         this.status = 0; /* Thread.STATUS_RUNNING */
 
         /**
-         * Whether the thread is killed in the middle of execution.
-         * @type {boolean}
-         */
-        this.isKilled = false;
-
-        /**
          * Target of this thread.
          * @type {?Target}
          */


### PR DESCRIPTION
### Resolves

General performance around iterating threads during a step.

### Proposed Changes

<del>Depends on https://github.com/LLK/scratch-vm/pull/2145 and https://github.com/LLK/scratch-vm/pull/2147.</del>
<ins>This PR is now standalone and does not depend on other PRs.</ins>

- Remove Thread.isKilled
- Test if a thread is STATUS_YIELD_TICK after STATUS_RUNNING
- Remove stack.length === 0 tests

### Reason for Changes

> - Remove Thread.isKilled

The current code base doesn't actually remove the thread so I'm not sure we need this additional data point.

Removing isKilled lets us remove the isKilled loop at the beginning of _step. Which currently, must loop over all threads.

The one way isKilled threads are configured that way is through stop thread, which also sets their status to DONE.

> - Test if a thread is STATUS_YIELD_TICK after STATUS_RUNNING

Generally most threads will be RUNNING and not YIELD_TICK. We can have the special case after the primary case in the same if/else branch chain and if it is YIELD_TICK, i-- to run it again and have the RUNNING branch activate. This removes a branch test from most thread execution.

> - Remove stack.length === 0 tests

The work in the depending PRs get us to a point where status === DONE when stack is length 0. So they should be synamous and we can use the one test.
