### PR TITLE
Consistently format text bubbles

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -234,6 +234,26 @@ class Scratch3LooksBlocks {
     }
 
     /**
+     * Properly format text for a text bubble.
+     * @param {string} text The text to be formatted
+     * @return {string} The formatted text
+     * @private
+     */
+    _formatBubbleText (text) {
+        if (text === '') return text;
+
+        // Limit decimal precision to 2 digits.
+        if (typeof text === 'number') {
+            text = parseFloat(text.toFixed(2));
+        }
+
+        // Limit the length of the string.
+        text = String(text).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT);
+
+        return text;
+    }
+
+    /**
      * The entry point for say/think blocks. Clears existing bubble if the text is empty.
      * Set the bubble custom state and then call _renderBubble.
      * @param {!Target} target Target that say/think blocks are being called on.
@@ -244,7 +264,7 @@ class Scratch3LooksBlocks {
     _updateBubble (target, type, text) {
         const bubbleState = this._getBubbleState(target);
         bubbleState.type = type;
-        bubbleState.text = text;
+        bubbleState.text = this._formatBubbleText(text);
         bubbleState.usageId = uid();
         this._renderBubble(target);
     }
@@ -300,12 +320,7 @@ class Scratch3LooksBlocks {
 
     say (args, util) {
         // @TODO in 2.0 calling say/think resets the right/left bias of the bubble
-        let message = args.MESSAGE;
-        if (typeof message === 'number') {
-            message = parseFloat(message.toFixed(2));
-        }
-        message = String(message).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT);
-        this.runtime.emit('SAY', util.target, 'say', message);
+        this.runtime.emit('SAY', util.target, 'say', args.MESSAGE);
     }
 
     sayforsecs (args, util) {
@@ -325,7 +340,7 @@ class Scratch3LooksBlocks {
     }
 
     think (args, util) {
-        this._updateBubble(util.target, 'think', String(args.MESSAGE).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT));
+        this.runtime.emit('SAY', util.target, 'think', args.MESSAGE);
     }
 
     thinkforsecs (args, util) {

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -34,7 +34,7 @@ class Scratch3LooksBlocks {
         this.runtime.on('targetWasRemoved', this._onTargetWillExit);
 
         // Enable other blocks to use bubbles like ask/answer
-        this.runtime.on('SAY', this._updateBubble);
+        this.runtime.on(Scratch3LooksBlocks.SAY_OR_THINK, this._updateBubble);
     }
 
     /**
@@ -58,6 +58,16 @@ class Scratch3LooksBlocks {
      */
     static get STATE_KEY () {
         return 'Scratch.looks';
+    }
+
+    /**
+     * Event name for a text bubble being created or updated.
+     * @const {string}
+     */
+    static get SAY_OR_THINK () {
+        // There are currently many places in the codebase which explicitly refer to this event by the string 'SAY',
+        // so keep this as the string 'SAY' for now rather than changing it to 'SAY_OR_THINK' and breaking things.
+        return 'SAY';
     }
 
     /**
@@ -320,7 +330,7 @@ class Scratch3LooksBlocks {
 
     say (args, util) {
         // @TODO in 2.0 calling say/think resets the right/left bias of the bubble
-        this.runtime.emit('SAY', util.target, 'say', args.MESSAGE);
+        this.runtime.emit(Scratch3LooksBlocks.SAY_OR_THINK, util.target, 'say', args.MESSAGE);
     }
 
     sayforsecs (args, util) {
@@ -340,7 +350,7 @@ class Scratch3LooksBlocks {
     }
 
     think (args, util) {
-        this.runtime.emit('SAY', util.target, 'think', args.MESSAGE);
+        this.runtime.emit(Scratch3LooksBlocks.SAY_OR_THINK, util.target, 'think', args.MESSAGE);
     }
 
     thinkforsecs (args, util) {

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -15,7 +15,9 @@ const util = {
                 {name: 'second name'},
                 {name: 'third name'}
             ]
-        }
+        },
+        _customState: {},
+        getCustomState: () => util.target._customState
     }
 };
 
@@ -202,14 +204,15 @@ test('numbers should be rounded to two decimals in say', t => {
     const args = {MESSAGE: 3.14159};
     const expectedSayString = '3.14';
 
-    rt.removeAllListeners('SAY'); // Prevent say blocks from executing
-
-    rt.addListener('SAY', (target, type, sayString) => {
-        t.strictEqual(sayString, expectedSayString);
-        t.end();
+    rt.addListener('SAY', () => {
+        const bubbleState = util.target.getCustomState(Looks.STATE_KEY);
+        t.strictEqual(bubbleState.text, expectedSayString);
     });
 
     looks.say(args, util);
+    looks.think(args, util);
+
+    t.end();
 });
 
 test('clamp graphic effects', t => {


### PR DESCRIPTION
### Resolves

Resolves #2186 

### Proposed Changes

This adds a new private function, `_formatBubbleText`, to `Scratch3LooksBlocks`. This function, which formats the bubble's text by clamping decimal precision to 2 digits and limiting its length, is called by `_updateBubble`, which is in turn called by all functions which change text bubble state.

This formatting was previously done by the `say` and `think` functions. However, only the `say` function limited decimal precision, making speech bubbles and thinking bubbles inconsistent.

This does introduce a minor compatibility change from 2.0: "ask" bubbles' decimal precision is now limited as well, whereas it was not limited in 2.0.

Another minor (non-compatibility) change: `say` emitted a `SAY` event, while `think` called `_updateBubble` directly. Now, both emit a `SAY` event.

### Reason for Changes

These changes, in addition to fixing one current bug, reduce code duplication and potential for future bugs.

### Test Coverage

I have modified the `blocks_looks` unit test to check the "think" block's rounding, and to check the string from the bubble as displayed instead of from the `SAY` event.

- Should the `SAY` event's text come already formatted? I don't believe it should, which is why I changed the test, but I want your opinion(s).
