### PR TITLE
Simplify BlockUtility.stackTimerFinished

### DIFF
--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -72,11 +72,7 @@ class BlockUtility {
      * @return {boolean} - true if the stack timer has finished.
      */
     stackTimerFinished () {
-        const timeElapsed = this.stackFrame.timer.timeElapsed();
-        if (timeElapsed < this.stackFrame.duration) {
-            return false;
-        }
-        return true;
+        return this.stackFrame.timer.timeElapsed() >= this.stackFrame.duration;
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

This PR simplifies the `BlockUtility.stackTimerFinished` function, removing an unnecessary conditional and assignment to the shorthand variable `timeElapsed`.

### Reason for Changes
This change reduces the cognitive burden on those reading through the code for the first time.