### PR TITLE
Add enter key to list of keyboard events detected.

### DIFF
--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -9,7 +9,8 @@ const KEY_NAME = {
     LEFT: 'left arrow',
     UP: 'up arrow',
     RIGHT: 'right arrow',
-    DOWN: 'down arrow'
+    DOWN: 'down arrow',
+    ENTER: 'enter'
 };
 
 /**
@@ -56,6 +57,7 @@ class Keyboard {
         case 'ArrowRight': return KEY_NAME.RIGHT;
         case 'Down':
         case 'ArrowDown': return KEY_NAME.DOWN;
+        case 'Enter': return KEY_NAME.ENTER;
         }
         // Ignore modifier keys
         if (keyString.length > 1) {


### PR DESCRIPTION
A centre push on the joystick on the Raspberry Pi SenseHAT generates the equivalent of pressing the "enter" key on a keyboard. This PR adds detection for that event to the keyboard handling for Scratch.