### PR TITLE
Fix 2232 by using unregulated motor command to turn off motors

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -160,6 +160,7 @@ const BoostMessage = {
  * @enum {number}
  */
 const BoostOutputSubCommand = {
+    START_POWER: 0x01,
     START_POWER_PAIR: 0x02,
     SET_ACC_TIME: 0x05,
     SET_DEC_TIME: 0x06,
@@ -541,12 +542,10 @@ class BoostMotor {
     turnOff (useLimiter = true) {
         const cmd = this._parent.generateOutputCommand(
             this._index,
-            BoostOutputExecution.EXECUTE_IMMEDIATELY ^ BoostOutputExecution.COMMAND_FEEDBACK,
-            BoostOutputSubCommand.START_SPEED,
+            BoostOutputExecution.EXECUTE_IMMEDIATELY,
+            BoostOutputSubCommand.START_POWER,
             [
-                BoostMotorEndState.FLOAT,
-                BoostMotorEndState.FLOAT,
-                BoostMotorProfile.DO_NOT_USE
+                BoostMotorEndState.FLOAT
             ]
         );
 


### PR DESCRIPTION
### Resolves

#2232 

### Proposed Changes

This PR adds a new `BoostOutputSubCommand` (documented as `StartPower(Power)` at https://lego.github.io/lego-ble-wireless-protocol-docs/index.html#output-command-0x81-motor-sub-commands-0x01-0x3f), which seems to turn off the motors more reliably.
Additionally removed feedback from the motor command since this was never needed in the first place.

### Reason for Changes

The issue describes erratic motor behavior when using time-based motor commands. It seems to have to do with interactions between motor commands that start and stop the motors. By using unregulated commands to turn off the motors we seem to get reliable behavior.