### PR TITLE
Use newName argument when renaming list

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -331,9 +331,13 @@ class Target extends EventEmitter {
                     }, this.runtime);
                     const monitorBlock = blocks.getBlock(variable.id);
                     if (monitorBlock) {
+                        const params = blocks._getBlockParams(monitorBlock);
+                        // _getBlockParams will return old name when the variable type is list.
+                        // Patch it so that the new name is passed.
+                        if (params.hasOwnProperty('LIST') && params.LIST !== newName) params.LIST = newName;
                         this.runtime.requestUpdateMonitor(Map({
                             id: id,
-                            params: blocks._getBlockParams(monitorBlock)
+                            params
                         }));
                     }
                 }


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-gui#4098
Resolves LLK/scratch-gui#5256
Resolves LLK/scratch-blocks#1415

### Proposed Changes
In renameVariable function (in engine/target.js), if the params from `blocks._getBlockParams` has LIST item and it is different from the `newName` argument, it will use the `newName` argument. `blocks._getBlockParams` makes a new object every time it is called, so pollution (if any) should not be a problem.

### Reason for Changes
The previous code caused the monitor data passed to GUI to have old name, so the list monitor kept the old name. This bug is well-known and several topics have been made on BaG forums.

### Test Coverage
Manually tested:
1) Renaming normal variable should change the name on the monitor
2) Renaming list should change the name on the monitor
