### PR TITLE
Remove remaining updateDrawableProperties calls

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -178,23 +178,21 @@ class Scratch3LooksBlocks {
             bubbleState.onSpriteRight = true;
             this._renderBubble(target);
         } else {
-            this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {
-                position: [
-                    bubbleState.onSpriteRight ? (
-                        Math.max(
-                            stageBounds.left, // Bubble should not extend past left edge of stage
-                            Math.min(stageBounds.right - bubbleWidth, targetBounds.right)
-                        )
-                    ) : (
-                        Math.min(
-                            stageBounds.right - bubbleWidth, // Bubble should not extend past right edge of stage
-                            Math.max(stageBounds.left, targetBounds.left - bubbleWidth)
-                        )
-                    ),
-                    // Bubble should not extend past the top of the stage
-                    Math.min(stageBounds.top, targetBounds.bottom + bubbleHeight)
-                ]
-            });
+            this.runtime.renderer.updateDrawablePosition(bubbleState.drawableId, [
+                bubbleState.onSpriteRight ? (
+                    Math.max(
+                        stageBounds.left, // Bubble should not extend past left edge of stage
+                        Math.min(stageBounds.right - bubbleWidth, targetBounds.right)
+                    )
+                ) : (
+                    Math.min(
+                        stageBounds.right - bubbleWidth, // Bubble should not extend past right edge of stage
+                        Math.max(stageBounds.left, targetBounds.left - bubbleWidth)
+                    )
+                ),
+                // Bubble should not extend past the top of the stage
+                Math.min(stageBounds.top, targetBounds.bottom + bubbleHeight)
+            ]);
             this.runtime.requestRedraw();
         }
     }
@@ -225,9 +223,7 @@ class Scratch3LooksBlocks {
             target.addListener(RenderedTarget.EVENT_TARGET_VISUAL_CHANGE, this._onTargetChanged);
             bubbleState.drawableId = this.runtime.renderer.createDrawable(StageLayering.SPRITE_LAYER);
             bubbleState.skinId = this.runtime.renderer.createTextSkin(type, text, bubbleState.onSpriteRight, [0, 0]);
-            this.runtime.renderer.updateDrawableProperties(bubbleState.drawableId, {
-                skinId: bubbleState.skinId
-            });
+            this.runtime.renderer.updateDrawableSkinId(bubbleState.drawableId, bubbleState.skinId);
         }
 
         this._positionBubble(target);

--- a/src/extensions/scratch3_pen/index.js
+++ b/src/extensions/scratch3_pen/index.js
@@ -132,7 +132,7 @@ class Scratch3PenBlocks {
         if (this._penSkinId < 0 && this.runtime.renderer) {
             this._penSkinId = this.runtime.renderer.createPenSkin();
             this._penDrawableId = this.runtime.renderer.createDrawable(StageLayering.PEN_LAYER);
-            this.runtime.renderer.updateDrawableProperties(this._penDrawableId, {skinId: this._penSkinId});
+            this.runtime.renderer.updateDrawableSkinId(this._penDrawableId, this._penSkinId);
         }
         return this._penSkinId;
     }

--- a/src/io/video.js
+++ b/src/io/video.js
@@ -128,16 +128,18 @@ class Video {
         this._ghost = ghost;
         // Confirm that the default value has been changed to a valid id for the drawable
         if (this._drawable !== -1) {
-            this.runtime.renderer.updateDrawableProperties(this._drawable, {
-                ghost: this._forceTransparentPreview ? 100 : ghost
-            });
+            this.runtime.renderer.updateDrawableEffect(
+                this._drawable,
+                'ghost',
+                this._forceTransparentPreview ? 100 : ghost
+            );
         }
     }
 
     _disablePreview () {
         if (this._skinId !== -1) {
             this.runtime.renderer.updateBitmapSkin(this._skinId, new ImageData(...Video.DIMENSIONS), 1);
-            this.runtime.renderer.updateDrawableProperties(this._drawable, {visible: false});
+            this.runtime.renderer.updateDrawableVisible(this._drawable, false);
         }
         this._renderPreviewFrame = null;
     }
@@ -149,17 +151,13 @@ class Video {
         if (this._skinId === -1 && this._drawable === -1) {
             this._skinId = renderer.createBitmapSkin(new ImageData(...Video.DIMENSIONS), 1);
             this._drawable = renderer.createDrawable(StageLayering.VIDEO_LAYER);
-            renderer.updateDrawableProperties(this._drawable, {
-                skinId: this._skinId
-            });
+            renderer.updateDrawableSkinId(this._drawable, this._skinId);
         }
 
         // if we haven't already created and started a preview frame render loop, do so
         if (!this._renderPreviewFrame) {
-            renderer.updateDrawableProperties(this._drawable, {
-                ghost: this._forceTransparentPreview ? 100 : this._ghost,
-                visible: true
-            });
+            renderer.updateDrawableEffect(this._drawable, 'ghost', this._forceTransparentPreview ? 100 : this._ghost);
+            renderer.updateDrawableVisible(this._drawable, true);
 
             this._renderPreviewFrame = () => {
                 clearTimeout(this._renderPreviewTimeout);

--- a/test/fixtures/fake-renderer.js
+++ b/test/fixtures/fake-renderer.js
@@ -34,10 +34,6 @@ FakeRenderer.prototype.updateDrawableVisible = function (d, visible) { // eslint
 FakeRenderer.prototype.updateDrawableEffect = function (d, effectName, value) { // eslint-disable-line no-unused-vars
 };
 
-FakeRenderer.prototype.updateDrawableProperties = function (d, p) { // eslint-disable-line no-unused-vars
-    throw new Error('updateDrawableProperties is deprecated');
-};
-
 FakeRenderer.prototype.getCurrentSkinSize = function (d) { // eslint-disable-line no-unused-vars
     return [0, 0];
 };


### PR DESCRIPTION
### Resolves

Resolves the rest of https://github.com/LLK/scratch-render/issues/364

### Proposed Changes

This PR builds on #2203 and removes the rest of the `updateDrawableProperties` calls from the VM codebase.

### Reason for Changes

As explained in https://github.com/LLK/scratch-render/pull/469, the new, more specific `updateDrawable` methods do less unnecessary work, possibly improving performance.

Since the old deprecated `updateDrawableProperties` method is now unused, this PR allows it to be fully removed from the renderer, reducing the API surface and cleaning up the codebase.
