### PR TITLE
Use correct name in changeBlock in renameVariable

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -326,7 +326,7 @@ class Target extends EventEmitter {
                     blocks.changeBlock({
                         id: id,
                         element: 'field',
-                        name: 'VARIABLE',
+                        name: variable.type === 'list' ? 'LIST' : 'VARIABLE',
                         value: id
                     }, this.runtime);
                     const monitorBlock = blocks.getBlock(variable.id);


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-gui#4098
Resolves LLK/scratch-gui#5256
Resolves LLK/scratch-blocks#1415

### Proposed Changes
When the variable type is list, use `LIST` as the name of the field, not `VARIABLE`.

### Reason for Changes
The previous code caused the monitor data passed to GUI to have old name, so the list monitor kept the old name. This bug is well-known and several topics have been made on BaG forums.

### Test Coverage
Manually tested:
1) Renaming normal variable should change the name on the monitor
2) Renaming list should change the name on the monitor
