### PR TITLE
Variables Extension Monitors

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -523,6 +523,10 @@ class SomeBlocks {
 }
 ```
 
+#### Specifying a palette key for a block instance
+With the addition of dynamic blocks, an extension can specify multiple blocks with the same opcode. The extension developer can optionally specify a `paletteKey` to differentiate the blocks in the toolbox (in particular this will
+be necessary if there are multiple reporter blocks with the same opcode, and they don't disable monitors).
+
 #### Adding Custom Context Menu Options
 Dynamic blocks can have custom context menu options in addition to the default options for adding
 a block comment, deleting the block, and duplicating the block.

--- a/src/CORE_BLOCKS.js
+++ b/src/CORE_BLOCKS.js
@@ -1,0 +1,13 @@
+module.exports = [
+    'data',
+    'coreExample'
+    // 'motion',
+    // 'looks',
+    // 'sound',
+    // 'events',
+    // 'control',
+    // 'sensing',
+    // 'operators',
+    // 'variables',
+    // 'myBlocks'
+];

--- a/src/blocks/data.js
+++ b/src/blocks/data.js
@@ -2,6 +2,7 @@ const ArgumentType = require('../extension-support/argument-type');
 const BlockType = require('../extension-support/block-type');
 const Cast = require('../util/cast');
 const log = require('../util/log');
+const StringUtil = require('../util/string-util');
 const Variable = require('../engine/variable');
 const formatMessage = require('format-message');
 
@@ -53,6 +54,8 @@ class Scratch3DataBlocks {
                 menuItems.push(v.name);
             }
         });
+        menuItems.sort(StringUtil.compareStrings);
+
         const selectedVariableText = menuState && menuState.selectedValue;
         if (selectedVariableText) {
             menuItems.push({
@@ -128,7 +131,7 @@ class Scratch3DataBlocks {
                 listNames.push(v.name);
             }
         });
-        return listNames;
+        return listNames.sort(StringUtil.stringCompare);
     }
 
     getListsMenuItems (editingTargetID, menuState) {
@@ -157,8 +160,8 @@ class Scratch3DataBlocks {
         return menuItems;
     }
 
-    getListContents ({LIST}, util) {
-        const list = this.getVariableObject(util, LIST, Variable.LIST_TYPE);
+    getListContents (args, util, blockInfo) {
+        const list = util.target.lookupOrCreateVariableByNameAndType(blockInfo.text, Variable.LIST_TYPE);
 
         // If block is running for monitors, return copy of list as an array if changed.
         if (util.thread.updateMonitor) {
@@ -333,6 +336,10 @@ class Scratch3DataBlocks {
                 break;
             }
         });
+
+        // Sort the variables and lists alphabetically
+        variables.sort((a, b) => StringUtil.compareStrings(a.name, b.name));
+        lists.sort((a, b) => StringUtil.compareStrings(a.name, b.name));
 
         const blocks = [];
         this.addBlocksForVariables(blocks, variables);

--- a/src/blocks/data.js
+++ b/src/blocks/data.js
@@ -387,6 +387,7 @@ class Scratch3DataBlocks {
             func: 'getVariableValue',
             blockType: BlockType.REPORTER,
             text: v.name,
+            paletteKey: v.id,
             customContextMenu: [
                 {
                     text: formatMessage({
@@ -511,6 +512,7 @@ class Scratch3DataBlocks {
             func: 'getListContents',
             blockType: BlockType.REPORTER,
             text: list.name,
+            paletteKey: list.id,
             customContextMenu: [
                 {
                     text: formatMessage({

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -597,9 +597,6 @@ class Blocks {
             } else {
                 // Changing the value in a dropdown
                 block.fields[args.name].value = args.value;
-                if (block.mutation && block.mutation.blockInfo) {
-                    block.mutation.blockInfo.arguments[args.name].selectedValue = args.value;
-                }
 
                 // The selected item in the sensing of block menu needs to change based on the
                 // selected target.  Set it to the first item in the menu list.

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -657,6 +657,19 @@ class Blocks {
                 isSpriteLocalVariable = !(this.runtime.getTargetForStage().variables[block.fields.VARIABLE.id]);
             } else if (block.opcode === 'data_listcontents') {
                 isSpriteLocalVariable = !(this.runtime.getTargetForStage().variables[block.fields.LIST.id]);
+            } else if (block.opcode === 'data2_variable') {
+                // TODO replace above cases with this one and the one below when we switch
+                // over to using the variables extension
+                const varName = block.mutation.blockInfo.text;
+                isSpriteLocalVariable = !(this.runtime.getTargetForStage().lookupVariableByNameAndType(
+                    varName, Variable.SCALAR_TYPE
+                ));
+            } else if (block.opcode === 'data2_listcontents') {
+                const listName = block.mutation.blockInfo.text;
+                isSpriteLocalVariable =
+                    !(this.runtime.getTargetForStage().lookupVariableByNameAndType(
+                        listName, Variable.LIST_TYPE
+                    ));
             }
 
             const isSpriteSpecific = isSpriteLocalVariable ||
@@ -684,7 +697,8 @@ class Blocks {
                         params: this._getBlockParams(block),
                         // @todo(vm#565) for numerical values with decimals, some countries use comma
                         value: '',
-                        mode: block.opcode === 'data_listcontents' ? 'list' : 'default'
+                        mode: (block.opcode === 'data_listcontents') || (block.opcode === 'data2_listcontents') ?
+                            'list' : 'default'
                     }));
                 }
             }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1181,7 +1181,9 @@ class Runtime extends EventEmitter {
 
         const mutation = blockInfo.isDynamic ? `<mutation blockInfo="${xmlEscape(JSON.stringify(blockInfo))}"/>` : '';
         const inputs = context.inputList.join('');
-        const blockXML = `<block type="${extendedOpcode}">${mutation}${inputs}</block>`;
+        const toolboxIdXml = blockInfo.isDynamic && blockInfo.paletteKey ?
+            ` id="${xmlEscape(blockInfo.paletteKey)}"` : '';
+        const blockXML = `<block type="${extendedOpcode}"${toolboxIdXml}>${mutation}${inputs}</block>`;
 
         return {
             info: context.blockInfo,

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -18,6 +18,8 @@ const Variable = require('./variable');
 const xmlEscape = require('../util/xml-escape');
 const ScratchLinkWebSocket = require('../util/scratch-link-websocket');
 
+const CORE_BLOCKS = require('../CORE_BLOCKS');
+
 // Virtual I/O devices.
 const Clock = require('../io/clock');
 const Cloud = require('../io/cloud');
@@ -2416,27 +2418,66 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Get the label or label function for an opcode
-     * @param {string} extendedOpcode - the opcode you want a label for
-     * @return {object} - object with label and category
-     * @property {string} category - the category for this opcode
-     * @property {Function} [labelFn] - function to generate the label for this opcode
-     * @property {string} [label] - the label for this opcode if `labelFn` is absent
+     * Check that the given category id is a core extension.
+     * @param {string} categoryId The ID of the category to be checked
+     * @returns {boolean} True if the given categoryId matches that of a core extension,
+     * otherwise false.
      */
-    getLabelForOpcode (extendedOpcode) {
+    isCoreExtension (categoryId) {
+        return CORE_BLOCKS.indexOf(categoryId) > -1;
+    }
+
+    /**
+     * Get the monitor label and color for a given toolbox block id.
+     * @param {string} id - the block id for a block with a monitor being requested
+     * @return {object} - object with label and color
+     * @property {string} color - the color for the monitor for the given block id
+     * @property {string} label - the label for the monitor for the given block id
+     */
+    getMonitorLabelForBlock (id) {
+        // Having dynamic extension blocks makes it so that a single extension category can have
+        // multiple toolbox blocks with the same opcode. This previously wasn't possible.
+        // This means that we can no longer use just the opcode to look up the block and
+        // should instead look up the block using its unique id.
+        const block = this.flyoutBlocks.getBlock(id);
+        // If the block doesn't actually exist in the flyout, we should not
+        // be creating a label for it.
+        if (!block) return;
+
+        // Look up category info from the block
+        const extendedOpcode = block.opcode;
         const [category, opcode] = StringUtil.splitFirst(extendedOpcode, '_');
         if (!(category && opcode)) return;
 
         const categoryInfo = this._blockInfo.find(ci => ci.id === category);
         if (!categoryInfo) return;
 
-        const block = categoryInfo.blocks.find(b => b.info.opcode === opcode);
-        if (!block) return;
+        const isDynamicExtensionBlock =
+            block.mutation &&
+            block.mutation.blockInfo &&
+            block.mutation.blockInfo.isDynamic;
+        let extensionBlockInfo;
+        if (isDynamicExtensionBlock) {
+            extensionBlockInfo = block.mutation.blockInfo;
+        } else {
+            const extensionBlockDesc = categoryInfo.blocks.find(b => b.info.opcode === opcode);
+            extensionBlockInfo = (extensionBlockDesc && extensionBlockDesc.info) || null;
+        }
+        if (!extensionBlockInfo) return;
+
+        // TODO get rid of this when we update the core extension name
+        const temporaryCategory = category === 'data2' ? 'data' : category;
+        if (this.isCoreExtension(temporaryCategory)) {
+            return {
+                color: extensionBlockInfo.color1 || categoryInfo.color1,
+                label: extensionBlockInfo.text
+            };
+        }
 
         // TODO: we may want to format the label in a locale-specific way.
         return {
-            category: 'extension', // This assumes that all extensions have the same monitor color.
-            label: `${categoryInfo.name}: ${block.info.text}`
+            color: categoryInfo.color1, // TODO This assumes that all extensions have the same monitor color.
+            label: `${categoryInfo.name}: ${extensionBlockInfo.text}`
         };
     }
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -271,7 +271,7 @@ class Runtime extends EventEmitter {
          * Track any monitors to be added that don't have corresponding monitor blocks
          * created yet.
          */
-        this._pendingMonitors = {};
+        this._pendingMonitors = new Set();
 
         /**
          * Whether the project is in "turbo mode."
@@ -1796,7 +1796,7 @@ class Runtime extends EventEmitter {
 
         this.targets.map(this.disposeTarget, this);
         this._monitorState = OrderedMap({});
-        this._pendingMonitors = {};
+        this._pendingMonitors.clear();
         this.emit(Runtime.RUNTIME_DISPOSED);
         // @todo clear out extensions? turboMode? etc.
 
@@ -2482,7 +2482,7 @@ class Runtime extends EventEmitter {
 
         // TODO: we may want to format the label in a locale-specific way.
         return {
-            color: categoryInfo.color1, // TODO This assumes that all extensions have the same monitor color.
+            color: categoryInfo.color1,
             label: `${categoryInfo.name}: ${extensionBlockInfo.text}`
         };
     }
@@ -2494,7 +2494,7 @@ class Runtime extends EventEmitter {
      * @param {string} blockId The id of the block with a pending monitor
      */
     addPendingMonitor (blockId) {
-        this._pendingMonitors[blockId] = true;
+        this._pendingMonitors.add(blockId);
     }
 
     /**
@@ -2503,7 +2503,7 @@ class Runtime extends EventEmitter {
      * @param {string} blockId The id of the block with a pending monitor
      */
     removePendingMonitor (blockId) {
-        delete this._pendingMonitors[blockId];
+        this._pendingMonitors.delete(blockId);
     }
 
     /**
@@ -2512,7 +2512,7 @@ class Runtime extends EventEmitter {
      * @return {boolean} True if the block has a pending monitor, false otherwise.
      */
     getPendingMonitor (blockId) {
-        return this._pendingMonitors[blockId] || false;
+        return this._pendingMonitors.has(blockId);
     }
 
     /**

--- a/src/util/string-util.js
+++ b/src/util/string-util.js
@@ -89,6 +89,21 @@ class StringUtil {
             }
         });
     }
+
+    // Port over the string comparison utiliy from scratch-blocks
+    // Blockly.scratchBlocksUtils.compareStrings
+    /**
+     * Compare strings with natural number sorting.
+     * @param {string} str1 First input.
+     * @param {string} str2 Second input.
+     * @return {number} -1, 0, or 1 to signify greater than, equality, or less than.
+     */
+    static compareStrings (str1, str2) {
+        return str1.localeCompare(str2, [], {
+            sensitivity: 'base',
+            numeric: true
+        });
+    }
 }
 
 module.exports = StringUtil;

--- a/src/util/string-util.js
+++ b/src/util/string-util.js
@@ -90,7 +90,7 @@ class StringUtil {
         });
     }
 
-    // Port over the string comparison utiliy from scratch-blocks
+    // Port over the string comparison utility from scratch-blocks
     // Blockly.scratchBlocksUtils.compareStrings
     /**
      * Compare strings with natural number sorting.

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -25,20 +25,10 @@ const {loadSound} = require('./import/load-sound.js');
 const {serializeSounds, serializeCostumes} = require('./serialization/serialize-assets');
 require('canvas-toBlob');
 
+const CORE_EXTENSIONS = require('./CORE_BLOCKS.js');
+
 const RESERVED_NAMES = ['_mouse_', '_stage_', '_edge_', '_myself_', '_random_'];
 
-const CORE_EXTENSIONS = [
-    'data'
-    // 'motion',
-    // 'looks',
-    // 'sound',
-    // 'events',
-    // 'control',
-    // 'sensing',
-    // 'operators',
-    // 'variables',
-    // 'myBlocks'
-];
 
 /**
  * Handles connections between blocks, stage, and extensions.

--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -82,7 +82,7 @@ test('monitorStateDoesNotEqual', t => {
     t.end();
 });
 
-test('getLabelForOpcode', t => {
+test('getMonitorLabelForBlock', t => {
     const r = new Runtime();
 
     const fakeExtension = {
@@ -108,15 +108,23 @@ test('getLabelForOpcode', t => {
         ]
     };
 
-    r._blockInfo.push(fakeExtension);
+    // Mock convertForScratchBlocks so extension info can get populated using
+    // registerExtensionPrimitives and default extension color can get filled in
+    // for extension category color
+    r._convertForScratchBlocks = blockInfo => blockInfo;
+    r._registerExtensionPrimitives(fakeExtension);
 
-    const result1 = r.getLabelForOpcode('fakeExtension_foo');
-    t.type(result1.category, 'string');
+    r.flyoutBlocks.createBlock({id: 'fooBlock', opcode: 'fakeExtension_foo'});
+    r.flyoutBlocks.createBlock({id: 'foo2Block', opcode: 'fakeExtension_foo_2'});
+
+
+    const result1 = r.getMonitorLabelForBlock('fooBlock');
+    t.type(result1.color, 'string');
     t.type(result1.label, 'string');
     t.equals(result1.label, 'Fake Extension: Foo');
 
-    const result2 = r.getLabelForOpcode('fakeExtension_foo_2');
-    t.type(result2.category, 'string');
+    const result2 = r.getMonitorLabelForBlock('foo2Block');
+    t.type(result2.color, 'string');
     t.type(result2.label, 'string');
     t.equals(result2.label, 'Fake Extension: Foo 2');
 


### PR DESCRIPTION
### Proposed Changes

- Make variable/list monitors work with the new variables extension.
    - Variable reporter blocks in the toolbox were getting random IDs assigned to them, and these ids were getting newly generated every time we refreshed the toolbox. This makes it impossible to have the block monitor stay associated with the toolbox block. Add `paletteKey` property to dynamic extension block info to keep a block id consistent.
     - When a variable or list is created from `make a variable` button, it should have its monitor checkbox checked. This was previously handled automatically by scratch-blocks, but with the new extension code paths, the variable block does not exist at the time when we have submitted the information in the modal. The VM needs to hold on to the variable creation information when it receives a `var_create` event from scratch-blocks and keep track that there is a monitor pending for a block with the same id as the variable. This pending monitor is used to later add the check to the monitor checkbox for the newly created variable reporter block.
    - Monitor label information (e.g. label text and monitor color) for extension monitors are now compatible with dynamic extension blocks as well as core extensions. The information returned about the monitor is now its label and color instead of its label and a string representing a category from which to derive color information from. The block color of the block being monitored is used directly instead.
- Sorts the variable reporters and the variables/lists (in the block dropdowns) alphabetically.

### Related PRs
This PR is related to LLK/scratch-gui#5102. This PR should go in first.

