### PR TITLE
Add power (exponentiation) operator

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -20,6 +20,7 @@ class Scratch3OperatorsBlocks {
             operator_subtract: this.subtract,
             operator_multiply: this.multiply,
             operator_divide: this.divide,
+            operator_power: this.power,
             operator_lt: this.lt,
             operator_equals: this.equals,
             operator_gt: this.gt,
@@ -52,6 +53,10 @@ class Scratch3OperatorsBlocks {
     divide (args) {
         return Cast.toNumber(args.NUM1) / Cast.toNumber(args.NUM2);
     }
+
+    power (args) {
+        return Math.pow(Cast.toNumber(args.NUM1), Cast.toNumber(args.NUM2));
+	}
 
     lt (args) {
         return Cast.compare(args.OPERAND1, args.OPERAND2) < 0;

--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -56,7 +56,7 @@ class Scratch3OperatorsBlocks {
 
     power (args) {
         return Math.pow(Cast.toNumber(args.NUM1), Cast.toNumber(args.NUM2));
-	}
+    }
 
     lt (args) {
         return Cast.compare(args.OPERAND1, args.OPERAND2) < 0;

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -1229,6 +1229,21 @@ const specMap = {
             }
         ]
     },
+    '^': {
+        opcode: 'operator_power',
+        argMap: [
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'NUM1'
+            },
+            {
+                type: 'input',
+                inputOp: 'math_number',
+                inputName: 'NUM2'
+            }
+        ]
+    },
     'randomFrom:to:': {
         opcode: 'operator_random',
         argMap: [

--- a/src/serialization/sb2_specmap.js
+++ b/src/serialization/sb2_specmap.js
@@ -1229,21 +1229,6 @@ const specMap = {
             }
         ]
     },
-    '^': {
-        opcode: 'operator_power',
-        argMap: [
-            {
-                type: 'input',
-                inputOp: 'math_number',
-                inputName: 'NUM1'
-            },
-            {
-                type: 'input',
-                inputOp: 'math_number',
-                inputName: 'NUM2'
-            }
-        ]
-    },
     'randomFrom:to:': {
         opcode: 'operator_random',
         argMap: [


### PR DESCRIPTION
### Proposed Changes

It adds power (exponentiation) operator to Scratch. It now supports an easy way to do exponentiations.

### Reason for Changes

Scratch does not support exponentiation. Although there are some ways to "simulate" it, they are very hard to do, especially for young users.

This was also requested a long time ago on [Scracth Forum](https://scratch.mit.edu/discuss/topic/70660/) and [Scratch Wiki](https://en.scratch-wiki.info/wiki/Solving_Exponents)

### Test Coverage

I didn't do any new "advanced" tests. I mostly copied things that are used for existing operator blocks to create a new block.

### Related PRs

Other PRs that are needed for this implementation are:

* LLK/scratch-vm#2296
* LLK/scratch-blocks#2007
* LLK/scratch-gui#5266
