### PR TITLE
add Profiler.increment and Profiler.frame

### DIFF
--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -121,12 +121,11 @@ class Sequencer {
                         if (stepThreadProfilerId === -1) {
                             stepThreadProfilerId = this.runtime.profiler.idByName(stepThreadProfilerFrame);
                         }
-                        this.runtime.profiler.start(stepThreadProfilerId);
+
+                        // Increment the number of times stepThread is called.
+                        this.runtime.profiler.increment(stepThreadProfilerId);
                     }
                     this.stepThread(activeThread);
-                    if (this.runtime.profiler !== null) {
-                        this.runtime.profiler.stop();
-                    }
                     activeThread.warpTimer = null;
                     if (activeThread.isKilled) {
                         i--; // if the thread is removed from the list (killed), do not increase index
@@ -203,22 +202,14 @@ class Sequencer {
                 if (executeProfilerId === -1) {
                     executeProfilerId = this.runtime.profiler.idByName(executeProfilerFrame);
                 }
-                // The method commented below has its code inlined underneath to
-                // reduce the bias recorded for the profiler's calls in this
-                // time sensitive stepThread method.
-                //
-                // this.runtime.profiler.start(executeProfilerId, null);
-                this.runtime.profiler.records.push(
-                    this.runtime.profiler.START, executeProfilerId, null, 0);
+
+                // Increment the number of times execute is called.
+                this.runtime.profiler.increment(executeProfilerId);
             }
             if (thread.target === null) {
                 this.retireThread(thread);
             } else {
                 execute(this, thread);
-            }
-            if (this.runtime.profiler !== null) {
-                // this.runtime.profiler.stop();
-                this.runtime.profiler.records.push(this.runtime.profiler.STOP, 0);
             }
             thread.blockGlowInFrame = currentBlockId;
             // If the thread has yielded or is waiting, yield to other threads.


### PR DESCRIPTION
### Resolves

Scratch performance when the profiler is recording.

### Proposed Changes

Let profiled code track frames and arguments called by incrementing a counter for a frame id or frame id and argument. This replaces the same counting by recording the call as part of a history of calls and returns. Updating the array for all calls counted takes enough time to bias the profiled run towards less overall executions.

### Reason for Changes

Scratch performance has improved to the point again that we need to change how the Profiler records performance to spend more time executing blocks than spending time recording that a block executed.

<details>
<summary><b>Benchmark Data</b></summary>

These numbers indicate a large improvement. Take note this improvement is only affecting when profiling is recording. This is a scratch developer facing improvement so we can get a better measure a change will make while developing the change and reviewing the change.

|  device | project id | warm up (s) | before (bps) | after (bps) | difference | change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
|  chrome mbp 15" 2017 | 130041250 | 0 | 803343 | 1338256 | 534913 | 66.59% |
|  chrome mbp 15" 2017 | 130041250 | 4 | 1038659 | 1715644 | 676985 | 65.18% |
|  chrome mbp 15" 2017 | 14844969 | 0 | 1259861 | 1922094 | 662233 | 52.56% |
|  chrome mbp 15" 2017 | 14844969 | 1 | 1393017 | 2238741 | 845724 | 60.71% |
|  chrome mbp 15" 2017 | 173918262 | 0 | 1120676 | 1853687 | 733011 | 65.41% |
|  chrome mbp 15" 2017 | 173918262 | 5 | 1149243 | 1602950 | 453707 | 39.48% |
|  chrome mbp 15" 2017 | 155128646 | 0 | 1011027 | 2084500 | 1073473 | 106.18% |
|  chrome mbp 15" 2017 | 155128646 | 5 | 856636 | 855513 | -1123 | -0.13% |
|  chrome mbp 15" 2017 | 89811578 | 0 | 1550713 | 2469557 | 918844 | 59.25% |
|  chrome mbp 15" 2017 | 89811578 | 5 | 1711245 | 2640594 | 929349 | 54.31% |
|  chrome mbp 15" 2017 | 139193539 | 0 | 1398716 | 2378486 | 979770 | 70.05% |
|  chrome mbp 15" 2017 | 139193539 | 5 | 1462682 | 2508699 | 1046017 | 71.51% |
|  chrome mbp 15" 2017 | 187694931 | 0 | 863060 | 2118414 | 1255354 | 145.45% |
|  chrome mbp 15" 2017 | 187694931 | 5 | 980702 | 2220644 | 1239942 | 126.43% |
|  chrome mbp 15" 2017 | 219313833 | 0 | 164755 | 176664 | 11909 | 7.23% |
|  chrome mbp 15" 2017 | 219313833 | 5 | 165293 | 182444 | 17151 | 10.38% |
|  chrome mbp 15" 2017 | 236115215 | 0 | 5268 | 5553 | 285 | 5.41% |
|  chrome mbp 15" 2017 | 236115215 | 5 | 5289 | 5526 | 237 | 4.48% |
|  chrome mbp 15" 2017 | 238750909 | 0 | 90887 | 91218 | 331 | 0.36% |
|  chrome mbp 15" 2017 | 238750909 | 5 | 96803 | 94128 | -2675 | -2.76% |

</details>
