### PR TITLE
Pen color range [0..99]

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -191,13 +191,13 @@ class Scratch3PenBlocks {
     }
 
     /**
-     * Wrap a color input into the range (0,100).
+     * Wrap a color input into the range (0,99).
      * @param {number} value - the value to be wrapped.
      * @returns {number} the wrapped value.
      * @private
      */
     _wrapColor (value) {
-        return MathUtil.wrapClamp(value, 0, 100);
+        return MathUtil.wrapClamp(value, 0, 99);
     }
 
     /**


### PR DESCRIPTION
Attempted bugfix for "Pen Colors repeat each 101 numbers rather than each 100 numbers" as reported in the Scratch forum:
https://scratch.mit.edu/discuss/topic/369220/

### Resolves

https://github.com/LLK/scratch-vm/issues/2273

### Proposed Changes

Apply modulo 100 on the pen color, instead of modulo 101.

### Reason for Changes

Current behavior is confusing, inconsistent with Scratch 2.0, and (most likely) unintended.

### Test Coverage

No test coverage yet. My apologies.
