### PR TITLE
Fix #2198 and #2199

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -136,8 +136,8 @@ class Scratch3OperatorsBlocks {
         case 'floor': return Math.floor(n);
         case 'ceiling': return Math.ceil(n);
         case 'sqrt': return Math.sqrt(n);
-        case 'sin': return parseFloat(Math.sin((Math.PI * n) / 180).toFixed(10));
-        case 'cos': return parseFloat(Math.cos((Math.PI * n) / 180).toFixed(10));
+        case 'sin': return Math.round(Math.sin(n % 360 / 180 * Math.PI) * 1e10) / 1e10;
+        case 'cos': return Math.round(Math.cos(n % 360 / 180 * Math.PI) * 1e10) / 1e10;
         case 'tan': return MathUtil.tan(n);
         case 'asin': return (Math.asin(n) * 180) / Math.PI;
         case 'acos': return (Math.acos(n) * 180) / Math.PI;

--- a/src/util/math-util.js
+++ b/src/util/math-util.js
@@ -60,7 +60,7 @@ class MathUtil {
         case 270:
             return -Infinity;
         default:
-            return parseFloat(Math.tan((Math.PI * angle) / 180).toFixed(10));
+            return Math.round(Math.tan(angle / 180 * Math.PI) * 1e10) / 1e10;
         }
     }
 


### PR DESCRIPTION
Fix #2198 and #2199

Take angle modulus 360 before multiplying my Math.PI to avoid issues with decimal accuracy when the angle measure gets large. (#2199) 
Round to 10 digits using Math.round and division instead of stringifying (#2198). This should result in some performance improvements.