### PR TITLE
Decrement clone counter only if it's clone

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1114,7 +1114,9 @@ class RenderedTarget extends Target {
      * Dispose, destroying any run-time properties.
      */
     dispose () {
-        this.runtime.changeCloneCounter(-1);
+        if (!this.isOriginal) {
+            this.runtime.changeCloneCounter(-1);
+        }
         this.runtime.stopForTarget(this);
         this.runtime.removeExecutable(this);
         this.sprite.removeClone(this);


### PR DESCRIPTION
### Resolves
Resolves #505
Resolves #2352 

### Proposed Changes
Decrement clone counter only if it's clone

### Reason for Changes
`RenderedTarget.dispose` is called when the target gets disposed somehow, including deleting a sprite or its clone. This makes the clone counter go below 0.