### PR TITLE
EV3 populate distance from either IR or UltraSonic sensor.

### DIFF
--- a/src/extensions/scratch3_ev3/index.js
+++ b/src/extensions/scratch3_ev3/index.js
@@ -111,6 +111,7 @@ const Ev3Device = {
     29: 'color',
     30: 'ultrasonic',
     32: 'gyro',
+    33: 'ir',
     16: 'touch',
     8: 'mediumMotor',
     7: 'largeMotor',
@@ -129,6 +130,7 @@ const Ev3Mode = {
     touch: 0, // touch
     color: 1, // ambient
     ultrasonic: 1, // inch
+    ir: 0, // proximity
     none: 0
 };
 
@@ -140,7 +142,8 @@ const Ev3Mode = {
 const Ev3Label = {
     touch: 'button',
     color: 'brightness',
-    ultrasonic: 'distance'
+    ultrasonic: 'distance',
+    ir: 'distance'
 };
 
 /**


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-vm/issues/1445

### Proposed Changes
In the EV3 Scratch extension, allow the distance to be populated from an IR sensor if installed.

### Reason for Changes
This is useful since the EV3 commercial kit (Lego 31313) contains only an IR sensor for distance sensing whereas educational kits (Lego 45544) contains the already supported UltraSonic sensor. This allows those with the commercial kit to use all Scratch EV3 features.

### Note
The range of values from the IR sensor matches what comes from the UltraSonic sensor, but the units are different. The UltraSonic returns values between 0 and 100 inches (the extension hard-codes it to inches mode), and the IR sensor returns "proximity" in the range of 0 to 100%, where 100% corresponds to "approximately 50-70cm". This is no different from how the sensors report in native EV3 programming.
