### PR TITLE
replaceItemOfList() by assigning value to array index instead of Array.splice

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -180,7 +180,7 @@ class Scratch3DataBlocks {
         if (index === Cast.LIST_INVALID) {
             return;
         }
-        list.value.splice(index - 1, 1, item);
+        list.value[index - 1] = item;
         list._monitorUpToDate = false;
     }
 


### PR DESCRIPTION
### Resolves

Resolves #1934

### Proposed Changes

This PR changes the `replaceItemOfList` method to change a list item's value by `list[index] = value` instead of `list.splice(index, 1, value)`.

### Reason for Changes

`Array.splice()` is much slower than setting an array element by index.