### PR TITLE
Add new matrix8 data field

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -72,6 +72,10 @@ const ArgumentTypeMap = (() => {
         shadowType: 'matrix',
         fieldType: 'MATRIX'
     };
+    map[ArgumentType.MATRIX8] = {
+        shadowType: 'matrix8',
+        fieldType: 'MATRIX8'
+    };
     map[ArgumentType.NOTE] = {
         shadowType: 'note',
         fieldType: 'NOTE'

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -34,6 +34,11 @@ const ArgumentType = {
     MATRIX: 'matrix',
 
     /**
+     * String value with 8x8 matrix field
+     */
+    MATRIX8: 'matrix8',
+
+    /**
      * MIDI note number with note picker (piano) field
      */
     NOTE: 'note'

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -9,7 +9,8 @@ const KEY_NAME = {
     LEFT: 'left arrow',
     UP: 'up arrow',
     RIGHT: 'right arrow',
-    DOWN: 'down arrow'
+    DOWN: 'down arrow',
+    ENTER: 'enter'
 };
 
 /**
@@ -56,6 +57,7 @@ class Keyboard {
         case 'ArrowRight': return KEY_NAME.RIGHT;
         case 'Down':
         case 'ArrowDown': return KEY_NAME.DOWN;
+        case 'Enter': return KEY_NAME.ENTER;
         }
         // Ignore modifier keys
         if (keyString.length > 1) {


### PR DESCRIPTION
This adds a new version of the matrix data field. The original matrix data field is hard-coded to a 5x5 matrix, used to represent the LED matrix on the micro:bit. This version is instead hard-coded to an 8x8 matrix, used to represent the LED matrix on the Raspberry Pi SenseHAT.