### PR TITLE
Fix video sensing error with stale matrices

### DIFF
--- a/src/extensions/scratch3_video_sensing/library.js
+++ b/src/extensions/scratch3_video_sensing/library.js
@@ -289,6 +289,11 @@ class VideoMotion {
                 _curr: curr
             } = this;
 
+            // The public APIs for Renderer#isTouching manage keeping the matrix and
+            // silhouette up-to-date, which is needed for drawable#isTouching to work
+            drawable.updateMatrix();
+            if (drawable.skin) drawable.skin.updateSilhouette();
+
             // Restrict the region the amount and direction are built from to
             // the area of the current frame overlapped by the given drawable's
             // bounding box.

--- a/src/extensions/scratch3_video_sensing/library.js
+++ b/src/extensions/scratch3_video_sensing/library.js
@@ -290,7 +290,7 @@ class VideoMotion {
             } = this;
 
             // The public APIs for Renderer#isTouching manage keeping the matrix and
-            // silhouette up-to-date, which is needed for drawable#isTouching to work
+            // silhouette up-to-date, which is needed for drawable#isTouching to work (used below)
             drawable.updateMatrix();
             if (drawable.skin) drawable.skin.updateSilhouette();
 

--- a/test/unit/extension_video_sensing.js
+++ b/test/unit/extension_video_sensing.js
@@ -87,6 +87,8 @@ const isNearAngle = (actual, expect, optMargin = 10) => (
 // A fake scratch-render drawable that will be used by VideoMotion to restrain
 // the area considered for motion detection in VideoMotion.getLocalMotion
 const fakeDrawable = {
+    updateMatrix () {}, // no-op, since isTouching always returns true
+
     getFastBounds () {
         return {
             left: -120,


### PR DESCRIPTION


### Resolves

_What Github issue does this resolve (please include link)?_

An issue where video sensing on a sprite was broken. 

An alternative to https://github.com/LLK/scratch-render/pull/516
### Proposed Changes

_Describe what this Pull Request does_

https://github.com/LLK/scratch-render/pull/468 introduced a performance optimization that removed inverse matrix updating from `getFastBounds`. It was observed that everywhere that needed the inverse matrix was updating it as needed, but that was only true looking within the scratch-render repo. Video sensing was using that private API and depending on getFastBounds to update the inverse matrix, because it uses `drawable.isTouching`. 

Since the public APIs on the renderer manage updating the inverse matrix and also doing lazy silhouette updates, it doesn't seem to be the renderers fault. instead, just make those updates before using the dangerous private APIs on this side.

This seems like the classic result of using private APIs, and I'd really like to move away from it here, but that will take more work. 

/cc @mzgoddard 