### PR TITLE
Fix 2215 by properly remapping ports to fit new firmware changes

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1012,6 +1012,7 @@ class Boost {
                 break;
             case BoostIO.CURRENT:
             case BoostIO.VOLTAGE:
+            case BoostIO.LED:
                 break;
             default:
                 log.warn(`Unknown sensor value! Type: ${type}`);

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -97,8 +97,8 @@ const BoostPortFeedback = {
 const BoostPort10000223OrOlder = {
     A: 55,
     B: 56,
-    C: 0,
-    D: 1
+    C: 1,
+    D: 2
 };
 
 const BoostPort10000224OrNewer = {

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1935,7 +1935,7 @@ class Scratch3BoostBlocks {
             log.warn('Asked for a motor position that doesnt exist!');
             return false;
         }
-        if (portID && this._peripheral.motor(portID)) {
+        if (portID !== null && this._peripheral.motor(portID)) {
             let val = this._peripheral.motor(portID).position;
             // Boost motor A position direction is reversed by design
             // so we have to reverse the position here

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -94,14 +94,14 @@ const BoostPortFeedback = {
  * @enum {number}
  */
 
-const BoostPort20000016OrOlder = {
+const BoostPort10000223OrOlder = {
     A: 55,
     B: 56,
     C: 0,
     D: 1
 };
 
-const BoostPort20000017OrNewer = {
+const BoostPort10000224OrNewer = {
     A: 0,
     B: 1,
     C: 2,
@@ -109,7 +109,7 @@ const BoostPort20000017OrNewer = {
 };
 
 // Set default port mapping to support the newer firmware
-let BoostPort = BoostPort20000017OrNewer;
+let BoostPort = BoostPort10000224OrNewer;
 
 /**
  * Ids for each color sensor value used by the extension.
@@ -1040,10 +1040,10 @@ class Boost {
                 const fwVersion10000224 = int32ArrayToNumber([0x24, 0x02, 0x00, 0x10]);
                 const fwHub = int32ArrayToNumber(data.slice(5, data.length));
                 if (fwHub < fwVersion10000224) {
-                    BoostPort = BoostPort20000016OrOlder;
+                    BoostPort = BoostPort10000223OrOlder;
                     log.info('Move Hub firmware older than version 1.0.00.0224 detected. Using old port mapping.');
                 } else {
-                    BoostPort = BoostPort20000017OrNewer;
+                    BoostPort = BoostPort10000224OrNewer;
                 }
                 break;
             }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -94,10 +94,10 @@ const BoostPortFeedback = {
  * @enum {number}
  */
 const BoostPort = {
-    A: 55,
-    B: 56,
-    C: 1,
-    D: 2
+    A: 0,
+    B: 1,
+    C: 2,
+    D: 3
 };
 
 /**

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -93,12 +93,23 @@ const BoostPortFeedback = {
  * @readonly
  * @enum {number}
  */
-const BoostPort = {
+
+const BoostPort20000016OrOlder = {
+    A: 55,
+    B: 56,
+    C: 0,
+    D: 1
+};
+
+const BoostPort20000017OrNewer = {
     A: 0,
     B: 1,
     C: 2,
     D: 3
 };
+
+// Set default port mapping to support the newer firmware
+let BoostPort = BoostPort20000017OrNewer;
 
 /**
  * Ids for each color sensor value used by the extension.


### PR DESCRIPTION
### Resolves

Resolves the part of #2215 that relates to block behavior, NOT connection issues.

### Proposed Changes

This PR changes port mapping as such:

Port `A`: `55` is now `0`
Port `B`: `56` is now `1`
Port `C`: `1` is now `2`
Port `D`: `2` is now `3`

Additionally it adds a `case` in `onMessage()` that catches responses from the LED to avoid warnings from appearing in the browser console. 

### Reason for Changes

LEGO has released a new firmware version 2.0.00.0017 for the LEGO BOOST Move Hub. The release included changes to the IDs that physical ports map to, and adds responses to LED commands.