### PR TITLE
Rename variables in sensing_of dropdown

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -915,6 +915,33 @@ class Blocks {
     }
 
     /**
+     * Update blocks after a variable gets renamed.
+     * Any block referring to the old name of the asset should get updated
+     * to refer to the new name.
+     * @param {string} oldName The old name of the asset that was renamed.
+     * @param {string} newName The new name of the asset that was renamed.
+     * @param {string} targetName The name of the target the variable belongs to.
+     */
+    updateVariableName (oldName, newName, targetName) {
+        const blocks = this._blocks;
+        for (const blockId in blocks) {
+            const block = this.getBlock(blockId);
+            if (block &&
+                block.fields.hasOwnProperty('PROPERTY') &&
+                block.opcode === 'sensing_of' &&
+                block.fields.PROPERTY.value === oldName &&
+                block.inputs.hasOwnProperty('OBJECT')) {
+                const menuFields = this.getBlock(block.inputs.OBJECT.shadow).fields;
+                if (
+                    menuFields.hasOwnProperty('OBJECT') &&
+                    menuFields.OBJECT.value === targetName) {
+                    block.fields.PROPERTY.value = newName;
+                }
+            }
+        }
+    }
+
+    /**
      * Update blocks after a sound, costume, or backdrop gets renamed.
      * Any block referring to the old name of the asset should get updated
      * to refer to the new name.

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -322,6 +322,12 @@ class Target extends EventEmitter {
                         this.runtime.ioDevices.cloud.requestRenameVariable(oldName, newName);
                     }
 
+                    if (variable.type === '') {
+                        this.runtime.targets.forEach(t => t.blocks.updateVariableName(
+                            oldName, newName, this.isStage ? '_stage_' : this.getName()));
+                        this.runtime.requestBlocksUpdate();
+                    }
+
                     const blocks = this.runtime.monitorBlocks;
                     blocks.changeBlock({
                         id: id,

--- a/test/unit/engine_blocks.js
+++ b/test/unit/engine_blocks.js
@@ -26,6 +26,7 @@ test('spec', t => {
     t.type(b.getBranch, 'function');
     t.type(b.getOpcode, 'function');
     t.type(b.mutationToXML, 'function');
+    t.type(b.updateVariableName, 'function');
 
     t.end();
 });
@@ -804,6 +805,108 @@ test('updateAssetName doesn\'t update name if name isn\'t being used', t => {
     t.equals(b.getBlock('id1').fields.BACKDROP.value, 'foo');
     b.updateAssetName('name1', 'name2', 'backdrop');
     t.equals(b.getBlock('id1').fields.BACKDROP.value, 'foo');
+    t.end();
+});
+
+test('updateVariableName renames variables in sensing_of block', t => {
+    const b = new Blocks(new Runtime());
+    b.createBlock({
+        id: 'id1',
+        opcode: 'sensing_of',
+        fields: {
+            PROPERTY: {
+                name: 'PROPERTY',
+                value: 'foo'
+            }
+        },
+        inputs: {
+            OBJECT: {
+                name: 'OBJECT',
+                block: 'id2',
+                shadow: 'id2'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id2',
+        fields: {
+            OBJECT: {
+                name: 'OBJECT',
+                value: '_stage_'
+            }
+        }
+    });
+    t.equals(b.getBlock('id1').fields.PROPERTY.value, 'foo');
+    b.updateVariableName('foo', 'bar', '_stage_');
+    t.equals(b.getBlock('id1').fields.PROPERTY.value, 'bar');
+    t.end();
+});
+
+test('updateVariableName doesn\'t rename if name is not being used', t => {
+    const b = new Blocks(new Runtime());
+    b.createBlock({
+        id: 'id1',
+        opcode: 'sensing_of',
+        fields: {
+            PROPERTY: {
+                name: 'PROPERTY',
+                value: 'foo'
+            }
+        },
+        inputs: {
+            OBJECT: {
+                name: 'OBJECT',
+                block: 'id2',
+                shadow: 'id2'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id2',
+        fields: {
+            OBJECT: {
+                name: 'OBJECT',
+                value: '_stage_'
+            }
+        }
+    });
+    t.equals(b.getBlock('id1').fields.PROPERTY.value, 'foo');
+    b.updateVariableName('meow', 'meow2', '_stage_');
+    t.equals(b.getBlock('id1').fields.PROPERTY.value, 'foo');
+    t.end();
+});
+
+test('updateVariableName doesn\'t rename other targets\' variables', t => {
+    const b = new Blocks(new Runtime());
+    b.createBlock({
+        id: 'id1',
+        opcode: 'sensing_of',
+        fields: {
+            PROPERTY: {
+                name: 'PROPERTY',
+                value: 'foo'
+            }
+        },
+        inputs: {
+            OBJECT: {
+                name: 'OBJECT',
+                block: 'id2',
+                shadow: 'id2'
+            }
+        }
+    });
+    b.createBlock({
+        id: 'id2',
+        fields: {
+            OBJECT: {
+                name: 'OBJECT',
+                value: '_stage_'
+            }
+        }
+    });
+    t.equals(b.getBlock('id1').fields.PROPERTY.value, 'foo');
+    b.updateVariableName('foo', 'bar', 'Cat');
+    t.equals(b.getBlock('id1').fields.PROPERTY.value, 'foo');
     t.end();
 });
 


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-gui#4392

### Proposed Changes
Adds a new function, `updateVariableName`, similiar to existing `updateAssetName`. This checks for every block that
1) has opcode `sensing_of`
2) has old name in PROPERTY
3) has the same OBJECT
and changes the property. 

### Reason for Changes
Variable blocks will change their variable name by itself, but sensing_of does not. This will make sensing_of blocks referencing the variable return 0 when they are renamed.

### Test Coverage
Added type test and 3 tests:
1) updateVariableName normal behavior
2) updateVariableName different variable
3) updateVariableName different target