### PR TITLE
Removing comment in WeDo2 extension

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -297,7 +297,6 @@ class WeDo2Motor {
 
     /**
      * Start active braking on this motor. After a short time, the motor will turn off.
-     * // TODO: rename this to coastAfter?
      */
     startBraking () {
         if (this._power === 0) return;


### PR DESCRIPTION
Removing a comment referencing possibly renaming `startBraking` to `coastAfter`.  After comparing those two functions across the EV3 and WeDo2 extensions, it was decided that they were distinct enough, so the comment is no longer needed.

The EV3 and WeDo2 command structures that are sent over bluetooth are different in their makeup, so complicated motor commands are sent in slightly different ways for the two peripheral types.