### PR TITLE
Implements BLE manufacturer data-feature in LEGO BOOST extension

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -802,9 +802,9 @@ class Boost {
             filters: [{
                 services: [BoostBLE.service],
                 manufacturerData: {
-                    0: {
-                        dataPrefix: [0x97, 0x03, 0x00, 0x40],
-                        mask: [0xFF, 0xFF, 0, 0xFF]
+                    0x0397: {
+                        dataPrefix: [0x00, 0x40],
+                        mask: [0x00, 0xFF]
                     }
                 }
             }],

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -800,13 +800,13 @@ class Boost {
         }
         this._ble = new BLE(this._runtime, this._extensionId, {
             filters: [{
-                services: [BoostBLE.service]/* ,
+                services: [BoostBLE.service],
                 manufacturerData: {
                     0: {
                         dataPrefix: [0x97, 0x03, 0x00, 0x40],
                         mask: [0xFF, 0xFF, 0, 0xFF]
                     }
-                } commented out until feature is enabled in scratch-link */
+                }
             }],
             optionalServices: []
         }, this._onConnect, this.reset);


### PR DESCRIPTION
### Resolves

#2230 

### Proposed Changes

Adds a filter to the `scan()`-function so that only properly initialised LEGO BOOST Move Hubs are discovered and connected to.

### Reason for Changes

In Move Hub firmware 2.0.00.0017 the Move Hub briefly appears with a non-connectable MAC-address. Additionally, while non-connectable, no advertisement data is found. By implementing this filter, the non-connectable device will not pass through it.