### PR TITLE
WeDo 2.0 isTilted-any function bug fix

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1543,10 +1543,10 @@ class Scratch3WeDo2Blocks {
     _isTilted (direction) {
         switch (direction) {
         case WeDo2TiltDirection.ANY:
-            return (this._peripheral.tiltX > 45 ? 256 - this._peripheral.tiltX : this._peripheral.tiltX) >=
-                Scratch3WeDo2Blocks.TILT_THRESHOLD ||
-                (this._peripheral.tiltY > 45 ? 256 - this._peripheral.tiltY : this._peripheral.tiltY) >=
-                Scratch3WeDo2Blocks.TILT_THRESHOLD;
+            return this._getTiltAngle(WeDo2TiltDirection.UP) >= Scratch3WeDo2Blocks.TILT_THRESHOLD ||
+                this._getTiltAngle(WeDo2TiltDirection.DOWN) >= Scratch3WeDo2Blocks.TILT_THRESHOLD ||
+                this._getTiltAngle(WeDo2TiltDirection.LEFT) >= Scratch3WeDo2Blocks.TILT_THRESHOLD ||
+                this._getTiltAngle(WeDo2TiltDirection.RIGHT) >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
         default:
             return this._getTiltAngle(direction) >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
         }

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1543,8 +1543,10 @@ class Scratch3WeDo2Blocks {
     _isTilted (direction) {
         switch (direction) {
         case WeDo2TiltDirection.ANY:
-            return (this._peripheral.tiltX > 45 ? 256 - this._peripheral.tiltX : this._peripheral.tiltX) >= Scratch3WeDo2Blocks.TILT_THRESHOLD ||
-                (this._peripheral.tiltY > 45 ? 256 - this._peripheral.tiltY : this._peripheral.tiltY) >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
+            return (this._peripheral.tiltX > 45 ? 256 - this._peripheral.tiltX : this._peripheral.tiltX)
+                >= Scratch3WeDo2Blocks.TILT_THRESHOLD ||
+                (this._peripheral.tiltY > 45 ? 256 - this._peripheral.tiltY : this._peripheral.tiltY)
+                >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
         default:
             return this._getTiltAngle(direction) >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
         }

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1543,10 +1543,10 @@ class Scratch3WeDo2Blocks {
     _isTilted (direction) {
         switch (direction) {
         case WeDo2TiltDirection.ANY:
-            return (this._peripheral.tiltX > 45 ? 256 - this._peripheral.tiltX : this._peripheral.tiltX)
-                >= Scratch3WeDo2Blocks.TILT_THRESHOLD ||
-                (this._peripheral.tiltY > 45 ? 256 - this._peripheral.tiltY : this._peripheral.tiltY)
-                >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
+            return (this._peripheral.tiltX > 45 ? 256 - this._peripheral.tiltX : this._peripheral.tiltX) >=
+                Scratch3WeDo2Blocks.TILT_THRESHOLD ||
+                (this._peripheral.tiltY > 45 ? 256 - this._peripheral.tiltY : this._peripheral.tiltY) >=
+                Scratch3WeDo2Blocks.TILT_THRESHOLD;
         default:
             return this._getTiltAngle(direction) >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
         }

--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1543,8 +1543,8 @@ class Scratch3WeDo2Blocks {
     _isTilted (direction) {
         switch (direction) {
         case WeDo2TiltDirection.ANY:
-            return (Math.abs(this._peripheral.tiltX) >= Scratch3WeDo2Blocks.TILT_THRESHOLD) ||
-                (Math.abs(this._peripheral.tiltY) >= Scratch3WeDo2Blocks.TILT_THRESHOLD);
+            return (this._peripheral.tiltX > 45 ? 256 - this._peripheral.tiltX : this._peripheral.tiltX) >= Scratch3WeDo2Blocks.TILT_THRESHOLD ||
+                (this._peripheral.tiltY > 45 ? 256 - this._peripheral.tiltY : this._peripheral.tiltY) >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
         default:
             return this._getTiltAngle(direction) >= Scratch3WeDo2Blocks.TILT_THRESHOLD;
         }


### PR DESCRIPTION
### Resolves

Resolves #2334

### Proposed Changes

Adds the value conversion before the threshold comparison

### Reason for Changes

The values of tiltX and tiltY should not be compared with the threshold(TILT_THRESHOLD) directly.
Because the tiltX and tiltY have the value 255 for 1 degree tilt, 254 for 2 degrees tilt for example. Therefore, the value should be converted like (256 - tiltX) before the comparison.

### Test Coverage

Manually tested:
1. "when tilted any"-block is triggered only when the tilt angle is more than the threshold(TILT_THRESHOLD=15)
2. "tilted any ?"-block returns true only when the tilt angle is more than the threshold(TILT_THRESHOLD=15)