### PR TITLE
Use new updateDrawable* methods

### DIFF
--- a/test/fixtures/fake-renderer.js
+++ b/test/fixtures/fake-renderer.js
@@ -14,12 +14,28 @@ FakeRenderer.prototype.getFencedPositionOfDrawable = function (d, p) { // eslint
     return [p[0], p[1]];
 };
 
+FakeRenderer.prototype.updateDrawableSkinId = function (d, skinId) { // eslint-disable-line no-unused-vars
+};
+
+FakeRenderer.prototype.updateDrawableSkinIdRotationCenter =
+    function (d, skinId, rotationCenter) {}; // eslint-disable-line no-unused-vars
+
+FakeRenderer.prototype.updateDrawablePosition = function (d, position) { // eslint-disable-line no-unused-vars
+    this.x = position[0];
+    this.y = position[1];
+};
+
+FakeRenderer.prototype.updateDrawableDirectionScale =
+    function (d, direction, scale) {}; // eslint-disable-line no-unused-vars
+
+FakeRenderer.prototype.updateDrawableVisible = function (d, visible) { // eslint-disable-line no-unused-vars
+};
+
+FakeRenderer.prototype.updateDrawableEffect = function (d, effectName, value) { // eslint-disable-line no-unused-vars
+};
+
 FakeRenderer.prototype.updateDrawableProperties = function (d, p) { // eslint-disable-line no-unused-vars
-    if (p.position) {
-        this.x = p.position[0];
-        this.y = p.position[1];
-    }
-    return true;
+    throw new Error('updateDrawableProperties is deprecated');
 };
 
 FakeRenderer.prototype.getCurrentSkinSize = function (d) { // eslint-disable-line no-unused-vars


### PR DESCRIPTION
### Resolves

Depends on https://github.com/LLK/scratch-vm/pull/2196.
Depends on https://github.com/LLK/scratch-render/pull/469.

Make VM and Render faster.

### Proposed Changes

- Use updateDrawable* methods added in render PR

### Reason for Changes

> - Use updateDrawable* methods added in render PR

As mentioned in the other PR, using an active tense API in place of a passive tense API allows changes to propagate to Drawables much faster.

### Benchmark Data

Refer to tables in https://github.com/LLK/scratch-render/pull/469.
