### PR TITLE
Replace backspace control characters with U+FFFD

### DIFF
--- a/src/util/string-util.js
+++ b/src/util/string-util.js
@@ -79,13 +79,17 @@ class StringUtil {
                 return unsafe;
             }
         }
-        return unsafe.replace(/[<>&'"]/g, c => {
+
+        // eslint-disable-next-line no-control-regex
+        return unsafe.replace(/[<>&'"\u0008]/g, c => {
             switch (c) {
             case '<': return 'lt';
             case '>': return 'gt';
             case '&': return 'amp';
             case '\'': return 'apos';
             case '"': return 'quot';
+            // This is the ASCII backspace control character. XML parsers don't like it very much.
+            case '\u0008': return '';
             }
         });
     }

--- a/src/util/xml-escape.js
+++ b/src/util/xml-escape.js
@@ -19,13 +19,19 @@ const xmlEscape = function (unsafe) {
             return unsafe;
         }
     }
-    return unsafe.replace(/[<>&'"]/g, c => {
+
+    // eslint-disable-next-line no-control-regex
+    return unsafe.replace(/[<>&'"\u0008]/g, c => {
         switch (c) {
         case '<': return '&lt;';
         case '>': return '&gt;';
         case '&': return '&amp;';
         case '\'': return '&apos;';
         case '"': return '&quot;';
+        // This is the ASCII backspace character, producable by the macOS Japanese IME, which XML parsers choke on.
+        // Replace it with U+FFFD 'REPLACEMENT CHARACTER', which means "this replaced an unrepresentable character".
+        // Note that if this string is then edited in Blockly (e.g. in a text field), the U+FFFD will become permanent.
+        case '\u0008': return '&#xFFFD;';
         }
     });
 };


### PR DESCRIPTION
### Resolves

Resolves #1873
Resolves https://github.com/LLK/scratch-parser/issues/58

### Proposed Changes

This PR changes the `xmlEscape` method to replace the backspace control character (`U+0008`) with [`U+FFFD REPLACEMENT CHARACTER`](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character).

It also changes `replaceUnsafeChars` to remove it entirely, which is okay since that function is used for internal IDs and not user-facing strings.

### Reason for Changes

This should more robustly fix backspace characters causing XML parsing to fail, and thus scripts to disappear, by replacing them when they're passed into XML.

This should allow scratch-parser to be less zealous in stripping backspace characters. It should now only have to replace raw backspace characters to make JSON strings parseable, as opposed to also replacing escaped backspace characters inside JSON string entities. This should make https://github.com/LLK/scratch-parser/issues/56 fixable.

One online source claims some XML parsers have trouble with `U+FFFD` itself, but I've tested this on Edge, Chromium, and Firefox and they all parse it just fine. I haven't tried Safari because I don't have any macOS devices. You can try it out on [this project](https://scratch.mit.edu/projects/345679267).

Note that if the affected strings are modified on the Blockly side (e.g. a text field, with an affected character, is typed into), the `U+FFFD` characters will be permanent (there's no "converting back"). This may be an issue with identifier names being mangled, but I'm not sure how the VM works with regards to that.

This technique could also be used to strip out other control characters that could potentially cause XML parsing failures, but I decided not to go that far yet.

### Test Coverage

None yet.
