### PR TITLE
Revert reformat think and ask bubbles

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -253,7 +253,7 @@ class Scratch3LooksBlocks {
         if (text === '') return text;
 
         // Limit decimal precision to 2 digits.
-        if (typeof text === 'number' && Math.abs(text) >= .01) {
+        if (typeof text === 'number') {
             text = parseFloat(text.toFixed(2));
         }
 

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -234,26 +234,6 @@ class Scratch3LooksBlocks {
     }
 
     /**
-     * Properly format text for a text bubble.
-     * @param {string} text The text to be formatted
-     * @return {string} The formatted text
-     * @private
-     */
-    _formatBubbleText (text) {
-        if (text === '') return text;
-
-        // Limit decimal precision to 2 digits.
-        if (typeof text === 'number') {
-            text = parseFloat(text.toFixed(2));
-        }
-
-        // Limit the length of the string.
-        text = String(text).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT);
-
-        return text;
-    }
-
-    /**
      * The entry point for say/think blocks. Clears existing bubble if the text is empty.
      * Set the bubble custom state and then call _renderBubble.
      * @param {!Target} target Target that say/think blocks are being called on.
@@ -264,7 +244,7 @@ class Scratch3LooksBlocks {
     _updateBubble (target, type, text) {
         const bubbleState = this._getBubbleState(target);
         bubbleState.type = type;
-        bubbleState.text = this._formatBubbleText(text);
+        bubbleState.text = text;
         bubbleState.usageId = uid();
         this._renderBubble(target);
     }
@@ -320,7 +300,12 @@ class Scratch3LooksBlocks {
 
     say (args, util) {
         // @TODO in 2.0 calling say/think resets the right/left bias of the bubble
-        this.runtime.emit('SAY', util.target, 'say', args.MESSAGE);
+        let message = args.MESSAGE;
+        if (typeof message === 'number') {
+            message = parseFloat(message.toFixed(2));
+        }
+        message = String(message).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT);
+        this.runtime.emit('SAY', util.target, 'say', message);
     }
 
     sayforsecs (args, util) {
@@ -340,7 +325,7 @@ class Scratch3LooksBlocks {
     }
 
     think (args, util) {
-        this.runtime.emit('SAY', util.target, 'think', args.MESSAGE);
+        this._updateBubble(util.target, 'think', String(args.MESSAGE).substr(0, Scratch3LooksBlocks.SAY_BUBBLE_LIMIT));
     }
 
     thinkforsecs (args, util) {

--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -34,7 +34,7 @@ class Scratch3LooksBlocks {
         this.runtime.on('targetWasRemoved', this._onTargetWillExit);
 
         // Enable other blocks to use bubbles like ask/answer
-        this.runtime.on(Scratch3LooksBlocks.SAY_OR_THINK, this._updateBubble);
+        this.runtime.on('SAY', this._updateBubble);
     }
 
     /**
@@ -58,16 +58,6 @@ class Scratch3LooksBlocks {
      */
     static get STATE_KEY () {
         return 'Scratch.looks';
-    }
-
-    /**
-     * Event name for a text bubble being created or updated.
-     * @const {string}
-     */
-    static get SAY_OR_THINK () {
-        // There are currently many places in the codebase which explicitly refer to this event by the string 'SAY',
-        // so keep this as the string 'SAY' for now rather than changing it to 'SAY_OR_THINK' and breaking things.
-        return 'SAY';
     }
 
     /**
@@ -330,7 +320,7 @@ class Scratch3LooksBlocks {
 
     say (args, util) {
         // @TODO in 2.0 calling say/think resets the right/left bias of the bubble
-        this.runtime.emit(Scratch3LooksBlocks.SAY_OR_THINK, util.target, 'say', args.MESSAGE);
+        this.runtime.emit('SAY', util.target, 'say', args.MESSAGE);
     }
 
     sayforsecs (args, util) {
@@ -350,7 +340,7 @@ class Scratch3LooksBlocks {
     }
 
     think (args, util) {
-        this.runtime.emit(Scratch3LooksBlocks.SAY_OR_THINK, util.target, 'think', args.MESSAGE);
+        this.runtime.emit('SAY', util.target, 'think', args.MESSAGE);
     }
 
     thinkforsecs (args, util) {

--- a/test/unit/blocks_looks.js
+++ b/test/unit/blocks_looks.js
@@ -15,9 +15,7 @@ const util = {
                 {name: 'second name'},
                 {name: 'third name'}
             ]
-        },
-        _customState: {},
-        getCustomState: () => util.target._customState
+        }
     }
 };
 
@@ -204,15 +202,14 @@ test('numbers should be rounded to two decimals in say', t => {
     const args = {MESSAGE: 3.14159};
     const expectedSayString = '3.14';
 
-    rt.addListener('SAY', () => {
-        const bubbleState = util.target.getCustomState(Looks.STATE_KEY);
-        t.strictEqual(bubbleState.text, expectedSayString);
+    rt.removeAllListeners('SAY'); // Prevent say blocks from executing
+
+    rt.addListener('SAY', (target, type, sayString) => {
+        t.strictEqual(sayString, expectedSayString);
+        t.end();
     });
 
     looks.say(args, util);
-    looks.think(args, util);
-
-    t.end();
 });
 
 test('clamp graphic effects', t => {


### PR DESCRIPTION
Reverts https://github.com/LLK/scratch-vm/pull/2333
Reverts https://github.com/LLK/scratch-vm/pull/2187

The pull requests change the behavior of 3.0 think bubbles to be more like 2.0 think bubbles. However, some team members have brought up misgivings about whether 2.0 say and think bubbles' behavior of rounding to 2 decimal places was the best approach. Scratch is often used to teach math, and it could be detrimental to teachers if we begin rounding unexpectedly, especially in ask bubbles, which didn't have the rounding behavior in 2.0 (e.g., think(2 + .003 = 2)).

Sorry about the churn @adroitwhiz! We do hope to bring your commits in eventually, after we have had a chance to discuss exactly how much rounding would be best with our designers.