### PR TITLE
Add API for attaching a block updater callback function to the VM

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -654,12 +654,18 @@ class Runtime extends EventEmitter {
         return 'RUNTIME_DISPOSED';
     }
 
+    // TODO remove this (it will be replaced by BLOCK_UPDATE below)
+    // when sensing_of block gets extension-ified.
     /**
      * Event name for reporting that a block was updated and needs to be rerendered.
      * @const {string}
      */
     static get BLOCKS_NEED_UPDATE () {
         return 'BLOCKS_NEED_UPDATE';
+    }
+
+    static get BLOCK_UPDATE () {
+        return 'BLOCK_UPDATE';
     }
 
     /**
@@ -2454,11 +2460,22 @@ class Runtime extends EventEmitter {
         this._refreshTargets = true;
     }
 
+    // TODO replace this function with the one below,
+    // when the sensing_of block gets extension-ified.
     /**
      * Emit an event that indicates that the blocks on the workspace need updating.
      */
     requestBlocksUpdate () {
         this.emit(Runtime.BLOCKS_NEED_UPDATE);
+    }
+
+    /**
+     * Emit an event that indicates that the given block got updated.
+     * @param {string} blockId The id of the block
+     * @param {ExtensionBlockMetadata} blockInfo The new block info
+     */
+    updateBlockInfo (blockId, blockInfo) {
+        this.emit(Runtime.BLOCK_UPDATE, blockId, blockInfo);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -115,11 +115,18 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.EXTENSION_FIELD_ADDED, (fieldName, fieldImplementation) => {
             this.emit(Runtime.EXTENSION_FIELD_ADDED, fieldName, fieldImplementation);
         });
+        // TODO rename this event (and corresponding references to blocksInfo in the runtime)
+        // so that it is not confused with an extension block instance's `blockInfo` property.
         this.runtime.on(Runtime.BLOCKSINFO_UPDATE, categoryInfo => {
             this.emit(Runtime.BLOCKSINFO_UPDATE, categoryInfo);
         });
+        // TODO remove this when sensing_of block gets extension-ified
+        // it will be replaced with the event above
         this.runtime.on(Runtime.BLOCKS_NEED_UPDATE, () => {
             this.emitWorkspaceUpdate();
+        });
+        this.runtime.on(Runtime.BLOCK_UPDATE, (blockId, blockInfo) => {
+            this.emit(Runtime.BLOCK_UPDATE, blockId, blockInfo);
         });
         this.runtime.on(Runtime.TOOLBOX_EXTENSIONS_NEED_UPDATE, () => {
             this.extensionManager.refreshBlocks();

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -1056,3 +1056,25 @@ test('toJSON encodes Infinity/NaN as 0, not null', t => {
 
     t.end();
 });
+
+test('update block event', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    let emitted = false;
+    let blockId = '';
+    let blockInfo = null;
+    const blockUpdater = (id, info) => {
+        emitted = true;
+        blockId = id;
+        blockInfo = info;
+    };
+
+    vm.on('BLOCK_UPDATE', blockUpdater);
+
+    runtime.updateBlockInfo('foo', {opcode: 'fooBlock'});
+
+    t.equal(emitted, true);
+    t.equal(blockId, 'foo');
+    t.deepEqual(blockInfo, {opcode: 'fooBlock'});
+    t.end();
+});


### PR DESCRIPTION
### Resolves

Towards #2120

### Proposed Changes

Add api for attaching a callback to update a block on the workspace. This PR works with LLK/scratch-gui#4973.

### Reason for Changes

Needed to allow extensions to be able to dynamically update dynamic extension blocks.
This will be used for variable renaming, editing a custom proc, changing the shape of the control stop block, and more.

### Test Coverage

Added a unit test for the callback attaching functionality.

### Related PRs
- Related to LLK/scratch-gui#4973. This PR should be merged first.