### PR TITLE
Add support for custom context menu items to the extension spec.

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -575,7 +575,9 @@ should appear in.
 The options for the context menu item context are as follows:
 
 `ContextMenuContext.ALL` - The context menu item should always appear in the block's context menu. This is the default option.
+
 `ContextMenuContext.TOOLBOX_ONLY` - The context menu item should only appear in the block's context menu when the block is in the toolbox.
+
 `ContextMenuContext.WORKSPACE_ONLY` - The context menu item should only appear in the block's context menu when the block is on the main workspace.
 
 By default, a context menu item will appear on the block in both the toolbox as well as the

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -487,3 +487,111 @@ class SomeBlocks {
     };
 }
 ```
+
+## Experimental / In Development Features
+
+The following are experimental features that are under active development and subject to change during the process
+of converting the core Scratch blocks into using the extension spec.
+
+### Dynamic Blocks
+The content above describes defining static extension blocks (e.g. blocks that will always keep the same shape). While most
+blocks in the Scratch language fall into this category, there are others which may dynamically change their shape based
+state information. An example of this is the `control_stop` block which changes whether or not it can have a command block
+attached after it based on which menu item is selected. Blocks that may dynamically change their shape are referred to below as
+"dynamic blocks".
+
+In order to support Scratch blocks like variables or custom procedure call blocks, we have added the support for dynamic blocks.
+A block is specified to be dynamic by using the `isDynamic` flag in the block specification.
+
+```js
+class SomeBlocks {
+    // ...
+    getInfo () {
+        return {
+            // ...
+            blocks: [
+                {
+                    isDynamic: true
+                    opcode: 'dynamicReporter',
+                    blockType: BlockType.REPORTER,
+                    text: 'my dynamic reporter block',
+                }
+            ]
+        };
+    }
+    // ...
+}
+```
+
+#### Adding Custom Context Menu Options
+Dynamic blocks can have custom context menu options in addition to the default options for adding
+a block comment, deleting the block, and duplicating the block.
+
+In order to specify custom context menu options, you can provide a list of context menu item descriptors
+which contain the text label for the menu item as well as the name of the function in the extension that should be run when
+the block is selected.
+
+```js
+class SomeBlocks {
+    // ...
+    getInfo () {
+        return {
+            // ...
+            blocks: [
+                {
+                    isDynamic: true
+                    opcode: 'dynamicReporter',
+                    blockType: BlockType.REPORTER,
+                    text: 'my dynamic reporter block',
+                    customContextMenu: [
+                        {
+                            text: 'Context Menu Item 1',
+                            callback: 'myContextMenuFunction'
+                        },
+                        {
+                            text: 'Context Menu Item 2',
+                            callback: 'anotherContextMenuFunction'
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    myContextMenuFunction () {
+        // ...
+    }
+
+    anotherContextMenuFunction () {
+        // ...
+    }
+    // ...
+}
+```
+
+For each context menu item, you can also optionally specify which situations that context menu item
+should appear in.
+
+The options for the context menu item context are as follows:
+
+`ContextMenuContext.ALL` - The context menu item should always appear in the block's context menu. This is the default option.
+`ContextMenuContext.TOOLBOX_ONLY` - The context menu item should only appear in the block's context menu when the block is in the toolbox.
+`ContextMenuContext.WORKSPACE_ONLY` - The context menu item should only appear in the block's context menu when the block is on the main workspace.
+
+By default, a context menu item will appear on the block in both the toolbox as well as the
+main workspace.
+
+```
+customContextMenu: [
+    {
+        text: 'Context Menu Item Hidden From Toolbox',
+        callback: 'myContextMenuFunction',
+        context: ContextMenuContext.WORKSPACE_ONLY
+    },
+    {
+        text: 'Context Menu Item Hidden From Workspace',
+        callback: 'anotherContextMenuFunction',
+        context: ContextMenuContext.TOOLBOX_ONLY
+    }
+]
+```

--- a/src/blocks/scratch3_core_example.js
+++ b/src/blocks/scratch3_core_example.js
@@ -1,4 +1,5 @@
 const BlockType = require('../extension-support/block-type');
+const ContextMenuContext = require('../extension-support/context-menu-context');
 const log = require('../util/log');
 
 /**
@@ -40,8 +41,18 @@ class Scratch3CoreExample {
                     isDynamic: true,
                     customContextMenu: [
                         {
-                            name: 'Custom Context Menu Option',
+                            text: 'Custom Context Menu Option',
                             callback: 'contextMenuOption'
+                        },
+                        {
+                            text: 'Custom Context Menu Option - Toolbox Only',
+                            callback: 'contextMenuOption',
+                            context: ContextMenuContext.TOOLBOX_ONLY
+                        },
+                        {
+                            text: 'Custom Context Menu Option - Workspace Only',
+                            callback: 'contextMenuOption',
+                            context: ContextMenuContext.WORKSPACE_ONLY
                         }
                     ]
                 }

--- a/src/blocks/scratch3_core_example.js
+++ b/src/blocks/scratch3_core_example.js
@@ -1,4 +1,5 @@
 const BlockType = require('../extension-support/block-type');
+const log = require('../util/log');
 
 /**
  * An example core block implemented using the extension spec.
@@ -31,6 +32,18 @@ class Scratch3CoreExample {
                     opcode: 'exampleOpcode',
                     blockType: BlockType.REPORTER,
                     text: 'example block'
+                },
+                {
+                    opcode: 'exampleDynamicOpcode',
+                    blockType: BlockType.COMMAND,
+                    text: 'example dynamic block',
+                    isDynamic: true,
+                    customContextMenu: [
+                        {
+                            name: 'Custom Context Menu Option',
+                            callback: 'contextMenuOption'
+                        }
+                    ]
                 }
             ]
         };
@@ -43,6 +56,20 @@ class Scratch3CoreExample {
     exampleOpcode () {
         const stage = this.runtime.getTargetForStage();
         return stage ? stage.getName() : 'no stage yet';
+    }
+
+    /**
+     * An example of a dynamic block.
+     */
+    exampleDynamicOpcode () {
+        log.info('Example dynamic block');
+    }
+
+    /**
+     * An example of a context menu callback.
+     */
+    contextMenuOption () {
+        log.info('Custom context menu example.');
     }
 
 }

--- a/src/extension-support/context-menu-context.js
+++ b/src/extension-support/context-menu-context.js
@@ -1,0 +1,25 @@
+/**
+ * Block argument types
+ * @enum {string}
+ */
+const ContextMenuContext = {
+    /**
+     * Indicates that the context menu item should appear regardless of whether
+     * the block is in the toolbox or on the main workspace.
+     */
+    ALL: 'all',
+
+    /**
+     * Indicates that the context menu item should only appear on a block
+     * if it is in the toolbox.
+     */
+    TOOLBOX_ONLY: 'toolbox',
+
+    /**
+     * Indicates that the context menu item should only appear on a block
+     * if it is on the main workspace.
+     */
+    WORKSPACE_ONLY: 'workspace'
+};
+
+module.exports = ContextMenuContext;

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -387,6 +387,19 @@ class ExtensionManager {
         blockInfo.opcode = blockInfo.opcode && this._sanitizeID(blockInfo.opcode);
         blockInfo.text = blockInfo.text || blockInfo.opcode;
 
+        if (blockInfo.customContextMenu && blockInfo.customContextMenu.length > 0) {
+            // Replace all the string callback names of the context menu items
+            // with the actual function call.
+            blockInfo.customContextMenu = blockInfo.customContextMenu.map(contextMenuOption => {
+                if (typeof contextMenuOption.callback === 'string') {
+                    const callbackName = this._sanitizeID(contextMenuOption.callback);
+                    contextMenuOption.callback = args =>
+                        dispatch.call(serviceName, callbackName, args);
+                }
+                return contextMenuOption;
+            });
+        }
+
         switch (blockInfo.blockType) {
         case BlockType.EVENT:
             if (blockInfo.func) {

--- a/test/integration/internal-extension.js
+++ b/test/integration/internal-extension.js
@@ -86,23 +86,18 @@ test('internal extension', t => {
     // loaded if we have core extensions defined in src/virtual-machine.
     t.ok(vm.runtime._blockInfo.length > 0);
 
-    for (const extensionInfo of vm.runtime._blockInfo) {
-        if (extensionInfo.id !== 'testInternalExtension') continue;
-
-        // The following should run only once, for the mock `testInternalExtension`
-        // defined above. Any other extensions (e.g. core extensions that are loaded)
-        // when a VM instance is constructed should be skipped above.
-
-        // There should be 2 menus - one is an array, one is the function to call.
-        t.equal(extensionInfo.menus.length, 2);
-        // First menu has 3 items.
-        t.equal(
-            extensionInfo.menus[0].json.args0[0].options.length, 3);
-        // Second menu is a dynamic menu and therefore should be a function.
-        t.type(
-            extensionInfo.menus[1].json.args0[0].options, 'function');
-        t.end();
-    }
+    // Find the extension info in the runtime.
+    const extensionInfo = vm.runtime._blockInfo.find(info => info.id === 'testInternalExtension');
+    t.ok(extensionInfo);
+    // There should be 2 menus - one is an array, one is the function to call.
+    t.equal(extensionInfo.menus.length, 2);
+    // First menu has 3 items.
+    t.equal(
+        extensionInfo.menus[0].json.args0[0].options.length, 3);
+    // Second menu is a dynamic menu and therefore should be a function.
+    t.type(
+        extensionInfo.menus[1].json.args0[0].options, 'function');
+    t.end();
 });
 
 test('load sync', t => {

--- a/test/integration/internal-extension.js
+++ b/test/integration/internal-extension.js
@@ -100,14 +100,17 @@ test('load sync', t => {
 
     t.equal(vm.runtime._blockInfo.length, 1);
 
-    // blocks should be an array of two items: a button pseudo-block and a reporter block.
-    t.equal(vm.runtime._blockInfo[0].blocks.length, 2);
+    // blocks should be an array of two items: a button pseudo-block, a reporter block, and a command block.
+    t.equal(vm.runtime._blockInfo[0].blocks.length, 3);
     t.type(vm.runtime._blockInfo[0].blocks[0].info, 'object');
     t.type(vm.runtime._blockInfo[0].blocks[0].info.func, 'MAKE_A_VARIABLE');
     t.equal(vm.runtime._blockInfo[0].blocks[0].info.blockType, 'button');
     t.type(vm.runtime._blockInfo[0].blocks[1].info, 'object');
     t.equal(vm.runtime._blockInfo[0].blocks[1].info.opcode, 'exampleOpcode');
     t.equal(vm.runtime._blockInfo[0].blocks[1].info.blockType, 'reporter');
+    t.type(vm.runtime._blockInfo[0].blocks[2].info, 'object');
+    t.equal(vm.runtime._blockInfo[0].blocks[2].info.opcode, 'exampleDynamicOpcode');
+    t.equal(vm.runtime._blockInfo[0].blocks[2].info.blockType, 'command');
 
     // Test the opcode function
     t.equal(vm.runtime._blockInfo[0].blocks[1].info.func(), 'no stage yet');

--- a/test/integration/internal-extension.js
+++ b/test/integration/internal-extension.js
@@ -112,7 +112,7 @@ test('load sync', t => {
 
     t.equal(vm.runtime._blockInfo.length, 1);
 
-    // blocks should be an array of two items: a button pseudo-block, a reporter block, and a command block.
+    // blocks should be an array of [button pseudo-block, reporter block, command block].
     t.equal(vm.runtime._blockInfo[0].blocks.length, 3);
     t.type(vm.runtime._blockInfo[0].blocks[0].info, 'object');
     t.type(vm.runtime._blockInfo[0].blocks[0].info.func, 'MAKE_A_VARIABLE');


### PR DESCRIPTION
### Resolves

Towards #2120 

Related to LLK/scratch-gui#4794

### Proposed Changes

Allow extensions to specify custom context menu items for dynamic blocks.

### Reason for Changes

Needed for extensionifying myBlocks and variables which have custom context menu items for editing a custom procedure or renaming/deleting a variable.

**Note:** this feature is only active for dynamic extension blocks.

### Test Coverage

Added a custom context menu to a new block in the core example extension.