### PR TITLE
Inline Images in Extensions

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -129,7 +129,7 @@ The possible types of block arguments are as follows:
 - Angle - an input similar to the number input, but it has an additional UI to be able to pick an angle from a
 circular dial
 - Boolean - an input for a boolean (hexagonal shaped) reporter block. This field is not type-able.
-- Color - an input which displays a color swatch. This field has additional UI to pick a color by choosing values for the color's hue, saturation and brightness. Optionally, the defaultValue for the color picker can also be chosen if the extension developer wishes to display the same color every time the extension is added. If the defaultValue is left out, the default behavior of picking a random color when the block is created will be used.
+- Color - an input which displays a color swatch. This field has additional UI to pick a color by choosing values for the color's hue, saturation and brightness. Optionally, the defaultValue for the color picker can also be chosen if the extension developer wishes to display the same color every time the extension is added. If the defaultValue is left out, the default behavior of picking a random color when the extension is loaded will be used.
 - Matrix - an input which displays a 5 x 5 matrix of cells, where each cell can be filled in or clear.
 - Note - a numeric input which can select a musical note. This field has additional UI to select a note from a
 visual keyboard.
@@ -137,7 +137,7 @@ visual keyboard.
 
 #### Adding an Inline Image
 In addition to specifying block arguments (an example of string arguments shown in the code snippet above),
-you can also specify an inline image for the block. You must include a dataURI and alt text for the image.
+you can also specify an inline image for the block. You must include a dataURI for the image. If left unspecified, blank space will be allocated for the image and a warning will be logged in the console.
 You can optionally also specify `flipRTL`, a property indicating whether the image should be flipped horizontally when the editor has a right to left language selected as its locale. By default, the image is not flipped.
 
 ```js

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -119,8 +119,50 @@ class SomeBlocks {
     // ...
 }
 ```
+### Block Arguments
+In addition to displaying text, blocks can have arguments in the form of slots to take other blocks getting plugged in, or dropdown menus to select an argument value from a list of possible values.
 
-### Defining a Menu
+The possible types of block arguments are as follows:
+
+- String - a string input, this is a type-able field which also accepts other reporter blocks to be plugged in
+- Number - an input similar to the string input, but the type-able values are constrained to numbers.
+- Angle - an input similar to the number input, but it has an additional UI to be able to pick an angle from a
+circular dial
+- Boolean - an input for a boolean (hexagonal shaped) reporter block. This field is not type-able.
+- Color - an input which displays a color swatch. This field has additional UI to pick a color by choosing values for the color's hue, saturation and brightness.
+- Matrix - an input which displays a 5 x 5 matrix of cells, where each cell can be filled in or clear.
+- Note - a numeric input which can select a musical note. This field has additional UI to select a note from a
+visual keyboard.
+- Image - an inline image displayed on a block. This is a special argument type in that it does not represent a value and does not accept other blocks to be plugged-in in place of this block field. See the section below about "Adding an Inline Image".
+
+#### Adding an Inline Image
+In addition to specifying block arguments (an example of string arguments shown in the code snippet above),
+you can also specify an inline image for the block. You must include a dataURI and alt text for the image.
+You can optionally also specify `flipRTL`, a property indicating whether the image should be flipped horizontally when the editor has a right to left language selected as its locale. By default, the image is not flipped.
+
+```js
+return {
+    // ...
+    blocks: [
+        {
+            //...
+            arguments {
+                MY_IMAGE: {
+                    type: ArgumentType.IMAGE,
+                    dataURI: 'myImageData',
+                    alt: 'This is an image',
+                    flipRTL: true
+                }
+            }
+        }
+    ]
+}
+```
+
+
+
+
+#### Defining a Menu
 
 To display a drop-down menu for a block argument, specify the `menu` property of that argument and a matching item in
 the `menus` section of your extension's definition:
@@ -201,7 +243,7 @@ menus: {
 }
 ```
 
-#### Accepting reporters ("droppable" menus)
+##### Accepting reporters ("droppable" menus)
 
 By default it is not possible to specify the value of a dropdown menu by inserting a reporter block. While we
 encourage extension authors to make their menus accept reporters when possible, doing so requires careful

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -129,7 +129,7 @@ The possible types of block arguments are as follows:
 - Angle - an input similar to the number input, but it has an additional UI to be able to pick an angle from a
 circular dial
 - Boolean - an input for a boolean (hexagonal shaped) reporter block. This field is not type-able.
-- Color - an input which displays a color swatch. This field has additional UI to pick a color by choosing values for the color's hue, saturation and brightness.
+- Color - an input which displays a color swatch. This field has additional UI to pick a color by choosing values for the color's hue, saturation and brightness. Optionally, the defaultValue for the color picker can also be chosen if the extension developer wishes to display the same color every time the extension is added. If the defaultValue is left out, the default behavior of picking a random color when the block is created will be used.
 - Matrix - an input which displays a 5 x 5 matrix of cells, where each cell can be filled in or clear.
 - Note - a numeric input which can select a musical note. This field has additional UI to select a note from a
 visual keyboard.

--- a/src/blocks/scratch3_core_example.js
+++ b/src/blocks/scratch3_core_example.js
@@ -43,8 +43,7 @@ class Scratch3CoreExample {
                     arguments: {
                         CLOCKWISE: {
                             type: ArgumentType.IMAGE,
-                            dataURI: blockIconURI,
-                            alt: 'sample-image'
+                            dataURI: blockIconURI
                         }
                     }
                 }

--- a/src/blocks/scratch3_core_example.js
+++ b/src/blocks/scratch3_core_example.js
@@ -1,4 +1,8 @@
 const BlockType = require('../extension-support/block-type');
+const ArgumentType = require('../extension-support/argument-type');
+
+/* eslint-disable-next-line max-len */
+const blockIconURI = 'data:image/svg+xml,%3Csvg id="rotate-counter-clockwise" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%233d79cc;%7D.cls-2%7Bfill:%23fff;%7D%3C/style%3E%3C/defs%3E%3Ctitle%3Erotate-counter-clockwise%3C/title%3E%3Cpath class="cls-1" d="M22.68,12.2a1.6,1.6,0,0,1-1.27.63H13.72a1.59,1.59,0,0,1-1.16-2.58l1.12-1.41a4.82,4.82,0,0,0-3.14-.77,4.31,4.31,0,0,0-2,.8,4.25,4.25,0,0,0-1.34,1.73,5.06,5.06,0,0,0,.54,4.62A5.58,5.58,0,0,0,12,17.74h0a2.26,2.26,0,0,1-.16,4.52A10.25,10.25,0,0,1,3.74,18,10.14,10.14,0,0,1,2.25,8.78,9.7,9.7,0,0,1,5.08,4.64,9.92,9.92,0,0,1,9.66,2.5a10.66,10.66,0,0,1,7.72,1.68l1.08-1.35a1.57,1.57,0,0,1,1.24-.6,1.6,1.6,0,0,1,1.54,1.21l1.7,7.37A1.57,1.57,0,0,1,22.68,12.2Z"/%3E%3Cpath class="cls-2" d="M21.38,11.83H13.77a.59.59,0,0,1-.43-1l1.75-2.19a5.9,5.9,0,0,0-4.7-1.58,5.07,5.07,0,0,0-4.11,3.17A6,6,0,0,0,7,15.77a6.51,6.51,0,0,0,5,2.92,1.31,1.31,0,0,1-.08,2.62,9.3,9.3,0,0,1-7.35-3.82A9.16,9.16,0,0,1,3.17,9.12,8.51,8.51,0,0,1,5.71,5.4,8.76,8.76,0,0,1,9.82,3.48a9.71,9.71,0,0,1,7.75,2.07l1.67-2.1a.59.59,0,0,1,1,.21L22,11.08A.59.59,0,0,1,21.38,11.83Z"/%3E%3C/svg%3E';
 
 /**
  * An example core block implemented using the extension spec.
@@ -31,6 +35,18 @@ class Scratch3CoreExample {
                     opcode: 'exampleOpcode',
                     blockType: BlockType.REPORTER,
                     text: 'example block'
+                },
+                {
+                    opcode: 'exampleWithInlineImage',
+                    blockType: BlockType.COMMAND,
+                    text: 'block with image [CLOCKWISE] inline',
+                    arguments: {
+                        CLOCKWISE: {
+                            type: ArgumentType.IMAGE,
+                            dataURI: blockIconURI,
+                            alt: 'sample-image'
+                        }
+                    }
                 }
             ]
         };
@@ -43,6 +59,10 @@ class Scratch3CoreExample {
     exampleOpcode () {
         const stage = this.runtime.getTargetForStage();
         return stage ? stage.getName() : 'no stage yet';
+    }
+
+    exampleWithInlineImage () {
+        return;
     }
 
 }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1250,7 +1250,9 @@ class Runtime extends EventEmitter {
                     src: argInfo.dataURI,
                     // TODO these probably shouldn't be hardcoded...?
                     width: 24,
-                    height: 24
+                    height: 24,
+                    // TODO is false a good default here?
+                    flip_rtl: argInfo.flipRTL || false
                 };
             }
         } else {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1276,7 +1276,6 @@ class Runtime extends EventEmitter {
                 // Whether or not the inline image should be flipped horizontally
                 // in RTL languages. Defaults to false, indicating that the
                 // image will not be flipped.
-                // TODO is false a good default here?
                 flip_rtl: argInfo.flipRTL || false
             };
             break;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1244,10 +1244,13 @@ class Runtime extends EventEmitter {
         // check if this is not one of those cases. E.g. an inline image on a block.
         if (argTypeInfo.type && !argTypeInfo.shadowType && !argTypeInfo.fieldType) {
             if (argTypeInfo.type === 'IMAGE') {
+                if (!argInfo.dataURI) {
+                    log.warn('Missing data URI in extension block with argument type IMAGE');
+                }
                 argJSON = {
                     type: 'field_image',
-                    alt: argInfo.alt,
-                    src: argInfo.dataURI,
+                    alt: argInfo.alt || '',
+                    src: argInfo.dataURI || '',
                     // TODO these probably shouldn't be hardcoded...?
                     width: 24,
                     height: 24,

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1251,6 +1251,9 @@ class Runtime extends EventEmitter {
                     // TODO these probably shouldn't be hardcoded...?
                     width: 24,
                     height: 24,
+                    // Whether or not the inline image should be flipped horizontally
+                    // in RTL languages. Defaults to false, indicating that the
+                    // image will not be flipped.
                     // TODO is false a good default here?
                     flip_rtl: argInfo.flipRTL || false
                 };

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1320,8 +1320,8 @@ class Runtime extends EventEmitter {
                 }
             } else {
                 valueName = placeholder;
-                shadowType = argTypeInfo.shadow.type || null;
-                fieldName = argTypeInfo.shadow.fieldName || null;
+                shadowType = (argTypeInfo.shadow && argTypeInfo.shadow.type) || null;
+                fieldName = (argTypeInfo.shadow && argTypeInfo.shadow.fieldName) || null;
             }
 
             // <value> is the ScratchBlocks name for a block input.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1180,7 +1180,7 @@ class Runtime extends EventEmitter {
                 src: './static/blocks-media/repeat.svg', // TODO: use a constant or make this configurable?
                 width: 24,
                 height: 24,
-                alt: '*',
+                alt: '*', // TODO remove this since we don't use collapsed blocks in scratch
                 flip_rtl: true
             }];
             ++outLineNum;
@@ -1269,7 +1269,6 @@ class Runtime extends EventEmitter {
             }
             argJSON = {
                 type: 'field_image',
-                alt: argInfo.alt || '',
                 src: argInfo.dataURI || '',
                 // TODO these probably shouldn't be hardcoded...?
                 width: 24,

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -36,7 +36,12 @@ const ArgumentType = {
     /**
      * MIDI note number with note picker (piano) field
      */
-    NOTE: 'note'
+    NOTE: 'note',
+
+    /**
+     * Inline image on block (as part of the label)
+     */
+    IMAGE: 'image'
 };
 
 module.exports = ArgumentType;

--- a/test/integration/internal-extension.js
+++ b/test/integration/internal-extension.js
@@ -101,13 +101,16 @@ test('load sync', t => {
     t.equal(vm.runtime._blockInfo.length, 1);
 
     // blocks should be an array of two items: a button pseudo-block and a reporter block.
-    t.equal(vm.runtime._blockInfo[0].blocks.length, 2);
+    t.equal(vm.runtime._blockInfo[0].blocks.length, 3);
     t.type(vm.runtime._blockInfo[0].blocks[0].info, 'object');
     t.type(vm.runtime._blockInfo[0].blocks[0].info.func, 'MAKE_A_VARIABLE');
     t.equal(vm.runtime._blockInfo[0].blocks[0].info.blockType, 'button');
     t.type(vm.runtime._blockInfo[0].blocks[1].info, 'object');
     t.equal(vm.runtime._blockInfo[0].blocks[1].info.opcode, 'exampleOpcode');
     t.equal(vm.runtime._blockInfo[0].blocks[1].info.blockType, 'reporter');
+    t.type(vm.runtime._blockInfo[0].blocks[2].info, 'object');
+    t.equal(vm.runtime._blockInfo[0].blocks[2].info.opcode, 'exampleWithInlineImage');
+    t.equal(vm.runtime._blockInfo[0].blocks[2].info.blockType, 'command');
 
     // Test the opcode function
     t.equal(vm.runtime._blockInfo[0].blocks[1].info.func(), 'no stage yet');

--- a/test/unit/extension_conversion.js
+++ b/test/unit/extension_conversion.js
@@ -139,7 +139,6 @@ const testInlineImage = function (t, inlineImage) {
         {
             type: 'field_image',
             src: 'invalid image URI',
-            alt: '', // Empty because not specified
             width: 24,
             height: 24,
             flip_rtl: false // False by default

--- a/test/unit/extension_conversion.js
+++ b/test/unit/extension_conversion.js
@@ -41,10 +41,14 @@ const testExtensionInfo = {
         {
             opcode: 'command',
             blockType: BlockType.COMMAND,
-            text: 'text with [ARG]',
+            text: 'text with [ARG] [ARG_WITH_DEFAULT]',
             arguments: {
                 ARG: {
                     type: ArgumentType.STRING
+                },
+                ARG_WITH_DEFAULT: {
+                    type: ArgumentType.STRING,
+                    defaultValue: 'default text'
                 }
             }
         },
@@ -157,7 +161,7 @@ const testCommand = function (t, command) {
     t.assert(command.json.hasOwnProperty('previousStatement'));
     t.assert(command.json.hasOwnProperty('nextStatement'));
     t.notOk(command.json.extensions && command.json.extensions.length); // OK if it's absent or empty
-    t.equal(command.json.message0, 'text with %1');
+    t.equal(command.json.message0, 'text with %1 %2');
     t.notOk(command.json.hasOwnProperty('message1'));
     t.strictSame(command.json.args0[0], {
         type: 'input_value',
@@ -165,8 +169,9 @@ const testCommand = function (t, command) {
     });
     t.notOk(command.json.hasOwnProperty('args1'));
     t.equal(command.xml,
-        '<block type="test_command"><value name="ARG"><shadow type="text"><field name="TEXT">' +
-        '</field></shadow></value></block>');
+        '<block type="test_command"><value name="ARG"><shadow type="text"></shadow></value>' +
+        '<value name="ARG_WITH_DEFAULT"><shadow type="text"><field name="TEXT">' +
+        'default text</field></shadow></value></block>');
 };
 
 const testConditional = function (t, conditional) {
@@ -223,8 +228,7 @@ const testLoop = function (t, loop) {
     t.equal(loop.json.args2[0].flip_rtl, true);
     t.notOk(loop.json.hasOwnProperty('args3'));
     t.equal(loop.xml,
-        '<block type="test_loop"><value name="MANY"><shadow type="math_number"><field name="NUM">' +
-        '</field></shadow></value></block>');
+        '<block type="test_loop"><value name="MANY"><shadow type="math_number"></shadow></value></block>');
 };
 
 test('registerExtensionPrimitives', t => {

--- a/test/unit/extension_conversion.js
+++ b/test/unit/extension_conversion.js
@@ -26,6 +26,17 @@ const testExtensionInfo = {
             text: 'simple text',
             blockIconURI: 'invalid icon URI' // trigger the 'scratch_extension' path
         },
+        {
+            opcode: 'inlineImage',
+            blockType: BlockType.REPORTER,
+            text: 'text and [IMAGE]',
+            arguments: {
+                IMAGE: {
+                    type: ArgumentType.IMAGE,
+                    dataURI: 'invalid image URI'
+                }
+            }
+        },
         '---', // separator between groups of blocks in an extension
         {
             opcode: 'command',
@@ -106,6 +117,32 @@ const testReporter = function (t, reporter) {
     ]);
     t.notOk(reporter.json.hasOwnProperty('args1'));
     t.equal(reporter.xml, '<block type="test_reporter"></block>');
+};
+
+const testInlineImage = function (t, inlineImage) {
+    t.equal(inlineImage.json.type, 'test_inlineImage');
+    testCategoryInfo(t, inlineImage);
+    t.equal(inlineImage.json.checkboxInFlyout, true);
+    t.equal(inlineImage.json.outputShape, ScratchBlocksConstants.OUTPUT_SHAPE_ROUND);
+    t.equal(inlineImage.json.output, 'String');
+    t.notOk(inlineImage.json.hasOwnProperty('previousStatement'));
+    t.notOk(inlineImage.json.hasOwnProperty('nextStatement'));
+    t.notOk(inlineImage.json.extensions && inlineImage.json.extensions.length); // OK if it's absent or empty
+    t.equal(inlineImage.json.message0, 'text and %1'); // block text followed by inline image
+    t.notOk(inlineImage.json.hasOwnProperty('message1'));
+    t.same(inlineImage.json.args0, [
+        // %1 in message0: the block icon
+        {
+            type: 'field_image',
+            src: 'invalid image URI',
+            alt: '', // Empty because not specified
+            width: 24,
+            height: 24,
+            flip_rtl: false // False by default
+        }
+    ]);
+    t.notOk(inlineImage.json.hasOwnProperty('args1'));
+    t.equal(inlineImage.xml, '<block type="test_inlineImage"></block>');
 };
 
 const testSeparator = function (t, separator) {
@@ -203,10 +240,11 @@ test('registerExtensionPrimitives', t => {
         });
 
         // Note that this also implicitly tests that block order is preserved
-        const [button, reporter, separator, command, conditional, loop] = blocksInfo;
+        const [button, reporter, inlineImage, separator, command, conditional, loop] = blocksInfo;
 
         testButton(t, button);
         testReporter(t, reporter);
+        testInlineImage(t, inlineImage);
         testSeparator(t, separator);
         testCommand(t, command);
         testConditional(t, conditional);


### PR DESCRIPTION
### Resolves

Adds support for inline images in extension blocks. Towards supporting the goals of the extension-ification project as well, however additional work will be needed to support inline images in *dynamic extension blocks* as introduced by the extensionification effort.

Closes #2259 as this PR provides the same functionality.

### Proposed Changes

- Add a new argument type "IMAGE". Add support in the `convertPlaceholders` function for creating an inline image on a block. This function is responsible for translating the extension specification for block arguments into the JSON and XML representations scratch blocks uses to define a block opcode and layout a block.

- Make the COLOR argument type more consistent with the others: the extension developer can now specify a defaultValue for the color picker to be used when the extension is first loaded. If the extension developer leaves out the `defaultValue` property in the argument description, the default scratch-blocks behavior of choosing a random color will be used.

Things that need discussion:
- We are adding something that does not actually represent a block "argument" to the set of "argument types" because inline images are currently the only type of addition to a block other than block text that does not represent a block argument of some sort.
- The re-structuring of the convertPlaceholders can be up for debate.
- Is `false` the right default for the `flipRTL` property for the inline image? A value of false means that the image will not be flipped horizontally when the block is laid out for an RTL language.
@chrisgarrity Any thoughts about this? I chose false as the default because that's how it is for our turn blocks (clockwise and counterclockwise should not be flipped in RTL), and the extension developer can be explicit about making the argument flip in RTL by specifying `flipRTL: true` in the argument specification in the extension info.
- Do we want to do anything else when the `dataURI` property is not provided in the specified IMAGE argument specification? Currently we log a warning in the console and the block gets laid out with space allocated for the image.
![image](https://user-images.githubusercontent.com/1786240/65364269-9668c680-dbc5-11e9-8f2d-16af78aa2b2b.png)
- It's unclear what the `alt` property in the scratch-blocks/blockly `field_image` descriptor is used for. I had expected the alt text to be either a tool-tip or alt text if the image was not provided or could not be loaded, but the above image indicates that's not true. Blockly documentation indicates that the alt text is used when the block is collapsed, see description of `opt_alt` property here:
https://developers.google.com/blockly/reference/js/Blockly.FieldImage
@picklesrus any ideas about this?

### Reason for Changes

Towards extension-ification, and also adding more features to the extension spec.

### Test Coverage

Added unit test for new inline image support.

You can test out these changes by bringing in the code from this PR and enabling the coreExample extension by adding `'coreExample'` to this list of core extensions:
https://github.com/LLK/scratch-vm/blob/develop/src/virtual-machine.js#L30

cc/ @thisandagain @knandersen @asnoba