### PR TITLE
Clean up hardware disconnect behavior

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -823,18 +823,22 @@ class Boost {
     }
 
     /**
-     * Disconnects from the current BLE socket.
+     * Disconnects from the current BLE socket and resets state.
      */
     disconnect () {
+        console.log('BOOST DISCONNECT CALLED');
         if (this._ble) {
             this._ble.disconnect();
         }
+
+        this.reset();
     }
 
     /**
      * Reset all the state and timeout/interval ids.
      */
     reset () {
+        console.log('BOOST RESET CALLED');
         this._ports = [];
         this._motors = [];
         this._sensors = {

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -826,8 +826,6 @@ class Boost {
      * Disconnects from the current BLE socket and resets state.
      */
     disconnect () {
-        console.log('BOOST DISCONNECT CALLED');
-
         if (this._ble) {
             this._ble.disconnect();
         }
@@ -839,8 +837,6 @@ class Boost {
      * Reset all the state and timeout/interval ids.
      */
     reset () {
-        console.log('BOOST RESET CALLED');
-
         this._ports = [];
         this._motors = [];
         this._sensors = {

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -827,6 +827,7 @@ class Boost {
      */
     disconnect () {
         console.log('BOOST DISCONNECT CALLED');
+
         if (this._ble) {
             this._ble.disconnect();
         }
@@ -839,6 +840,7 @@ class Boost {
      */
     reset () {
         console.log('BOOST RESET CALLED');
+        
         this._ports = [];
         this._motors = [];
         this._sensors = {

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -840,7 +840,7 @@ class Boost {
      */
     reset () {
         console.log('BOOST RESET CALLED');
-        
+
         this._ports = [];
         this._motors = [];
         this._sensors = {

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -678,7 +678,7 @@ class Boost {
          */
         this._pingDeviceId = null;
 
-        this.disconnect = this.disconnect.bind(this);
+        this.reset = this.reset.bind(this);
         this._onConnect = this._onConnect.bind(this);
         this._onMessage = this._onMessage.bind(this);
         this._pingDevice = this._pingDevice.bind(this);
@@ -809,7 +809,7 @@ class Boost {
                 } commented out until feature is enabled in scratch-link */
             }],
             optionalServices: []
-        }, this._onConnect, this.disconnect);
+        }, this._onConnect, this.reset);
     }
 
     /**
@@ -826,6 +826,15 @@ class Boost {
      * Disconnects from the current BLE socket.
      */
     disconnect () {
+        if (this._ble) {
+            this._ble.disconnect();
+        }
+    }
+
+    /**
+     * Reset all the state and timeout/interval ids.
+     */
+    reset () {
         this._ports = [];
         this._motors = [];
         this._sensors = {
@@ -834,10 +843,6 @@ class Boost {
             color: BoostColor.NONE,
             previousColor: BoostColor.NONE
         };
-
-        if (this._ble) {
-            this._ble.disconnect();
-        }
 
         if (this._pingDeviceId) {
             window.clearInterval(this._pingDeviceId);

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -497,7 +497,7 @@ class EV3 {
          */
         this._rateLimiter = new RateLimiter(BTSendRateMax);
 
-        this.disconnect = this.disconnect.bind(this);
+        this.reset = this.reset.bind(this);
         this._onConnect = this._onConnect.bind(this);
         this._onMessage = this._onMessage.bind(this);
         this._pollValues = this._pollValues.bind(this);
@@ -583,7 +583,7 @@ class EV3 {
         this._bt = new BT(this._runtime, this._extensionId, {
             majorDeviceClass: 8,
             minorDeviceClass: 1
-        }, this._onConnect, this.disconnect, this._onMessage);
+        }, this._onConnect, this.reset, this._onMessage);
     }
 
     /**
@@ -600,13 +600,28 @@ class EV3 {
      * Called by the runtime when user wants to disconnect from the EV3 peripheral.
      */
     disconnect () {
-        this._clearSensorsAndMotors();
-        window.clearInterval(this._pollingIntervalID);
-        this._pollingIntervalID = null;
-
         if (this._bt) {
             this._bt.disconnect();
         }
+
+        this.reset();
+    }
+
+    /**
+     * Reset all the state and timeout/interval ids.
+     */
+    reset () {
+        this._sensorPorts = [];
+        this._motorPorts = [];
+        this._sensors = {
+            distance: 0,
+            brightness: 0,
+            buttons: [0, 0, 0, 0]
+        };
+        this._motors = [null, null, null, null];
+
+        window.clearInterval(this._pollingIntervalID);
+        this._pollingIntervalID = null;
     }
 
     /**
@@ -886,22 +901,6 @@ class EV3 {
             }
         }
     }
-
-    /**
-     * Clear all the senor port and motor names, and their values.
-     * @private
-     */
-    _clearSensorsAndMotors () {
-        this._sensorPorts = [];
-        this._motorPorts = [];
-        this._sensors = {
-            distance: 0,
-            brightness: 0,
-            buttons: [0, 0, 0, 0]
-        };
-        this._motors = [null, null, null, null];
-    }
-
 }
 
 /**

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -599,7 +599,8 @@ class EV3 {
     /**
      * Called by the runtime when user wants to disconnect from the EV3 peripheral.
      */
-    disconnect () {
+    disconnect() {
+        console.log('EV3 DISCONNECT CALLED');
         if (this._bt) {
             this._bt.disconnect();
         }
@@ -610,7 +611,8 @@ class EV3 {
     /**
      * Reset all the state and timeout/interval ids.
      */
-    reset () {
+    reset() {
+        console.log('EV3 RESET CALLED');
         this._sensorPorts = [];
         this._motorPorts = [];
         this._sensors = {

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -614,7 +614,7 @@ class EV3 {
      */
     reset() {
         console.log('EV3 RESET CALLED');
-        
+
         this._sensorPorts = [];
         this._motorPorts = [];
         this._sensors = {
@@ -624,8 +624,10 @@ class EV3 {
         };
         this._motors = [null, null, null, null];
 
-        window.clearInterval(this._pollingIntervalID);
-        this._pollingIntervalID = null;
+        if (this._pollingIntervalID) {
+            window.clearInterval(this._pollingIntervalID);
+            this._pollingIntervalID = null;
+        }
     }
 
     /**

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -599,9 +599,7 @@ class EV3 {
     /**
      * Called by the runtime when user wants to disconnect from the EV3 peripheral.
      */
-    disconnect() {
-        console.log('EV3 DISCONNECT CALLED');
-
+    disconnect () {
         if (this._bt) {
             this._bt.disconnect();
         }
@@ -612,9 +610,7 @@ class EV3 {
     /**
      * Reset all the state and timeout/interval ids.
      */
-    reset() {
-        console.log('EV3 RESET CALLED');
-
+    reset () {
         this._sensorPorts = [];
         this._motorPorts = [];
         this._sensors = {

--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -601,6 +601,7 @@ class EV3 {
      */
     disconnect() {
         console.log('EV3 DISCONNECT CALLED');
+
         if (this._bt) {
             this._bt.disconnect();
         }
@@ -613,6 +614,7 @@ class EV3 {
      */
     reset() {
         console.log('EV3 RESET CALLED');
+        
         this._sensorPorts = [];
         this._motorPorts = [];
         this._sensors = {

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -209,9 +209,7 @@ class GdxFor {
      * Called by the runtime when a user exits the connection popup.
      * Disconnect from the GDX FOR.
      */
-    disconnect() {
-        console.log('GDXFOR DISCONNECT CALLED');
-
+    disconnect () {
         if (this._ble) {
             this._ble.disconnect();
         }
@@ -223,8 +221,6 @@ class GdxFor {
      * Reset all the state and timeout/interval ids.
      */
     reset () {
-        console.log('GDXFOR RESET CALLED');
-
         this._sensors = {
             force: 0,
             accelerationX: 0,

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -172,7 +172,7 @@ class GdxFor {
          */
         this._timeoutID = null;
 
-        this.disconnect = this.disconnect.bind(this);
+        this.reset = this.reset.bind(this);
         this._onConnect = this._onConnect.bind(this);
     }
 
@@ -192,7 +192,7 @@ class GdxFor {
             optionalServices: [
                 BLEUUID.service
             ]
-        }, this._onConnect, this.disconnect);
+        }, this._onConnect, this.reset);
     }
 
     /**
@@ -209,8 +209,22 @@ class GdxFor {
      * Called by the runtime when a user exits the connection popup.
      * Disconnect from the GDX FOR.
      */
-    disconnect () {
-        window.clearInterval(this._timeoutID);
+    disconnect() {
+        console.log('GDXFOR DISCONNECT CALLED');
+
+        if (this._scratchLinkSocket) {
+            this._scratchLinkSocket.disconnect();
+        }
+
+        this.reset();
+    }
+
+    /**
+     * Reset all the state and timeout/interval ids.
+     */
+    reset () {
+        console.log('GDXFOR RESET CALLED');
+        
         this._sensors = {
             force: 0,
             accelerationX: 0,
@@ -220,9 +234,8 @@ class GdxFor {
             spinSpeedY: 0,
             spinSpeedZ: 0
         };
-        if (this._scratchLinkSocket) {
-            this._scratchLinkSocket.disconnect();
-        }
+
+        window.clearInterval(this._timeoutID);
     }
 
     /**

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -212,8 +212,8 @@ class GdxFor {
     disconnect() {
         console.log('GDXFOR DISCONNECT CALLED');
 
-        if (this._scratchLinkSocket) {
-            this._scratchLinkSocket.disconnect();
+        if (this._ble) {
+            this._ble.disconnect();
         }
 
         this.reset();

--- a/src/extensions/scratch3_gdx_for/index.js
+++ b/src/extensions/scratch3_gdx_for/index.js
@@ -224,7 +224,7 @@ class GdxFor {
      */
     reset () {
         console.log('GDXFOR RESET CALLED');
-        
+
         this._sensors = {
             force: 0,
             accelerationX: 0,
@@ -235,7 +235,10 @@ class GdxFor {
             spinSpeedZ: 0
         };
 
-        window.clearInterval(this._timeoutID);
+        if (this._timeoutID) {
+            window.clearInterval(this._timeoutID);
+            this._timeoutID = null;
+        }
     }
 
     /**

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -254,7 +254,10 @@ class MicroBit {
     reset() {
         console.log('MICROBIT RESET CALLED');
 
-        window.clearTimeout(this._timeoutID);
+        if (this._timeoutID) {
+            window.clearTimeout(this._timeoutID);
+            this._timeoutID = null;
+        }
     }
 
     /**

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -238,9 +238,7 @@ class MicroBit {
     /**
      * Disconnect from the micro:bit.
      */
-    disconnect() {
-        console.log('MICROBIT DISCONNECT CALLED');
-
+    disconnect () {
         if (this._ble) {
             this._ble.disconnect();
         }
@@ -251,9 +249,7 @@ class MicroBit {
     /**
      * Reset all the state and timeout/interval ids.
      */
-    reset() {
-        console.log('MICROBIT RESET CALLED');
-
+    reset () {
         if (this._timeoutID) {
             window.clearTimeout(this._timeoutID);
             this._timeoutID = null;

--- a/src/extensions/scratch3_microbit/index.js
+++ b/src/extensions/scratch3_microbit/index.js
@@ -144,7 +144,7 @@ class MicroBit {
          */
         this._busyTimeoutID = null;
 
-        this.disconnect = this.disconnect.bind(this);
+        this.reset = this.reset.bind(this);
         this._onConnect = this._onConnect.bind(this);
         this._onMessage = this._onMessage.bind(this);
     }
@@ -222,7 +222,7 @@ class MicroBit {
             filters: [
                 {services: [BLEUUID.service]}
             ]
-        }, this._onConnect, this.disconnect);
+        }, this._onConnect, this.reset);
     }
 
     /**
@@ -238,11 +238,23 @@ class MicroBit {
     /**
      * Disconnect from the micro:bit.
      */
-    disconnect () {
-        window.clearTimeout(this._timeoutID);
+    disconnect() {
+        console.log('MICROBIT DISCONNECT CALLED');
+
         if (this._ble) {
             this._ble.disconnect();
         }
+
+        this.reset();
+    }
+
+    /**
+     * Reset all the state and timeout/interval ids.
+     */
+    reset() {
+        console.log('MICROBIT RESET CALLED');
+
+        window.clearTimeout(this._timeoutID);
     }
 
     /**

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -609,9 +609,7 @@ class WeDo2 {
     /**
      * Disconnects from the current BLE socket.
      */
-    disconnect() {
-        console.log('WEDO2 DISCONNECT CALLED');
-
+    disconnect () {
         if (this._ble) {
             this._ble.disconnect();
         }
@@ -622,9 +620,7 @@ class WeDo2 {
     /**
      * Reset all the state and timeout/interval ids.
      */
-    reset() {
-        console.log('WEDO2 RESET CALLED');
-
+    reset () {
         this._ports = ['none', 'none'];
         this._motors = [null, null];
         this._sensors = {

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -435,7 +435,7 @@ class WeDo2 {
          */
         this._batteryLevelIntervalId = null;
 
-        this.disconnect = this.disconnect.bind(this);
+        this.reset = this.reset.bind(this);
         this._onConnect = this._onConnect.bind(this);
         this._onMessage = this._onMessage.bind(this);
         this._checkBatteryLevel = this._checkBatteryLevel.bind(this);
@@ -594,7 +594,7 @@ class WeDo2 {
                 services: [BLEService.DEVICE_SERVICE]
             }],
             optionalServices: [BLEService.IO_SERVICE]
-        }, this._onConnect, this.disconnect);
+        }, this._onConnect, this.reset);
     }
 
     /**
@@ -610,7 +610,22 @@ class WeDo2 {
     /**
      * Disconnects from the current BLE socket.
      */
-    disconnect () {
+    disconnect() {
+        console.log('WEDO2 DISCONNECT CALLED');
+
+        if (this._ble) {
+            this._ble.disconnect();
+        }
+
+        this.reset();
+    }
+
+    /**
+     * Reset all the state and timeout/interval ids.
+     */
+    reset() {
+        console.log('WEDO2 RESET CALLED');
+
         this._ports = ['none', 'none'];
         this._motors = [null, null];
         this._sensors = {
@@ -618,10 +633,6 @@ class WeDo2 {
             tiltY: 0,
             distance: 0
         };
-
-        if (this._ble) {
-            this._ble.disconnect();
-        }
 
         if (this._batteryLevelIntervalId) {
             window.clearInterval(this._batteryLevelIntervalId);

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -72,6 +72,8 @@ class BLE extends JSONRPC {
      * Close the websocket.
      */
     disconnect () {
+        console.log('BLE DISCONNECT CALLED');
+
         if (this._connected) {
             this._connected = false;
         }
@@ -205,6 +207,7 @@ class BLE extends JSONRPC {
         // log.error(`BLE error: ${JSON.stringify(e)}`);
 
         if (!this._connected) return;
+        console.log('BLE HANDLEDISCONNECTERROR CALLED');
 
         this.disconnect();
 

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -9,9 +9,9 @@ class BLE extends JSONRPC {
      * @param {string} extensionId - the id of the extension using this socket.
      * @param {object} peripheralOptions - the list of options for peripheral discovery.
      * @param {object} connectCallback - a callback for connection.
-     * @param {object} disconnectCallback - a callback for disconnection.
+     * @param {object} resetCallback - a callback for resetting extension state.
      */
-    constructor (runtime, extensionId, peripheralOptions, connectCallback, disconnectCallback = null) {
+    constructor (runtime, extensionId, peripheralOptions, connectCallback, resetCallback = null) {
         super();
 
         this._socket = runtime.getScratchLinkSocket('BLE');
@@ -26,7 +26,7 @@ class BLE extends JSONRPC {
         this._connectCallback = connectCallback;
         this._connected = false;
         this._characteristicDidChangeCallback = null;
-        this._disconnectCallback = disconnectCallback;
+        this._resetCallback = resetCallback;
         this._discoverTimeoutID = null;
         this._extensionId = extensionId;
         this._peripheralOptions = peripheralOptions;
@@ -199,18 +199,17 @@ class BLE extends JSONRPC {
      * - being powered down
      *
      * Disconnect the socket, and if the extension using this socket has a
-     * disconnect callback, call it. Finally, emit an error to the runtime.
+     * reset callback, call it. Finally, emit an error to the runtime.
      */
     handleDisconnectError (/* e */) {
         // log.error(`BLE error: ${JSON.stringify(e)}`);
 
         if (!this._connected) return;
 
-        // TODO: Fix branching by splitting up cleanup/disconnect in extension
-        if (this._disconnectCallback) {
-            this._disconnectCallback(); // must call disconnect()
-        } else {
-            this.disconnect();
+        this.disconnect();
+
+        if (this._resetCallback) {
+            this._resetCallback();
         }
 
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_CONNECTION_LOST_ERROR, {

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -72,8 +72,6 @@ class BLE extends JSONRPC {
      * Close the websocket.
      */
     disconnect () {
-        console.log('BLE DISCONNECT CALLED');
-
         if (this._connected) {
             this._connected = false;
         }
@@ -203,10 +201,8 @@ class BLE extends JSONRPC {
      * Disconnect the socket, and if the extension using this socket has a
      * reset callback, call it. Finally, emit an error to the runtime.
      */
-    handleDisconnectError (e) {
-        console.error(`BLE error: ${JSON.stringify(e)}`);
-        console.error(e);
-        console.log('BLE HANDLEDISCONNECTERROR CALLED');
+    handleDisconnectError (/* e */) {
+        // log.error(`BLE error: ${JSON.stringify(e)}`);
 
         if (!this._connected) return;
 

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -205,9 +205,9 @@ class BLE extends JSONRPC {
      */
     handleDisconnectError (/* e */) {
         // log.error(`BLE error: ${JSON.stringify(e)}`);
+        console.log('BLE HANDLEDISCONNECTERROR CALLED');
 
         if (!this._connected) return;
-        console.log('BLE HANDLEDISCONNECTERROR CALLED');
 
         this.disconnect();
 

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -203,8 +203,9 @@ class BLE extends JSONRPC {
      * Disconnect the socket, and if the extension using this socket has a
      * reset callback, call it. Finally, emit an error to the runtime.
      */
-    handleDisconnectError (/* e */) {
-        // log.error(`BLE error: ${JSON.stringify(e)}`);
+    handleDisconnectError (e) {
+        console.error(`BLE error: ${JSON.stringify(e)}`);
+        console.error(e);
         console.log('BLE HANDLEDISCONNECTERROR CALLED');
 
         if (!this._connected) return;

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -78,7 +78,9 @@ class BT extends JSONRPC {
     /**
      * Close the websocket.
      */
-    disconnect () {
+    disconnect() {
+        console.log('BT DISCONNECT CALLED');
+
         if (this._connected) {
             this._connected = false;
         }
@@ -149,6 +151,7 @@ class BT extends JSONRPC {
      */
     handleDisconnectError (/* e */) {
         // log.error(`BT error: ${JSON.stringify(e)}`);
+        console.log('BT HANDLEDISCONNECTERROR CALLED');
 
         if (!this._connected) return;
 

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -149,8 +149,9 @@ class BT extends JSONRPC {
      * Disconnect the socket, and if the extension using this socket has a
      * reset callback, call it. Finally, emit an error to the runtime.
      */
-    handleDisconnectError (/* e */) {
-        // log.error(`BT error: ${JSON.stringify(e)}`);
+    handleDisconnectError (e) {
+        console.error(`BT error: ${JSON.stringify(e)}`);
+        console.error(e);
         console.log('BT HANDLEDISCONNECTERROR CALLED');
 
         if (!this._connected) return;

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -147,7 +147,7 @@ class BT extends JSONRPC {
      * - being powered down
      *
      * Disconnect the socket, and if the extension using this socket has a
-     * disconnect callback, call it. Finally, emit an error to the runtime.
+     * reset callback, call it. Finally, emit an error to the runtime.
      */
     handleDisconnectError (/* e */) {
         // log.error(`BT error: ${JSON.stringify(e)}`);

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -9,10 +9,10 @@ class BT extends JSONRPC {
      * @param {string} extensionId - the id of the extension using this socket.
      * @param {object} peripheralOptions - the list of options for peripheral discovery.
      * @param {object} connectCallback - a callback for connection.
-     * @param {object} disconnectCallback - a callback for disconnection.
+     * @param {object} resetCallback - a callback for resetting extension state.
      * @param {object} messageCallback - a callback for message sending.
      */
-    constructor (runtime, extensionId, peripheralOptions, connectCallback, disconnectCallback = null, messageCallback) {
+    constructor (runtime, extensionId, peripheralOptions, connectCallback, resetCallback = null, messageCallback) {
         super();
 
         this._socket = runtime.getScratchLinkSocket('BT');
@@ -27,7 +27,7 @@ class BT extends JSONRPC {
         this._connectCallback = connectCallback;
         this._connected = false;
         this._characteristicDidChangeCallback = null;
-        this._disconnectCallback = disconnectCallback;
+        this._resetCallback = resetCallback;
         this._discoverTimeoutID = null;
         this._extensionId = extensionId;
         this._peripheralOptions = peripheralOptions;
@@ -152,11 +152,10 @@ class BT extends JSONRPC {
 
         if (!this._connected) return;
 
-        // TODO: Fix branching by splitting up cleanup/disconnect in extension
-        if (this._disconnectCallback) {
-            this._disconnectCallback(); // must call disconnect()
-        } else {
-            this.disconnect();
+        this.disconnect();
+
+        if (this._resetCallback) {
+            this._resetCallback();
         }
 
         this._runtime.emit(this._runtime.constructor.PERIPHERAL_CONNECTION_LOST_ERROR, {

--- a/src/io/bt.js
+++ b/src/io/bt.js
@@ -78,9 +78,7 @@ class BT extends JSONRPC {
     /**
      * Close the websocket.
      */
-    disconnect() {
-        console.log('BT DISCONNECT CALLED');
-
+    disconnect () {
         if (this._connected) {
             this._connected = false;
         }
@@ -149,10 +147,8 @@ class BT extends JSONRPC {
      * Disconnect the socket, and if the extension using this socket has a
      * reset callback, call it. Finally, emit an error to the runtime.
      */
-    handleDisconnectError (e) {
-        console.error(`BT error: ${JSON.stringify(e)}`);
-        console.error(e);
-        console.log('BT HANDLEDISCONNECTERROR CALLED');
+    handleDisconnectError (/* e */) {
+        // log.error(`BT error: ${JSON.stringify(e)}`);
 
         if (!this._connected) return;
 


### PR DESCRIPTION
### Resolves

- Resolves #1929: Hardware Extensions: separate extension cleanup and disconnect

### Proposed Changes

- Instead of relying on a "disconnect callback" from the extension to close the socket on some disconnection cases, always close the socket from within itself instead, and just call a "reset callback" on the extension so it can reset its state.  This requires the hardware extensions to separate out their disconnect behavior into distinct `disconnect` and `reset` functions.

### Reason for Changes

- Clarifies the hardware extension disconnect routines so they are more legible for developers and concerns are more neatly refactored into cleaner functions

### Testing

Would be good to test and verify the following behavior for *all* hardware extensions:
1. Disconnect by turning off bluetooth
2. Disconnect by turning off Scratch Link
3. Disconnect by turning off peripheral
4. Disconnect by clicking the 'disconnect' button in the peripheral connection modal
5. Disconnect by closing the tab
6. Disconnect by closing the browser
7. Disconnect by removing the battery from peripheral (if possible)