### PR TITLE
Fix mod operator comment

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -119,7 +119,7 @@ class Scratch3OperatorsBlocks {
         const n = Cast.toNumber(args.NUM1);
         const modulus = Cast.toNumber(args.NUM2);
         let result = n % modulus;
-        // Scratch mod is kept positive.
+        // Scratch mod uses floored division instead of truncated division.
         if (result / modulus < 0) result += modulus;
         return result;
     }


### PR DESCRIPTION
The remainder of mod in Scratch is not always positive.

According to the wiki, Scratch uses floored division like Smalltalk instead of truncated division like JavaScript.

With floored division, the sign of the remainder matches the sign of the divisor - it is not always positive.
