### PR TITLE
Add custom mime-type to exported sb3 and sprite

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -382,6 +382,7 @@ class VirtualMachine extends EventEmitter {
 
         return zip.generateAsync({
             type: 'blob',
+            mimeType: 'application/x.scratch.sb3',
             compression: 'DEFLATE',
             compressionOptions: {
                 level: 6 // Tradeoff between best speed (1) and best compression (9)
@@ -432,6 +433,7 @@ class VirtualMachine extends EventEmitter {
 
         return zip.generateAsync({
             type: typeof optZipType === 'string' ? optZipType : 'blob',
+            mimeType: 'application/x.scratch.sprite3',
             compression: 'DEFLATE',
             compressionOptions: {
                 level: 6


### PR DESCRIPTION
### Resolves

Part of https://github.com/LLK/scratch-android/issues/78

### Proposed Changes

Add a custom mime type to the file created for sb3 and sprite3 files.

### Reason for Changes

Override the default mime-type of application/zip

### Test Coverage

Creating a unit test would require invasive changes (node does not support blob, we're using JSZip to create a blob for the sb3, so a test that creates an sb3 fails with an error from JSzip). It doesn't seem worth changing how we save sb3s just to be able to write a test.
