### PR TITLE
Add support for Scratch 1.x "stretch" blocks

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -272,7 +272,7 @@ class Scratch3LooksBlocks {
             looks_cleargraphiceffects: this.clearEffects,
             looks_changesizeby: this.changeSize,
             looks_setsizeto: this.setSize,
-            looks_changestretchby: this.changeStretch, // legacy no-op blocks
+            looks_changestretchby: this.changeStretch, // weird legacy blocks
             looks_setstretchto: this.setStretch,
             looks_gotofrontback: this.goToFrontBack,
             looks_goforwardbackwardlayers: this.goForwardBackwardLayers,

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -272,8 +272,8 @@ class Scratch3LooksBlocks {
             looks_cleargraphiceffects: this.clearEffects,
             looks_changesizeby: this.changeSize,
             looks_setsizeto: this.setSize,
-            looks_changestretchby: () => {}, // legacy no-op blocks
-            looks_setstretchto: () => {},
+            looks_changestretchby: this.changeStretch, // legacy no-op blocks
+            looks_setstretchto: this.setStretch,
             looks_gotofrontback: this.goToFrontBack,
             looks_goforwardbackwardlayers: this.goForwardBackwardLayers,
             looks_size: this.getSize,
@@ -537,6 +537,16 @@ class Scratch3LooksBlocks {
     setSize (args, util) {
         const size = Cast.toNumber(args.SIZE);
         util.target.setSize(size);
+    }
+
+    changeStretch (args, util) {
+        const change = Cast.toNumber(args.CHANGE);
+        util.target.setStretch(util.target.stretch + change);
+    }
+
+    setStretch (args, util) {
+        const stretch = Cast.toNumber(args.STRETCH);
+        util.target.setStretch(stretch);
     }
 
     goToFrontBack (args, util) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -60,6 +60,13 @@ class RenderedTarget extends Target {
         };
 
         /**
+         * Stretch "effect" from Scratch 1.x.
+         * @type {Number}
+         */
+
+        this.stretch = 100;
+
+        /**
          * Whether this represents an "original" non-clone rendered-target for a sprite,
          * i.e., created by the editor and not clone blocks.
          * @type {boolean}
@@ -408,6 +415,34 @@ class RenderedTarget extends Target {
             this.renderer.updateDrawableProperties(this.drawableID, {
                 direction: renderedDirectionScale.direction,
                 scale: renderedDirectionScale.scale
+            });
+            if (this.visible) {
+                this.emit(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this);
+                this.runtime.requestRedraw();
+            }
+        }
+        this.runtime.requestTargetsUpdate(this);
+    }
+
+    /**
+     * Set stretch, as a percentage (e.g. 200% = twice as wide, 50% = half as wide)
+     * @param {!number} stretch Stretch amount
+     */
+    setStretch (stretch) {
+        if (this.isStage) {
+            return;
+        }
+        if (this.renderer) {
+            // Clamp to scales relative to costume and stage size.
+            const costumeSize = this.renderer.getCurrentSkinSize(this.drawableID);
+            const origW = costumeSize[0];
+            const minScale = 5 / origW;
+            const maxScale = (this.runtime.constructor.STAGE_WIDTH + 20) / origW;
+            this.stretch = MathUtil.clamp(stretch * 0.01, minScale, maxScale) * 100;
+            const renderedDirectionScale = this._getRenderedDirectionAndScale();
+            this.renderer.updateDrawableProperties(this.drawableID, {
+                direction: renderedDirectionScale.direction,
+                scale: [renderedDirectionScale.scale[0] * (this.stretch * 0.01), renderedDirectionScale.scale[1]]
             });
             if (this.visible) {
                 this.emit(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this);


### PR DESCRIPTION
(I don't really expect this to get merged; it was just for fun)

### Proposed Changes

This adds support for the "set stretch to" and "change stretch by" blocks from Scratch 1.x.

Replicated behavior:
- Rough scale fencing
- Stretch being overridden/reset by "set size" and "change size"

Not replicated:
- The "size" reporter (but not the actual internal "size" value) being set by the stretch blocks

This fixes e.g. [Jelly](https://scratch.mit.edu/projects/1059859/)