### PR TITLE
touching mouse-pointer returns false when outside stage

### DIFF
--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -59,19 +59,13 @@ class Mouse {
     postData (data) {
         if (data.x) {
             this._clientX = data.x;
-            this._scratchX = Math.round(MathUtil.clamp(
-                480 * ((data.x / data.canvasWidth) - 0.5),
-                -240,
-                240
-            ));
+            this._rawScratchX = 480 * ((data.x / data.canvasWidth) - 0.5);
+            this._scratchX = Math.round(MathUtil.clamp(this._rawScratchX, -240, 240));
         }
         if (data.y) {
             this._clientY = data.y;
-            this._scratchY = Math.round(MathUtil.clamp(
-                -360 * ((data.y / data.canvasHeight) - 0.5),
-                -180,
-                180
-            ));
+            this._rawScratchY = -360 * ((data.y / data.canvasHeight) - 0.5);
+            this._scratchY = Math.round(MathUtil.clamp(this._rawScratchY, -180, 180));
         }
         if (typeof data.isDown !== 'undefined') {
             const previousDownState = this._isDown;
@@ -131,6 +125,19 @@ class Mouse {
      */
     getScratchY () {
         return this._scratchY;
+    }
+
+    /**
+     * Check if the mouse is outside the stage.
+     * @return {boolean} Is the mouse outside the stage?
+     */
+    getIsOutside () {
+        return !(
+            this._rawScratchX >= -240 &&
+            this._rawScratchX <= 240 &&
+            this._rawScratchY >= -180 &&
+            this._rawScratchY <= 180
+        );
     }
 
     /**

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -777,6 +777,7 @@ class RenderedTarget extends Target {
     isTouchingObject (requestedObject) {
         if (requestedObject === '_mouse_') {
             if (!this.runtime.ioDevices.mouse) return false;
+            if (this.runtime.ioDevices.mouse.getIsOutside()) return false;
             const mouseX = this.runtime.ioDevices.mouse.getClientX();
             const mouseY = this.runtime.ioDevices.mouse.getClientY();
             return this.isTouchingPoint(mouseX, mouseY);

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -295,6 +295,20 @@ test('isTouchingObjectOutsideStage', t => {
     t.end();
 });
 
+test('isTouchingMouse', t => {
+    const r = new Runtime();
+    const s = new Sprite(null, r);
+    const renderer = new FakeRenderer();
+    r.attachRenderer(renderer);
+    const a = new RenderedTarget(s, r);
+    a.renderer = renderer;
+    r.ioDevices.mouse.postData({
+        x: 0,
+        y: 0
+    });
+    t.equals(a.isTouchingObject('__mouse__'), true);
+    t.end();
+});
 
 test('isTouchingEdge', t => {
     const r = new Runtime();

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -291,7 +291,7 @@ test('isTouchingObjectOutsideStage', t => {
         x: 1000,
         y: -300
     });
-    t.equals(a.isTouchingObject('__mouse__'), false);
+    t.equals(a.isTouchingObject('_mouse_'), false);
     t.end();
 });
 
@@ -309,7 +309,7 @@ test('isTouchingMouse', t => {
         x: 240,
         y: 180
     });
-    t.equals(a.isTouchingObject('__mouse__'), true);
+    t.equals(a.isTouchingObject('_mouse_'), true);
     t.end();
 });
 

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -280,6 +280,22 @@ test('isTouchingPoint', t => {
     t.end();
 });
 
+test('isTouchingObjectOutsideStage', t => {
+    const r = new Runtime();
+    const s = new Sprite(null, r);
+    const renderer = new FakeRenderer();
+    r.attachRenderer(renderer);
+    const a = new RenderedTarget(s, r);
+    a.renderer = renderer;
+    r.ioDevices.mouse.postData({
+        x: 1000,
+        y: -300
+    });
+    t.equals(a.isTouchingObject('__mouse__'), false);
+    t.end();
+});
+
+
 test('isTouchingEdge', t => {
     const r = new Runtime();
     const s = new Sprite(null, r);

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -302,9 +302,12 @@ test('isTouchingMouse', t => {
     r.attachRenderer(renderer);
     const a = new RenderedTarget(s, r);
     a.renderer = renderer;
+    // (0, 0) is the top left, and (canvasWidth, canvasHeight) is the bottom right
     r.ioDevices.mouse.postData({
-        x: 0,
-        y: 0
+        canvasHeight: 360,
+        canvasWidth: 480,
+        x: 240,
+        y: 180
     });
     t.equals(a.isTouchingObject('__mouse__'), true);
     t.end();


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-gui#5243

### Proposed Changes
Adds `getIsOutside` function in io/mouse and uses it inside rendered-target `isTouchingObject`. If the param is `__mouse__` and getIsOutside is true, it returns false.

### Reason for Changes
See LLK/scratch-gui#5243

### Test Coverage
Added one test.
