### PR TITLE
E16N: move extension manager from VM to Runtime

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -5,6 +5,7 @@ const ArgumentType = require('../extension-support/argument-type');
 const Blocks = require('./blocks');
 const BlocksRuntimeCache = require('./blocks-runtime-cache');
 const BlockType = require('../extension-support/block-type');
+const ExtensionManager = require('../extension-support/extension-manager');
 const Profiler = require('./profiler');
 const Sequencer = require('./sequencer');
 const execute = require('./execute.js');
@@ -367,6 +368,11 @@ class Runtime extends EventEmitter {
          * @type {function}
          */
         this.removeCloudVariable = this._initializeRemoveCloudVariable(newCloudDataManager);
+
+        /**
+         * The Extension Manager handles loading and registering extensions, their services, and their blocks.
+         */
+        this.extensionManager = new ExtensionManager(this);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -170,6 +170,14 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * @returns {ExtensionManager} the extension manager, now owned by the runtime.
+     * @deprecated Please access the extension manager through the runtime instead.
+     */
+    get extensionManager () {
+        return this.runtime.extensionManager;
+    }
+
+    /**
      * Start running the VM - do this before anything else.
      */
     start () {

--- a/test/integration/internal-extension.js
+++ b/test/integration/internal-extension.js
@@ -59,7 +59,7 @@ test('internal extension', t => {
     t.ok(extension.status.constructorCalled);
 
     t.notOk(extension.status.getInfoCalled);
-    vm.extensionManager._registerInternalExtension(extension);
+    vm.runtime.extensionManager._registerInternalExtension(extension);
     t.ok(extension.status.getInfoCalled);
 
     const func = vm.runtime.getOpcodeFunction('testInternalExtension_go');
@@ -102,8 +102,8 @@ test('internal extension', t => {
 
 test('load sync', t => {
     const vm = new VirtualMachine();
-    vm.extensionManager.loadExtensionIdSync('coreExample');
-    t.ok(vm.extensionManager.isExtensionLoaded('coreExample'));
+    vm.runtime.extensionManager.loadExtensionIdSync('coreExample');
+    t.ok(vm.runtime.extensionManager.isExtensionLoaded('coreExample'));
 
     t.equal(vm.runtime._blockInfo.length, 1);
 

--- a/test/integration/load-extensions.js
+++ b/test/integration/load-extensions.js
@@ -20,7 +20,7 @@ test('Load external extensions', async t => {
         await t.test('Confirm expected extension is installed in example sb2 and sb3 projects', extTest => {
             vm.loadProject(project)
                 .then(() => {
-                    extTest.ok(vm.extensionManager.isExtensionLoaded(ext));
+                    extTest.ok(vm.runtime.extensionManager.isExtensionLoaded(ext));
                     extTest.end();
                 });
         });
@@ -53,7 +53,7 @@ test('Load video sensing extension and video properties', async t => {
 
         const stage = vm.runtime.getTargetForStage();
 
-        t.ok(vm.extensionManager.isExtensionLoaded('videoSensing'));
+        t.ok(vm.runtime.extensionManager.isExtensionLoaded('videoSensing'));
 
         // Check that the stage target has the video state values we expect
         // based on the test project files, then check that the video io device

--- a/test/integration/monitors_sb3.js
+++ b/test/integration/monitors_sb3.js
@@ -235,7 +235,7 @@ test('importing sb3 project with monitors', t => {
         t.equal(monitorRecord.visible, true);
         t.equal(monitorRecord.spriteName, null);
         t.equal(monitorRecord.targetId, null);
-        t.equal(vm.extensionManager.isExtensionLoaded('music'), true);
+        t.equal(vm.runtime.extensionManager.isExtensionLoaded('music'), true);
 
         monitorId = 'ev3_getDistance';
         monitorRecord = vm.runtime._monitorState.get(monitorId);
@@ -245,7 +245,7 @@ test('importing sb3 project with monitors', t => {
         t.equal(monitorRecord.visible, true);
         t.equal(monitorRecord.spriteName, null);
         t.equal(monitorRecord.targetId, null);
-        t.equal(vm.extensionManager.isExtensionLoaded('ev3'), true);
+        t.equal(vm.runtime.extensionManager.isExtensionLoaded('ev3'), true);
 
         t.end();
         process.nextTick(process.exit);

--- a/test/integration/sb2-import-extension-monitors.js
+++ b/test/integration/sb2-import-extension-monitors.js
@@ -37,7 +37,7 @@ test('loading sb2 project with invisible video monitor should not load monitor o
     vm.setCompatibilityMode(false);
     vm.setTurboMode(false);
     vm.loadProject(invisibleVideoMonitorProject).then(() => {
-        t.equal(vm.extensionManager.isExtensionLoaded('videoSensing'), false);
+        t.equal(vm.runtime.extensionManager.isExtensionLoaded('videoSensing'), false);
         t.equal(vm.runtime._monitorState.size, 0);
         t.end();
     });
@@ -53,7 +53,7 @@ test('loading sb2 project with visible video monitor should not load extension',
     vm.setCompatibilityMode(false);
     vm.setTurboMode(false);
     vm.loadProject(visibleVideoMonitorProject).then(() => {
-        t.equal(vm.extensionManager.isExtensionLoaded('videoSensing'), false);
+        t.equal(vm.runtime.extensionManager.isExtensionLoaded('videoSensing'), false);
         t.equal(vm.runtime._monitorState.size, 0);
         t.end();
     });
@@ -84,7 +84,7 @@ test('sb2 project with invisible music monitor should not load monitor or extens
     vm.setCompatibilityMode(false);
     vm.setTurboMode(false);
     vm.loadProject(invisibleTempoMonitorProject).then(() => {
-        t.equal(vm.extensionManager.isExtensionLoaded('music'), false);
+        t.equal(vm.runtime.extensionManager.isExtensionLoaded('music'), false);
         t.equal(vm.runtime._monitorState.size, 0);
         t.end();
     });
@@ -100,7 +100,7 @@ test('sb2 project with visible music monitor should load monitor and extension',
     vm.setCompatibilityMode(false);
     vm.setTurboMode(false);
     vm.loadProject(visibleTempoMonitorProject).then(() => {
-        t.equal(vm.extensionManager.isExtensionLoaded('music'), true);
+        t.equal(vm.runtime.extensionManager.isExtensionLoaded('music'), true);
         t.equal(vm.runtime._monitorState.size, 1);
         t.equal(vm.runtime._monitorState.has('music_getTempo'), true);
         t.equal(vm.runtime._monitorState.get('music_getTempo').visible, true);

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -964,7 +964,7 @@ test('shareBlocksToTarget loads extensions that have not yet been loaded', t => 
 
     // Stub the extension manager
     const loadedIds = [];
-    vm.extensionManager = {
+    vm.runtime.extensionManager = {
         isExtensionLoaded: id => id === 'loaded',
         loadExtensionURL: id => new Promise(resolve => {
             loadedIds.push(id);


### PR DESCRIPTION
### Proposed Changes

Move the Extension Manager class from being owned by the VM to being owned by the Runtime.

### Reason for Changes

For one thing, the extension manager has more to do with the runtime than the VM, so it seems to make sense that it would be more closely associated with the runtime. I could even see the argument that the extension manager's functionality should be merged into the runtime.

The real reason, though, is that I'm in a situation where it would be really handy to make calls into the extension manager from a place which has access to the runtime but not to the VM. Specifically, in `src/engine/blocks.js`. I think it's right that `blocks.js` doesn't have access to the VM, but it needs access to information that comes from the extension manager, so... here's my proposed change :)

~Interestingly, the GUI doesn't care about the extension manager moving. All of the interaction between the GUI and the extension manager happens through events, so as long as those events get registered correctly everyone's happy. It's a bit unfortunate that the VM registers the runtime for events externally, but that's a separate problem.~

EDIT: I was wrong... there are a couple of lines in `scratch-gui/containers/extension-library.jsx` that would need to change but it'd just be a matter of replacing `vm.extensionManager` with `vm.runtime.extensionManager`.

### Test Coverage

This change is covered by existing tests, a few of which needed minor changes to access the extension manager in its new home.