### PR TITLE
Make BOOST extension displayed name all-caps

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1204,7 +1204,7 @@ class Scratch3BoostBlocks {
     getInfo () {
         return {
             id: Scratch3BoostBlocks.EXTENSION_ID,
-            name: 'Boost',
+            name: 'BOOST',
             blockIconURI: iconURI,
             showStatusButton: true,
             blocks: [


### PR DESCRIPTION
![Screen Shot 2019-04-29 at 3 44 35 PM](https://user-images.githubusercontent.com/567844/56922248-bd4b2280-6a95-11e9-9520-ab93aec4096a.png)
