### PR TITLE
BOOST extension: Always clear motor promises when setting state

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -431,14 +431,8 @@ class BoostMotor {
      * @param {BoostMotorState} value - set this motor's state.
      */
     set status (value) {
-        if (value !== BoostMotorState.ON_FOR_ROTATION) {
-            // clear rotation pending promise only if not already in rotation state
-            this._clearRotationState();
-        }
-        if (value !== BoostMotorState.ON_FOR_TIME) {
-            // clear duration pending promise only if not already in duration state
-            this._clearTimeout();
-        }
+        this._clearRotationState();
+        this._clearTimeout();
         this._status = value;
     }
 
@@ -534,7 +528,7 @@ class BoostMotor {
                 BoostMotorProfile.DO_NOT_USE
             ]
         );
-        
+
         this.status = BoostMotorState.ON_FOR_ROTATION;
         this._pendingPositionDestination = this.position + (degrees * this.direction * direction);
         this._parent.send(BoostBLE.characteristic, cmd);


### PR DESCRIPTION
We saw a bug (no issue filed) where if you ran a "turn motor A for rotations" block, and before it completes, run another "turn motor A for rotations", the first block will hang (i.e. stay highlighted).

This change fixes that problem, and a similar problem with the "on for seconds" block.  