### PR TITLE
Clear some stats when disposing runtime

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -13,6 +13,8 @@ class Scratch3ControlBlocks {
          * @type {number}
          */
         this._counter = 0;
+
+        this.runtime.on('RUNTIME_DISPOSED', this.clearCounter.bind(this));
     }
 
     /**

--- a/src/blocks/scratch3_sensing.js
+++ b/src/blocks/scratch3_sensing.js
@@ -44,6 +44,7 @@ class Scratch3SensingBlocks {
         this.runtime.on('PROJECT_START', this._resetAnswer.bind(this));
         this.runtime.on('PROJECT_STOP_ALL', this._clearAllQuestions.bind(this));
         this.runtime.on('STOP_FOR_TARGET', this._clearTargetQuestions.bind(this));
+        this.runtime.on('RUNTIME_DISPOSED', this._resetAnswer.bind(this));
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1835,6 +1835,7 @@ class Runtime extends EventEmitter {
         this.targets.map(this.disposeTarget, this);
         this._monitorState = OrderedMap({});
         this.emit(Runtime.RUNTIME_DISPOSED);
+        this.ioDevices.clock.resetProjectTimer();
         // @todo clear out extensions? turboMode? etc.
 
         // *********** Cloud *******************

--- a/test/unit/blocks_sensing.js
+++ b/test/unit/blocks_sensing.js
@@ -153,6 +153,23 @@ test('ask and answer with a visible target', t => {
     s.askAndWait({QUESTION: expectedQuestion}, util);
 });
 
+test('answer gets reset when runtime is disposed', t => {
+    const rt = new Runtime();
+    const s = new Sensing(rt);
+    const util = {target: {visible: false}};
+    const expectedAnswer = 'the answer';
+
+    rt.addListener('QUESTION', () => rt.emit('ANSWER', expectedAnswer));
+    const promise = s.askAndWait({QUESTION: ''}, util);
+
+    promise.then(() => t.strictEqual(s.getAnswer(), expectedAnswer))
+        .then(() => rt.dispose())
+        .then(() => {
+            t.strictEqual(s.getAnswer(), '');
+            t.end();
+        });
+});
+
 test('set drag mode', t => {
     const runtime = new Runtime();
     runtime.requestTargetsUpdate = () => {}; // noop for testing


### PR DESCRIPTION
### Resolves
Resolves #2340
Resolves #2346
Resolves #2347

### Proposed Changes
Answer, counter and timer gets cleared when runtime is disposed.

### Reason for Changes
Previous behavior (answer does not get cleared when runtime is disposed, but gets cleared when green flag is pressed) did not make sense. Also, this matches Scratch 1.4 behavior.

### Test Coverage
Added 1 test
