### PR TITLE
Allow selecting the last two piano keys

### DIFF
--- a/src/extensions/scratch3_music/index.js
+++ b/src/extensions/scratch3_music/index.js
@@ -692,7 +692,7 @@ class Scratch3MusicBlocks {
      * @type {{min: number, max: number}}
      */
     static get MIDI_NOTE_RANGE () {
-        return {min: 0, max: 130};
+        return {min: 0, max: 132};
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

Currently, the last two piano keys in the `note_field` type are not selectable. This PR changes the max note for the field validation, so that you can select the last two piano keys.

### Reason for Changes

Either the last two blocks should be selectable or the last octave should be removed (IMO :))

See https://github.com/LLK/scratch-blocks/pull/1950 as well.
