### PR TITLE
Use bitmap skin for video preview

### DIFF
--- a/src/io/video.js
+++ b/src/io/video.js
@@ -135,7 +135,7 @@ class Video {
     }
 
     _disablePreview () {
-        if (this._skinId) {
+        if (this._skinId !== -1) {
             this.runtime.renderer.updateBitmapSkin(this._skinId, new ImageData(...Video.DIMENSIONS), 1);
             this.runtime.renderer.updateDrawableProperties(this._drawable, {visible: false});
         }

--- a/src/io/video.js
+++ b/src/io/video.js
@@ -22,12 +22,6 @@ class Video {
         this._skinId = -1;
 
         /**
-         * The Scratch Renderer Skin object.
-         * @type {Skin}
-         */
-        this._skin = null;
-
-        /**
          * Id for a drawable using the video's skin that will render as a video
          * preview.
          * @type {Drawable}
@@ -141,8 +135,8 @@ class Video {
     }
 
     _disablePreview () {
-        if (this._skin) {
-            this._skin.clear();
+        if (this._skinId) {
+            this.runtime.renderer.updateBitmapSkin(this._skinId, new ImageData(...Video.DIMENSIONS), 1);
             this.runtime.renderer.updateDrawableProperties(this._drawable, {visible: false});
         }
         this._renderPreviewFrame = null;
@@ -152,9 +146,8 @@ class Video {
         const {renderer} = this.runtime;
         if (!renderer) return;
 
-        if (this._skinId === -1 && this._skin === null && this._drawable === -1) {
-            this._skinId = renderer.createPenSkin();
-            this._skin = renderer._allSkins[this._skinId];
+        if (this._skinId === -1 && this._drawable === -1) {
+            this._skinId = renderer.createBitmapSkin(new ImageData(...Video.DIMENSIONS), 1);
             this._drawable = renderer.createDrawable(StageLayering.VIDEO_LAYER);
             renderer.updateDrawableProperties(this._drawable, {
                 skinId: this._skinId
@@ -176,16 +169,17 @@ class Video {
 
                 this._renderPreviewTimeout = setTimeout(this._renderPreviewFrame, this.runtime.currentStepTime);
 
-                const canvas = this.getFrame({format: Video.FORMAT_CANVAS});
+                const imageData = this.getFrame({
+                    format: Video.FORMAT_IMAGE_DATA,
+                    cacheTimeout: this.runtime.currentStepTime
+                });
 
-                if (!canvas) {
-                    this._skin.clear();
+                if (!imageData) {
+                    renderer.updateBitmapSkin(this._skinId, new ImageData(...Video.DIMENSIONS), 1);
                     return;
                 }
 
-                const xOffset = Video.DIMENSIONS[0] / -2;
-                const yOffset = Video.DIMENSIONS[1] / 2;
-                this._skin.drawStamp(canvas, xOffset, yOffset);
+                renderer.updateBitmapSkin(this._skinId, imageData, 1);
                 this.runtime.requestRedraw();
             };
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves LLK/scratch-gui#4888

### Proposed Changes

_Describe what this Pull Request does_

Use the BitmapSkin type for the video layer instead of the PenSkin, because the PenSkin cannot have the ghost effect applied to it due to using premultiplied alpha blending modes.

This is the solution I wanted to implement https://github.com/LLK/scratch-vm/pull/2291, but was concerned with the performance of silhouette updates. I was concerned that the bitmap skin was too slow to update because updating the silhouette required a slow canvas -> ImageData conversion. After more digging, it turns out, we are actually already doing that conversion in the video motion extension in a similarly timed loop, and so we can take advantage of the caching mechanism in the VideoProvider and request the cached ImageData. sometimes the extension loop freshens the cache, sometimes this preview updater loop does, but either way it only gets done once every 30ms, which is as good as we are going to get performance-wise since the extension requires ImageData for computation. 

So no fancy silhouette deferral is needed! Although i _did_ look into that also... we can talk about framebuffers later... @cwillisf 

### Reason for Changes

_Explain why these changes should be made_

We were using private APIs, and public APIs in unexpected ways, to get the result we wanted from the renderer. Now just use the public APIs in totally expected ways. :) 

### Test Coverage

_Please show how you have added tests to cover your changes_

To test manually, add the video extension and see how adjusting the transparency displays correct colors. Turning transparency up to 100 should make you completely disappear.


