### PR TITLE
Fall back to default bitmap if asset loading fails

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -268,7 +268,14 @@ const loadCostumeFromAsset = function (costume, runtime, optVersion) {
                 return loadVector_(costume, runtime);
             });
     }
-    return loadBitmap_(costume, runtime, rotationCenter, optVersion);
+    return loadBitmap_(costume, runtime, rotationCenter, optVersion)
+        .catch(() => {
+            // Use default asset if original fails to load
+            costume.assetId = runtime.storage.defaultAssetId.ImageBitmap;
+            costume.asset = runtime.storage.get(costume.assetId);
+            costume.md5 = `${costume.assetId}.${AssetType.ImageBitmap.runtimeFormat}`;
+            return loadBitmap_(costume, runtime);
+        });
 };
 
 /**


### PR DESCRIPTION
### Resolves

I'm not sure whether there's a bug report for this, but it resolves one cause of the dreaded "Oops!" screen. Sometimes, bitmap assets will 404, and previously there was no error checking to deal with this like there is for vector assets, so the project would crash upon loading and become completely unviewable. This was causing one forum user [a lot of distress](https://scratch.mit.edu/discuss/topic/352542/).

### Proposed Changes

This PR loads the placeholder question mark if a bitmap asset fails to load, just like it does with vector assets.

### Reason for Changes

The "Oops" screen must be avoided at all costs.
