### PR TITLE
Fix Cast.LIST_ALL casting case

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -135,7 +135,7 @@ class Scratch3DataBlocks {
     deleteOfList (args, util) {
         const list = util.target.lookupOrCreateList(
             args.LIST.id, args.LIST.name);
-        const index = Cast.toListIndex(args.INDEX, list.value.length);
+        const index = Cast.toListIndex(args.INDEX, list.value.length, true);
         if (index === Cast.LIST_INVALID) {
             return;
         } else if (index === Cast.LIST_ALL) {
@@ -157,7 +157,7 @@ class Scratch3DataBlocks {
         const item = args.ITEM;
         const list = util.target.lookupOrCreateList(
             args.LIST.id, args.LIST.name);
-        const index = Cast.toListIndex(args.INDEX, list.value.length + 1);
+        const index = Cast.toListIndex(args.INDEX, list.value.length + 1, false);
         if (index === Cast.LIST_INVALID) {
             return;
         }
@@ -176,7 +176,7 @@ class Scratch3DataBlocks {
         const item = args.ITEM;
         const list = util.target.lookupOrCreateList(
             args.LIST.id, args.LIST.name);
-        const index = Cast.toListIndex(args.INDEX, list.value.length);
+        const index = Cast.toListIndex(args.INDEX, list.value.length, false);
         if (index === Cast.LIST_INVALID) {
             return;
         }
@@ -187,7 +187,7 @@ class Scratch3DataBlocks {
     getItemOfList (args, util) {
         const list = util.target.lookupOrCreateList(
             args.LIST.id, args.LIST.name);
-        const index = Cast.toListIndex(args.INDEX, list.value.length);
+        const index = Cast.toListIndex(args.INDEX, list.value.length, false);
         if (index === Cast.LIST_INVALID) {
             return '';
         }

--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -192,12 +192,13 @@ class Cast {
      * LIST_INVALID: if the index was invalid in any way.
      * @param {*} index Scratch arg, including 1-based numbers or special cases.
      * @param {number} length Length of the list.
+     * @param {boolean} acceptAll Whether it should accept "all" or not.
      * @return {(number|string)} 1-based index for list, LIST_ALL, or LIST_INVALID.
      */
-    static toListIndex (index, length) {
+    static toListIndex (index, length, acceptAll) {
         if (typeof index !== 'number') {
             if (index === 'all') {
-                return Cast.LIST_ALL;
+                return acceptAll ? Cast.LIST_ALL : Cast.LIST_INVALID;
             }
             if (index === 'last') {
                 if (length > 0) {

--- a/test/unit/util_cast.js
+++ b/test/unit/util_cast.js
@@ -167,32 +167,33 @@ test('toListIndex', t => {
     const empty = [];
 
     // Valid
-    t.strictEqual(cast.toListIndex(1, list.length), 1);
-    t.strictEqual(cast.toListIndex(6, list.length), 6);
+    t.strictEqual(cast.toListIndex(1, list.length, false), 1);
+    t.strictEqual(cast.toListIndex(6, list.length, false), 6);
 
     // Invalid
-    t.strictEqual(cast.toListIndex(-1, list.length), cast.LIST_INVALID);
-    t.strictEqual(cast.toListIndex(0.1, list.length), cast.LIST_INVALID);
-    t.strictEqual(cast.toListIndex(0, list.length), cast.LIST_INVALID);
-    t.strictEqual(cast.toListIndex(7, list.length), cast.LIST_INVALID);
+    t.strictEqual(cast.toListIndex(-1, list.length, false), cast.LIST_INVALID);
+    t.strictEqual(cast.toListIndex(0.1, list.length, false), cast.LIST_INVALID);
+    t.strictEqual(cast.toListIndex(0, list.length, false), cast.LIST_INVALID);
+    t.strictEqual(cast.toListIndex(7, list.length, false), cast.LIST_INVALID);
 
     // "all"
-    t.strictEqual(cast.toListIndex('all', list.length), cast.LIST_ALL);
+    t.strictEqual(cast.toListIndex('all', list.length, true), cast.LIST_ALL);
+    t.strictEqual(cast.toListIndex('all', list.length, false), cast.LIST_INVALID);
 
     // "last"
-    t.strictEqual(cast.toListIndex('last', list.length), list.length);
-    t.strictEqual(cast.toListIndex('last', empty.length), cast.LIST_INVALID);
+    t.strictEqual(cast.toListIndex('last', list.length, false), list.length);
+    t.strictEqual(cast.toListIndex('last', empty.length, false), cast.LIST_INVALID);
 
     // "random"
-    const random = cast.toListIndex('random', list.length);
+    const random = cast.toListIndex('random', list.length, false);
     t.ok(random <= list.length);
     t.ok(random > 0);
-    t.strictEqual(cast.toListIndex('random', empty.length), cast.LIST_INVALID);
+    t.strictEqual(cast.toListIndex('random', empty.length, false), cast.LIST_INVALID);
 
     // "any" (alias for "random")
-    const any = cast.toListIndex('any', list.length);
+    const any = cast.toListIndex('any', list.length, false);
     t.ok(any <= list.length);
     t.ok(any > 0);
-    t.strictEqual(cast.toListIndex('any', empty.length), cast.LIST_INVALID);
+    t.strictEqual(cast.toListIndex('any', empty.length, false), cast.LIST_INVALID);
     t.end();
 });


### PR DESCRIPTION
### Resolves
Resolves a bug where
`add (item (join [all] []) of [list v]) to [list v]` crashes the editor.
### Proposed Changes
Fix toListIndex and add new `acceptAll` argument.
If false, it will return Cast.LIST_INVALID instead.
### Reason for Changes
No crashing!

### Test Coverage
Added a new test to `unit/cast.js`
