### PR TITLE
Change BOOST variable names regarding duration and rotation blocks

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -437,21 +437,21 @@ class BoostMotor {
     }
 
     /**
-     * @return {number} - time, in milliseconds, of when the pending timeout began.
+     * @return {number} - time, in milliseconds, of when the pending duration timeout began.
      */
     get pendingTimeoutStartTime () {
         return this._pendingDurationTimeoutStartTime;
     }
 
     /**
-     * @return {number} - delay, in milliseconds, of the pending timeout.
+     * @return {number} - delay, in milliseconds, of the pending duration timeout.
      */
     get pendingTimeoutDelay () {
         return this._pendingDurationTimeoutDelay;
     }
 
     /**
-     * @return {number} - delay, in milliseconds, of the pending timeout.
+     * @return {number} - delay, in milliseconds, of the pending duration timeout.
      */
     get pendingPositionDestination () {
         return this._pendingRotationDestination;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -458,7 +458,7 @@ class BoostMotor {
     }
 
     /**
-     * @return {boolean} - true if this motor is currently moving, false if this motor is off or braking.
+     * @return {Promise} - the Promise function for the pending rotation.
      */
     get pendingRotationPromise () {
         return this._pendingRotationPromise;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -356,8 +356,8 @@ class BoostMotor {
         this._pendingRotationDestination = null;
 
         /**
-         * If the motor has been turned on run for a specific duration,
-         * this is the function that will be called once Scratch VM gets a notification from the Move Hub.
+         * If the motor has been turned on run for a specific rotation, this is the function
+         * that will be called once Scratch VM gets a notification from the Move Hub.
          * @type {Object}
          * @private
          */

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -432,7 +432,7 @@ class BoostMotor {
      */
     set status (value) {
         this._clearRotationState();
-        this._clearTimeout();
+        this._clearDurationTimeout();
         this._status = value;
     }
 
@@ -505,7 +505,7 @@ class BoostMotor {
         milliseconds = Math.max(0, milliseconds);
         this.status = BoostMotorState.ON_FOR_TIME;
         this._turnOn();
-        this._setNewTimeout(this.turnOff, milliseconds);
+        this._setNewDurationTimeout(this.turnOff, milliseconds);
     }
 
     /**
@@ -558,7 +558,7 @@ class BoostMotor {
      * Clear the motor action timeout, if any. Safe to call even when there is no pending timeout.
      * @private
      */
-    _clearTimeout () {
+    _clearDurationTimeout () {
         if (this._pendingDurationTimeoutId !== null) {
             clearTimeout(this._pendingDurationTimeoutId);
             this._pendingDurationTimeoutId = null;
@@ -573,8 +573,8 @@ class BoostMotor {
      * @param {int} delay - wait this many milliseconds before calling the callback.
      * @private
      */
-    _setNewTimeout (callback, delay) {
-        this._clearTimeout();
+    _setNewDurationTimeout (callback, delay) {
+        this._clearDurationTimeout();
         const timeoutID = setTimeout(() => {
             if (this._pendingDurationTimeoutId === timeoutID) {
                 this._pendingDurationTimeoutId = null;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -439,35 +439,35 @@ class BoostMotor {
     /**
      * @return {number} - time, in milliseconds, of when the pending duration timeout began.
      */
-    get pendingTimeoutStartTime () {
+    get pendingDurationTimeoutStartTime () {
         return this._pendingDurationTimeoutStartTime;
     }
 
     /**
      * @return {number} - delay, in milliseconds, of the pending duration timeout.
      */
-    get pendingTimeoutDelay () {
+    get pendingDurationTimeoutDelay () {
         return this._pendingDurationTimeoutDelay;
     }
 
     /**
      * @return {number} - delay, in milliseconds, of the pending duration timeout.
      */
-    get pendingPositionDestination () {
+    get pendingRotationDestination () {
         return this._pendingRotationDestination;
     }
 
     /**
      * @return {boolean} - true if this motor is currently moving, false if this motor is off or braking.
      */
-    get pendingPromiseFunction () {
+    get pendingRotationPromise () {
         return this._pendingRotationPromise;
     }
 
     /**
      * @param {function} func - function to resolve promise
      */
-    set pendingPromiseFunction (func) {
+    set pendingRotationPromise (func) {
         this._pendingRotationPromise = func;
     }
 
@@ -1669,7 +1669,7 @@ class Scratch3BoostBlocks {
                 if (motor.power === 0) return Promise.resolve();
                 return new Promise(resolve => {
                     motor.turnOnForDegrees(degrees, sign);
-                    motor.pendingPromiseFunction = resolve;
+                    motor.pendingRotationPromise = resolve;
                 });
             }
             return null;
@@ -1739,7 +1739,7 @@ class Scratch3BoostBlocks {
                     motor.turnOnForever();
                     break;
                 case BoostMotorState.ON_FOR_TIME:
-                    motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now());
+                    motor.turnOnFor(motor.pendingDurationTimeoutStartTime + motor.pendingDurationTimeoutDelay - Date.now());
                     break;
                 }
             }
@@ -1785,7 +1785,7 @@ class Scratch3BoostBlocks {
                         motor.turnOnForever();
                         break;
                     case BoostMotorState.ON_FOR_TIME:
-                        motor.turnOnFor(motor.pendingTimeoutStartTime + motor.pendingTimeoutDelay - Date.now());
+                        motor.turnOnFor(motor.pendingDurationTimeoutStartTime + motor.pendingDurationTimeoutDelay - Date.now());
                         break;
                     }
                 }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -332,28 +332,28 @@ class BoostMotor {
          * @type {Object}
          * @private
          */
-        this._pendingTimeoutId = null;
+        this._pendingDurationTimeoutId = null;
 
         /**
-         * The starting time for the pending timeout.
+         * The starting time for the pending duration timeout.
          * @type {number}
          * @private
          */
-        this._pendingTimeoutStartTime = null;
+        this._pendingDurationTimeoutStartTime = null;
 
         /**
-         * The delay/duration of the pending timeout.
+         * The delay/duration of the pending duration timeout.
          * @type {number}
          * @private
          */
-        this._pendingTimeoutDelay = null;
+        this._pendingDurationTimeoutDelay = null;
 
         /**
          * The target position of a turn-based command.
          * @type {number}
          * @private
          */
-        this._pendingPositionDestination = null;
+        this._pendingRotationDestination = null;
 
         /**
          * If the motor has been turned on run for a specific duration,
@@ -361,7 +361,7 @@ class BoostMotor {
          * @type {Object}
          * @private
          */
-        this._pendingPromiseFunction = null;
+        this._pendingRotationPromise = null;
 
         this.turnOff = this.turnOff.bind(this);
     }
@@ -440,35 +440,35 @@ class BoostMotor {
      * @return {number} - time, in milliseconds, of when the pending timeout began.
      */
     get pendingTimeoutStartTime () {
-        return this._pendingTimeoutStartTime;
+        return this._pendingDurationTimeoutStartTime;
     }
 
     /**
      * @return {number} - delay, in milliseconds, of the pending timeout.
      */
     get pendingTimeoutDelay () {
-        return this._pendingTimeoutDelay;
+        return this._pendingDurationTimeoutDelay;
     }
 
     /**
      * @return {number} - delay, in milliseconds, of the pending timeout.
      */
     get pendingPositionDestination () {
-        return this._pendingPositionDestination;
+        return this._pendingRotationDestination;
     }
 
     /**
      * @return {boolean} - true if this motor is currently moving, false if this motor is off or braking.
      */
     get pendingPromiseFunction () {
-        return this._pendingPromiseFunction;
+        return this._pendingRotationPromise;
     }
 
     /**
      * @param {function} func - function to resolve promise
      */
     set pendingPromiseFunction (func) {
-        this._pendingPromiseFunction = func;
+        this._pendingRotationPromise = func;
     }
 
     /**
@@ -530,7 +530,7 @@ class BoostMotor {
         );
 
         this.status = BoostMotorState.ON_FOR_ROTATION;
-        this._pendingPositionDestination = this.position + (degrees * this.direction * direction);
+        this._pendingRotationDestination = this.position + (degrees * this.direction * direction);
         this._parent.send(BoostBLE.characteristic, cmd);
     }
 
@@ -559,11 +559,11 @@ class BoostMotor {
      * @private
      */
     _clearTimeout () {
-        if (this._pendingTimeoutId !== null) {
-            clearTimeout(this._pendingTimeoutId);
-            this._pendingTimeoutId = null;
-            this._pendingTimeoutStartTime = null;
-            this._pendingTimeoutDelay = null;
+        if (this._pendingDurationTimeoutId !== null) {
+            clearTimeout(this._pendingDurationTimeoutId);
+            this._pendingDurationTimeoutId = null;
+            this._pendingDurationTimeoutStartTime = null;
+            this._pendingDurationTimeoutDelay = null;
         }
     }
 
@@ -576,16 +576,16 @@ class BoostMotor {
     _setNewTimeout (callback, delay) {
         this._clearTimeout();
         const timeoutID = setTimeout(() => {
-            if (this._pendingTimeoutId === timeoutID) {
-                this._pendingTimeoutId = null;
-                this._pendingTimeoutStartTime = null;
-                this._pendingTimeoutDelay = null;
+            if (this._pendingDurationTimeoutId === timeoutID) {
+                this._pendingDurationTimeoutId = null;
+                this._pendingDurationTimeoutStartTime = null;
+                this._pendingDurationTimeoutDelay = null;
             }
             callback();
         }, delay);
-        this._pendingTimeoutId = timeoutID;
-        this._pendingTimeoutStartTime = Date.now();
-        this._pendingTimeoutDelay = delay;
+        this._pendingDurationTimeoutId = timeoutID;
+        this._pendingDurationTimeoutStartTime = Date.now();
+        this._pendingDurationTimeoutDelay = delay;
     }
 
     /**
@@ -594,11 +594,11 @@ class BoostMotor {
      * @private
      */
     _clearRotationState () {
-        if (this._pendingPromiseFunction !== null) {
-            this._pendingPromiseFunction();
-            this._pendingPromiseFunction = null;
+        if (this._pendingRotationPromise !== null) {
+            this._pendingRotationPromise();
+            this._pendingRotationPromise = null;
         }
-        this._pendingPositionDestination = null;
+        this._pendingRotationDestination = null;
     }
 }
 

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -451,7 +451,7 @@ class BoostMotor {
     }
 
     /**
-     * @return {number} - rotation destination, in degrees, of the pending rotation.
+     * @return {number} - target position, in degrees, of the pending rotation.
      */
     get pendingRotationDestination () {
         return this._pendingRotationDestination;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -451,7 +451,7 @@ class BoostMotor {
     }
 
     /**
-     * @return {number} - delay, in milliseconds, of the pending duration timeout.
+     * @return {number} - rotation destination, in degrees, of the pending rotation.
      */
     get pendingRotationDestination () {
         return this._pendingRotationDestination;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -465,7 +465,7 @@ class BoostMotor {
     }
 
     /**
-     * @param {function} func - function to resolve promise
+     * @param {function} func - function to resolve pending rotation Promise
      */
     set pendingRotationPromise (func) {
         this._pendingRotationPromise = func;

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1739,7 +1739,8 @@ class Scratch3BoostBlocks {
                     motor.turnOnForever();
                     break;
                 case BoostMotorState.ON_FOR_TIME:
-                    motor.turnOnFor(motor.pendingDurationTimeoutStartTime + motor.pendingDurationTimeoutDelay - Date.now());
+                    motor.turnOnFor(motor.pendingDurationTimeoutStartTime +
+                        motor.pendingDurationTimeoutDelay - Date.now());
                     break;
                 }
             }
@@ -1785,7 +1786,8 @@ class Scratch3BoostBlocks {
                         motor.turnOnForever();
                         break;
                     case BoostMotorState.ON_FOR_TIME:
-                        motor.turnOnFor(motor.pendingDurationTimeoutStartTime + motor.pendingDurationTimeoutDelay - Date.now());
+                        motor.turnOnFor(motor.pendingDurationTimeoutStartTime +
+                            motor.pendingDurationTimeoutDelay - Date.now());
                         break;
                     }
                 }


### PR DESCRIPTION
### Resolves

- Resolves #2153: BOOST extension: Rename pendingPromiseFunction variable?
- Fixes some inaccurate class variable comments.

### Reason for change

- Although this name change diverges slightly from the WeDo2 variable names, it adds clarity to the complex BOOST duration/rotation pending functions, timings and behaviors.