### PR TITLE
Don't stamp when isStage

### DIFF
--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -505,6 +505,7 @@ class Scratch3PenBlocks {
         const penSkinId = this._getPenLayerID();
         if (penSkinId >= 0) {
             const target = util.target;
+            if (target.isStage) return; // stages can't stamp
             this.runtime.renderer.penStamp(penSkinId, target.drawableID);
             this.runtime.requestRedraw();
         }


### PR DESCRIPTION
### Resolves
Fixes #2297 

### Proposed Changes
Don't stamp when `target.isStage` is true

### Reason for Changes
Stage should do nothing for stamp block.
