### PR TITLE
Use stack timer for "say/think for () secs"

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -307,7 +307,6 @@ class Scratch3LooksBlocks {
      */
     _bubbleForSecs (args, util, type) {
         if (util.stackTimerNeedsInit()) {
-            
             this.runtime.emit('SAY', util.target, type, args.MESSAGE);
 
             const duration = Math.max(0, 1000 * Cast.toNumber(args.SECS));

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -307,14 +307,20 @@ class Scratch3LooksBlocks {
      */
     _bubbleForSecs (args, util, type) {
         if (util.stackTimerNeedsInit()) {
+            
             this.runtime.emit('SAY', util.target, type, args.MESSAGE);
 
             const duration = Math.max(0, 1000 * Cast.toNumber(args.SECS));
 
+            util.stackFrame.bubbleId = this._getBubbleState(util.target).usageId;
             util.startStackTimer(duration);
             util.yield();
         } else if (util.stackTimerFinished()) {
-            this._updateBubble(util.target, type, '');
+            // Make sure the bubble we're removing is the same bubble we created.
+            // We don't want to cancel a bubble started from another script.
+            if (util.stackFrame.bubbleId === this._getBubbleState(util.target).usageId) {
+                this._updateBubble(util.target, type, '');
+            }
         } else {
             util.yield();
         }


### PR DESCRIPTION
### Resolves

Resolves one instance of #904
Resolves #2217 

### Proposed Changes

This PR changes "say () for () secs" and "think () for () secs" to use the "stack timer" implemented in #1759 and used in the "wait () secs" block.

### Reason for Changes

This prevents projects which rely on the timing of the "say/think () for ()" blocks from going out of sync (demo: [project 313683010](https://scratch.mit.edu/projects/313683010/editor)).
