### PR TITLE
Add md5 for default asset

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -219,6 +219,7 @@ const loadCostumeFromAsset = function (costume, runtime, optVersion) {
                 // Use default asset if original fails to load
                 costume.assetId = runtime.storage.defaultAssetId.ImageVector;
                 costume.asset = runtime.storage.get(costume.assetId);
+                costume.md5 = `${costume.assetId}.${AssetType.ImageVector.runtimeFormat}`;
                 return loadVector_(costume, runtime);
             });
     }


### PR DESCRIPTION
### Resolves

This was causing a crash when opening the paint editor on a sprite that had the default question mark costume