### PR TITLE
GDXFOR: Rename scratchLinkSocket variables to 'socket' and 'ble' 

### DIFF
--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -134,7 +134,7 @@ class GdxFor {
          * @type {BLE}
          * @private
          */
-        this._scratchLinkSocket = null;
+        this._ble = null;
 
         /**
          * An @vernier/godirect Device
@@ -181,11 +181,11 @@ class GdxFor {
      * Called by the runtime when user wants to scan for a peripheral.
      */
     scan () {
-        if (this._scratchLinkSocket) {
-            this._scratchLinkSocket.disconnect();
+        if (this._ble) {
+            this._ble.disconnect();
         }
 
-        this._scratchLinkSocket = new BLE(this._runtime, this._extensionId, {
+        this._ble = new BLE(this._runtime, this._extensionId, {
             filters: [
                 {namePrefix: 'GDX-FOR'}
             ],
@@ -200,8 +200,8 @@ class GdxFor {
      * @param {number} id - the id of the peripheral to connect to.
      */
     connect (id) {
-        if (this._scratchLinkSocket) {
-            this._scratchLinkSocket.connectPeripheral(id);
+        if (this._ble) {
+            this._ble.connectPeripheral(id);
         }
     }
 
@@ -220,8 +220,8 @@ class GdxFor {
             spinSpeedY: 0,
             spinSpeedZ: 0
         };
-        if (this._scratchLinkSocket) {
-            this._scratchLinkSocket.disconnect();
+        if (this._ble) {
+            this._ble.disconnect();
         }
     }
 
@@ -231,8 +231,8 @@ class GdxFor {
      */
     isConnected () {
         let connected = false;
-        if (this._scratchLinkSocket) {
-            connected = this._scratchLinkSocket.isConnected();
+        if (this._ble) {
+            connected = this._ble.isConnected();
         }
         return connected;
     }
@@ -242,7 +242,7 @@ class GdxFor {
      * @private
      */
     _onConnect () {
-        const adapter = new ScratchLinkDeviceAdapter(this._scratchLinkSocket, BLEUUID);
+        const adapter = new ScratchLinkDeviceAdapter(this._ble, BLEUUID);
         godirect.createDevice(adapter, {open: true, startMeasurements: false}).then(device => {
             // Setup device
             this._device = device;
@@ -262,7 +262,7 @@ class GdxFor {
                     });
                 });
                 this._timeoutID = window.setInterval(
-                    () => this._scratchLinkSocket.handleDisconnectError(BLEDataStoppedError),
+                    () => this._ble.handleDisconnectError(BLEDataStoppedError),
                     BLETimeout
                 );
             });
@@ -306,7 +306,7 @@ class GdxFor {
         // cancel disconnect timeout and start a new one
         window.clearInterval(this._timeoutID);
         this._timeoutID = window.setInterval(
-            () => this._scratchLinkSocket.handleDisconnectError(BLEDataStoppedError),
+            () => this._ble.handleDisconnectError(BLEDataStoppedError),
             BLETimeout
         );
     }

--- a/src/extensions/scratch3_gdx_for/scratch-link-device-adapter.js
+++ b/src/extensions/scratch3_gdx_for/scratch-link-device-adapter.js
@@ -4,8 +4,8 @@ const Base64Util = require('../../util/base64-util');
  * Adapter class
  */
 class ScratchLinkDeviceAdapter {
-    constructor (scratchLinkSocket, {service, commandChar, responseChar}) {
-        this.scratchLinkSocket = scratchLinkSocket;
+    constructor (socket, {service, commandChar, responseChar}) {
+        this.socket = socket;
 
         this._service = service;
         this._commandChar = commandChar;
@@ -21,13 +21,13 @@ class ScratchLinkDeviceAdapter {
     writeCommand (commandBuffer) {
         const data = Base64Util.uint8ArrayToBase64(commandBuffer);
 
-        return this.scratchLinkSocket
+        return this.socket
             .write(this._service, this._commandChar, data, 'base64');
     }
 
     setup ({onResponse}) {
         this._deviceOnResponse = onResponse;
-        return this.scratchLinkSocket
+        return this.socket
             .startNotifications(this._service, this._responseChar, this._onResponse);
 
         // TODO:


### PR DESCRIPTION
### Resolves

- #1974 Vernier Extension: rename `scratchLinkSocket` throughout to `ble`

### Reason for Changes

To avoid potential confusions with the upcoming `ScratchLinkWebSocket` class (see: https://github.com/LLK/scratch-vm/pull/2182).  Renamed to `ble` in the extension file to match the other extensions, and renamed to `socket` in the device adapter class.
