### PR TITLE
Add docs and example for custom context menu callback with access to blockInfo.

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -531,6 +531,8 @@ In order to specify custom context menu options, you can provide a list of conte
 which contain the text label for the menu item as well as the name of the function in the extension that should be run when
 the block is selected.
 
+The context menu callback function will have access to an object with the `blockInfo` for the block instance whose context menu was triggered.
+
 ```js
 class SomeBlocks {
     // ...
@@ -558,11 +560,11 @@ class SomeBlocks {
         };
     }
 
-    myContextMenuFunction () {
+    myContextMenuFunction ({blockInfo}) {
         // ...
     }
 
-    anotherContextMenuFunction () {
+    anotherContextMenuFunction ({blockInfo}) {
         // ...
     }
     // ...

--- a/src/blocks/scratch3_core_example.js
+++ b/src/blocks/scratch3_core_example.js
@@ -79,8 +79,8 @@ class Scratch3CoreExample {
     /**
      * An example of a context menu callback.
      */
-    contextMenuOption () {
-        log.info('Custom context menu example.');
+    contextMenuOption ({blockInfo}) {
+        log.info('Custom context menu example. ', blockInfo);
     }
 
 }


### PR DESCRIPTION
Add documentation and example for a feature introduced by LLK/scratch-gui#4794. The custom context menu callback now gets passed in an object containing the blockInfo for the block instance that owns the custom context menu.