### PR TITLE
Remove calls to updateDrawableSkinIdRotationCenter

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -212,7 +212,7 @@ const loadBitmap_ = function (costume, runtime, _rotationCenter) {
             return fetched;
         })
         .then(({canvas, mergeCanvas, rotationCenter}) => {
-            // createBitmapSkin does the right thing if costume.rotationCenter are undefined.
+            // createBitmapSkin does the right thing if costume.rotationCenter is undefined.
             // That will be the case if you upload a bitmap asset or create one by taking a photo.
             let center;
             if (rotationCenter) {

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -212,8 +212,17 @@ const loadBitmap_ = function (costume, runtime, _rotationCenter) {
             return fetched;
         })
         .then(({canvas, mergeCanvas, rotationCenter}) => {
-            // createBitmapSkin does the right thing if costume.bitmapResolution or rotationCenter are undefined...
-            costume.skinId = runtime.renderer.createBitmapSkin(canvas, costume.bitmapResolution, rotationCenter);
+            // createBitmapSkin does the right thing if costume.bitmapResolution is undefined...
+            // TODO: is rotationCenter ever undefined?
+            let center;
+            if (rotationCenter) {
+                center = [
+                    rotationCenter[0] / 2,
+                    rotationCenter[1] / 2
+                ];
+            }
+
+            costume.skinId = runtime.renderer.createBitmapSkin(canvas, costume.bitmapResolution, center);
             canvasPool.release(mergeCanvas);
             const renderSize = runtime.renderer.getSkinSize(costume.skinId);
             costume.size = [renderSize[0] * 2, renderSize[1] * 2]; // Actual size, since all bitmaps are resolution 2

--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -212,16 +212,20 @@ const loadBitmap_ = function (costume, runtime, _rotationCenter) {
             return fetched;
         })
         .then(({canvas, mergeCanvas, rotationCenter}) => {
-            // createBitmapSkin does the right thing if costume.bitmapResolution is undefined...
-            // TODO: is rotationCenter ever undefined?
+            // createBitmapSkin does the right thing if costume.rotationCenter are undefined.
+            // That will be the case if you upload a bitmap asset or create one by taking a photo.
             let center;
             if (rotationCenter) {
+                // fetchBitmapCanvas will ensure that the costume's bitmap resolution is 2 and its rotation center is
+                // scaled to match, so it's okay to always divide by 2.
                 center = [
                     rotationCenter[0] / 2,
                     rotationCenter[1] / 2
                 ];
             }
 
+            // TODO: costume.bitmapResolution will always be 2 at this point because of fetchBitmapCanvas_, so we don't
+            // need to pass it in here.
             costume.skinId = runtime.renderer.createBitmapSkin(canvas, costume.bitmapResolution, center);
             canvasPool.release(mergeCanvas);
             const renderSize = runtime.renderer.getSkinSize(costume.skinId);

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -458,19 +458,7 @@ class RenderedTarget extends Target {
         );
         if (this.renderer) {
             const costume = this.getCostumes()[this.currentCostume];
-            if (
-                typeof costume.rotationCenterX !== 'undefined' &&
-                typeof costume.rotationCenterY !== 'undefined'
-            ) {
-                const scale = costume.bitmapResolution || 2;
-                const rotationCenter = [
-                    costume.rotationCenterX / scale,
-                    costume.rotationCenterY / scale
-                ];
-                this.renderer.updateDrawableSkinIdRotationCenter(this.drawableID, costume.skinId, rotationCenter);
-            } else {
-                this.renderer.updateDrawableSkinId(this.drawableID, costume.skinId);
-            }
+            this.renderer.updateDrawableSkinId(this.drawableID, costume.skinId);
 
             if (this.visible) {
                 this.emit(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this);
@@ -709,11 +697,7 @@ class RenderedTarget extends Target {
             this.renderer.updateDrawableVisible(this.drawableID, this.visible);
 
             const costume = this.getCostumes()[this.currentCostume];
-            const bitmapResolution = costume.bitmapResolution || 2;
-            this.renderer.updateDrawableSkinIdRotationCenter(this.drawableID, costume.skinId, [
-                costume.rotationCenterX / bitmapResolution,
-                costume.rotationCenterY / bitmapResolution
-            ]);
+            this.renderer.updateDrawableSkinId(this.drawableID, costume.skinId);
 
             for (const effectName in this.effects) {
                 if (!this.effects.hasOwnProperty(effectName)) continue;

--- a/test/fixtures/fake-renderer.js
+++ b/test/fixtures/fake-renderer.js
@@ -17,9 +17,6 @@ FakeRenderer.prototype.getFencedPositionOfDrawable = function (d, p) { // eslint
 FakeRenderer.prototype.updateDrawableSkinId = function (d, skinId) { // eslint-disable-line no-unused-vars
 };
 
-FakeRenderer.prototype.updateDrawableSkinIdRotationCenter =
-    function (d, skinId, rotationCenter) {}; // eslint-disable-line no-unused-vars
-
 FakeRenderer.prototype.updateDrawablePosition = function (d, position) { // eslint-disable-line no-unused-vars
     this.x = position[0];
     this.y = position[1];


### PR DESCRIPTION
### Proposed Changes

This PR removes calls to `Renderer.updateDrawableSkinIdRotationCenter`, replacing them with calls to `Renderer.updateDrawableSkinId`.

It also fixes `loadBitmap_` to properly set bitmap costumes' rotation centers.

### Reason for Changes

Everywhere in the current codebase, updating a drawable's rotation center should do nothing.

It appears to be a vestige of the time when rotation centers belonged to `Drawable`s and not `Skin`s (the code to update drawables' rotation centers [was added Oct 9, 2016](https://github.com/LLK/scratch-vm/commit/9af9a87cb6d5dbc4d9408252f26d0b55650a396d), `Skin`s [were introduced Dec 28, 2016](https://github.com/LLK/scratch-render/commit/64c59914861a47162aee48a8e9f60854118617e8)).

Fixing a long-standing bug with vector costumes in `scratch-render` (see https://github.com/LLK/scratch-render/issues/550 for a detailed writeup) involves changes to the way vector costumes' rotation centers are set; notably, changing the rotation center requires re-loading the SVG. Supporting the ability to set a skin's rotation center after it is created makes the required `scratch-render` fix much harder to implement.

Furthermore, since the functionality to set a `Drawable`'s rotation center is currently effectively unused, changing the parts of `scratch-render` that involve rotation centers could break it unknowingly, causing future headaches if others try to use the API.

Finally, as I mentioned earlier, rotation centers now belong to `Skin`s (which correspond to costumes), so it doesn't make sense to consider them a "`Drawable` property".

There was one case in which updating a costume's rotation center actually did something: when first loading a bitmap, the costume rotation center was not divided by 2. The call to `updateDrawableSkinIdRotationCenter` when setting a target's costume, which did properly set the rotation center for bitmap costumes, hid this oversight.