### PR TITLE
Stop all sounds in the sound bank in stopAllSounds

### DIFF
--- a/src/blocks/scratch3_sound.js
+++ b/src/blocks/scratch3_sound.js
@@ -229,8 +229,19 @@ class Scratch3SoundBlocks {
     stopAllSounds () {
         if (this.runtime.targets === null) return;
         const allTargets = this.runtime.targets;
-        for (let i = 0; i < allTargets.length; i++) {
-            this._stopAllSoundsForTarget(allTargets[i]);
+        for (const target of allTargets) {
+            if (target.sprite.soundBank) {
+                // stopAllSounds default to ALL_TARGETS.
+                // This function is supposed to stop all sounds, so it should be fine.
+                // Because of some weird clone handlings, SoundBank.playerTargets can
+                // contain targets that are no longer in runtime.targets.
+                // For this reason, passing targets to stopAllSounds is unreliable,
+                // so _stopAllSoundsForTarget is not used.
+                target.sprite.soundBank.stopAllSounds();
+                if (this.waitingSounds[target.id]) {
+                    this.waitingSounds[target.id].clear();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Resolves
Resolves #2320
### Proposed Changes
`stopAllSounds` no longer uses `_stopAllSoundsForTarget`, instead it stops all sounds in the soundBank (by passing no arguments to SoundBank.stopAllSounds).

### Reason for Changes
Because of some weird clone handlings, SoundBank.playerTargets can contain targets that are no longer in runtime.targets, so sometimes sounds become unstoppable.

`SoundBank.stopAllSounds` take an optional argument, and if passed (current behavior) only the specified target will have sounds stopped. However, this isn't necessary at all - it's expected to stop every sounds in every targets when VM's stopAllSounds is called.

### Test Coverage
Manually tested with GUI+VM
