### PR TITLE
Allow extension to force to BLE write without response as well as with response

### DIFF
--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -153,7 +153,7 @@ class BLE extends JSONRPC {
         if (encoding) {
             params.encoding = encoding;
         }
-        if (withResponse) {
+        if (withResponse !== null) {
             params.withResponse = withResponse;
         }
         return this.sendRemoteRequest('write', params)


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-link/issues/150

### Proposed Changes

* Avoid missing ```withResponse``` is ```false``` in BLE write parameter

### Reason for Changes

This PR allows extension to force to write without response as well as with response (#1471).
