### PR TITLE
Feature/lego boost support distance

### DIFF
--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -132,6 +132,16 @@ const BoostColorIndex = {
 };
 
 /**
+ * Enum for comparison-operator
+ * @type {{LESS: string, GREATER: string, EQUAL: string}}
+ */
+const BoostOperator = {
+    LESS: '<',
+    GREATER: '>',
+    EQUAL: '='
+};
+
+/**
  * Enum for Message Types
  * @readonly
  * @enum {number}
@@ -231,6 +241,7 @@ const BoostMode = {
     TILT: 0, // angle (pitch/yaw)
     LED: 1, // Set LED to accept RGB values
     COLOR: 0, // Read indexed colors from Vision Sensor
+    COLOR_DISTANCE: 8, // Read indexed colors from Vision Sensor and the distance
     MOTOR_SENSOR: 2, // Set motors to report their position
     UNKNOWN: 0 // Anything else will use the default mode (mode 0)
 };
@@ -645,7 +656,8 @@ class Boost {
             tiltX: 0,
             tiltY: 0,
             color: BoostColor.NONE,
-            previousColor: BoostColor.NONE
+            previousColor: BoostColor.NONE,
+            distance: null
         };
 
         /**
@@ -710,6 +722,15 @@ class Boost {
      */
     get previousColor () {
         return this._sensors.previousColor;
+    }
+
+    /**
+     *
+     * @returns {number} - the latest distance in float inches received from the vision sensor. Resolution is higher
+     * for closer distances.
+     */
+    get distance () {
+        return this._sensors.distance;
     }
 
     /**
@@ -832,7 +853,8 @@ class Boost {
             tiltX: 0,
             tiltY: 0,
             color: BoostColor.NONE,
-            previousColor: BoostColor.NONE
+            previousColor: BoostColor.NONE,
+            distance: null
         };
 
         if (this._ble) {
@@ -998,6 +1020,13 @@ class Boost {
                 } else {
                     this._sensors.color = BoostColor.NONE;
                 }
+                const distance = data[5];
+                const partialDistance = data[7];
+                let totalDistance = distance;
+                if (partialDistance > 0) {
+                    totalDistance = totalDistance + 1 / partialDistance;
+                }
+                this._sensors.distance = totalDistance;
                 break;
             case BoostIO.MOTOREXT:
             case BoostIO.MOTORINT:
@@ -1073,7 +1102,7 @@ class Boost {
             mode = BoostMode.MOTOR_SENSOR;
             break;
         case BoostIO.COLOR:
-            mode = BoostMode.COLOR;
+            mode = BoostMode.COLOR_DISTANCE;
             delta = 0;
             break;
         case BoostIO.LED:
@@ -1114,6 +1143,7 @@ class Boost {
         }
         if (type === BoostIO.COLOR) {
             this._sensors.color = BoostColor.NONE;
+            this._sensors.distance = null;
         }
         this._ports[portID] = 'none';
         this._motors[portID] = null;
@@ -1364,6 +1394,35 @@ class Scratch3BoostBlocks {
                     }
                 },
                 {
+                    opcode: 'whenDistance',
+                    text: formatMessage({
+                        id: 'boost.whenDistance',
+                        default: 'when distance [OPERATOR] [THRESHOLD]',
+                        description: 'when distance fulfils the given condition'
+                    }),
+                    blockType: BlockType.HAT,
+                    arguments: {
+                        OPERATOR: {
+                            type: ArgumentType.STRING,
+                            menu: 'OPERATOR',
+                            defaultValue: BoostOperator.LESS
+                        },
+                        THRESHOLD: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: 5
+                        }
+                    }
+                },
+                {
+                    opcode: 'getDistance',
+                    text: formatMessage({
+                        id: 'boost.getDistance',
+                        default: 'distance',
+                        description: 'the distance returned by the vision sensor'
+                    }),
+                    blockType: BlockType.REPORTER,
+                },
+                {
                     opcode: 'whenTilted',
                     text: formatMessage({
                         id: 'boost.whenTilted',
@@ -1612,6 +1671,20 @@ class Scratch3BoostBlocks {
                         }),
                         value: BoostColor.ANY
                     }
+                ],
+                OPERATOR: [
+                    {
+                        text: BoostOperator.LESS,
+                        value: BoostOperator.LESS
+                    },
+                    {
+                        text: BoostOperator.GREATER,
+                        value: BoostOperator.GREATER
+                    },
+                    {
+                        text: BoostOperator.EQUAL,
+                        value: BoostOperator.EQUAL
+                    },
                 ]
             }
         };
@@ -1971,6 +2044,38 @@ class Scratch3BoostBlocks {
         }
 
         return args.COLOR === this._peripheral.color;
+    }
+
+    /**
+     * Edge-triggering hat function, for when the vision sensor is detecting a distance (in float inches)
+     * for the given condition.
+     * @param {object} args - the block's arguments
+     * @return {boolean} - true when the distance fulfils the condition, false otherwise.
+     */
+    whenDistance (args) {
+        const threshold = Cast.toNumber(args.THRESHOLD);
+
+        if (this._peripheral.distance === null) {
+            return false;
+        } else if (args.OPERATOR === BoostOperator.LESS) {
+            return this._peripheral.distance < threshold;
+        } else if (args.OPERATOR === BoostOperator.GREATER) {
+            return this._peripheral.distance > threshold;
+        } else if (args.OPERATOR === BoostOperator.EQUAL) {
+            return this._peripheral.distance === threshold;
+        } else {
+            // should never reach here
+            return false;
+        }
+    }
+
+
+    /**
+     *
+     * @returns {number} the distance (in float inches)
+     */
+    getDistance () {
+        return this._peripheral.distance;
     }
 
     /**

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1095,7 +1095,7 @@ class Boost {
                 this._sensors.tiltX = data[4];
                 this._sensors.tiltY = data[5];
                 break;
-            case BoostIO.COLOR:
+            case BoostIO.COLOR: {
                 this._colorSamples.unshift(data[4]);
                 if (this._colorSamples.length > BoostColorSampleSize) {
                     this._colorSamples.pop();
@@ -1112,10 +1112,11 @@ class Boost {
                 const partialDistance = data[7];
                 let totalDistance = distance;
                 if (partialDistance > 0) {
-                    totalDistance = totalDistance + 1 / partialDistance;
+                    totalDistance = totalDistance + (1 / partialDistance);
                 }
                 this._sensors.distance = totalDistance;
                 break;
+            }
             case BoostIO.MOTOREXT:
             case BoostIO.MOTORINT:
                 this.motor(portID).position = int32ArrayToNumber(data.slice(4, 8));
@@ -1509,7 +1510,7 @@ class Scratch3BoostBlocks {
                         default: 'distance',
                         description: 'the distance returned by the vision sensor'
                     }),
-                    blockType: BlockType.REPORTER,
+                    blockType: BlockType.REPORTER
                 },
                 {
                     opcode: 'whenTilted',
@@ -1794,7 +1795,7 @@ class Scratch3BoostBlocks {
                     {
                         text: BoostOperator.EQUAL,
                         value: BoostOperator.EQUAL
-                    },
+                    }
                 ]
             }
         };
@@ -2173,9 +2174,6 @@ class Scratch3BoostBlocks {
             return this._peripheral.distance > threshold;
         } else if (args.OPERATOR === BoostOperator.EQUAL) {
             return this._peripheral.distance === threshold;
-        } else {
-            // should never reach here
-            return false;
         }
     }
 

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1783,20 +1783,23 @@ class Scratch3BoostBlocks {
                         }
                     ]
                 },
-                OPERATOR: [
-                    {
-                        text: BoostOperator.LESS,
-                        value: BoostOperator.LESS
-                    },
-                    {
-                        text: BoostOperator.GREATER,
-                        value: BoostOperator.GREATER
-                    },
-                    {
-                        text: BoostOperator.EQUAL,
-                        value: BoostOperator.EQUAL
-                    }
-                ]
+                OPERATOR: {
+                    acceptReporters: true,
+                    items: [
+                        {
+                            text: BoostOperator.LESS,
+                            value: BoostOperator.LESS
+                        },
+                        {
+                            text: BoostOperator.GREATER,
+                            value: BoostOperator.GREATER
+                        },
+                        {
+                            text: BoostOperator.EQUAL,
+                            value: BoostOperator.EQUAL
+                        }
+                    ]
+                },
             }
         };
     }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1799,7 +1799,7 @@ class Scratch3BoostBlocks {
                             value: BoostOperator.EQUAL
                         }
                     ]
-                },
+                }
             }
         };
     }

--- a/src/extensions/scratch3_boost/index.js
+++ b/src/extensions/scratch3_boost/index.js
@@ -1007,7 +1007,7 @@ class Boost {
                 this._sensors.tiltX = data[4];
                 this._sensors.tiltY = data[5];
                 break;
-            case BoostIO.COLOR:
+            case BoostIO.COLOR: {
                 this._colorSamples.unshift(data[4]);
                 if (this._colorSamples.length > BoostColorSampleSize) {
                     this._colorSamples.pop();
@@ -1024,10 +1024,11 @@ class Boost {
                 const partialDistance = data[7];
                 let totalDistance = distance;
                 if (partialDistance > 0) {
-                    totalDistance = totalDistance + 1 / partialDistance;
+                    totalDistance = totalDistance + (1 / partialDistance);
                 }
                 this._sensors.distance = totalDistance;
                 break;
+            }
             case BoostIO.MOTOREXT:
             case BoostIO.MOTORINT:
                 this.motor(portID).position = int32ArrayToNumber(data.slice(4, 8));
@@ -1420,7 +1421,7 @@ class Scratch3BoostBlocks {
                         default: 'distance',
                         description: 'the distance returned by the vision sensor'
                     }),
-                    blockType: BlockType.REPORTER,
+                    blockType: BlockType.REPORTER
                 },
                 {
                     opcode: 'whenTilted',
@@ -1684,7 +1685,7 @@ class Scratch3BoostBlocks {
                     {
                         text: BoostOperator.EQUAL,
                         value: BoostOperator.EQUAL
-                    },
+                    }
                 ]
             }
         };
@@ -2063,9 +2064,6 @@ class Scratch3BoostBlocks {
             return this._peripheral.distance > threshold;
         } else if (args.OPERATOR === BoostOperator.EQUAL) {
             return this._peripheral.distance === threshold;
-        } else {
-            // should never reach here
-            return false;
         }
     }
 


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/2210


### Proposed Changes

The LegoBoost-vision-sensor reports the distance (how far is the sensor away from any obstacle).
This PR adds support to the LegoBoost-Extension to read the distance-sensor-value from the MoveHub.

According to https://github.com/JorgePe/BOOSTreveng/blob/master/ColorDistanceSensor.md the color-sensor can be put into a "color and distance (0x08)" mode, where not only the color is reported but also the distance.

This PR adds two new blocks for the LegoBoost-Extension:

whenDistance - BlockType.HAT with a menu for the "<, >, =" operators
getDistance - BlockType.REPORTER - reports the distance as a float.
the resolution is higher for closer distances

### Reason for Changes

Having a possibility to get the distance-sensor-value from the MoveHub, greatly improves the possibilities what can be done with LegoBoost and Scratch.
Eg:

Stop a robot (or drive into another direction) before he hits a wall or some other obstacle -> we can write some Scratch-programs for autonomous navigation.

Count objects passing (slowly) the distance-sensor

### Test Coverage

There's no test-automation for LegoBoost-Extension. I tested manually in this environments:
Ubuntu 18.04.2 LTS
Browsers: Chrome, Firefox
ScratchLink running on Windows

Windows 10 Pro
Browsers: Chrome, Edge

macOS Mojave 10.14.5
Browsers: Safari, Chrome

See the attached SB3-file for the test-program, which does the following:

Play a sound (in a forever-loop) when distance-reporter detects a distance < 4
Play an alarm-sound whenDistance (HAT-block) equals 5
Show a message when the vision-sensor detects the color "green" -> regression-test for the existing color-feature.
[LegoBoost-Distance-Test.zip](https://github.com/LLK/scratch-vm/files/3816978/LegoBoost-Distance-Test.zip)
