### PR TITLE
Sort variable reporter blocks and variables dropdown by name.

### DIFF
--- a/src/util/string-util.js
+++ b/src/util/string-util.js
@@ -89,6 +89,21 @@ class StringUtil {
             }
         });
     }
+
+    // Port over the string comparison utiliy from scratch-blocks
+    // Blockly.scratchBlocksUtils.compareStrings
+    /**
+     * Compare strings with natural number sorting.
+     * @param {string} str1 First input.
+     * @param {string} str2 Second input.
+     * @return {number} -1, 0, or 1 to signify greater than, equality, or less than.
+     */
+    static compareStrings (str1, str2) {
+        return str1.localeCompare(str2, [], {
+            sensitivity: 'base',
+            numeric: true
+        });
+    }
 }
 
 module.exports = StringUtil;


### PR DESCRIPTION
### Resolves

- Towards #2120 

### Proposed Changes

Refactor variables extension code a bit (no longer using forEachVariable because we don't actually use anything other than the variable name, and there is already a function in `target` which returns a list of variable names. 

Sort variables by name in set of variable/list reporters in toolbox as well as in variable/list dropdown menus.

### Reason for Changes

Consistency with regular (non-extensionified) variable category.
