### PR TITLE
Cast malformed color hex strings to RGBA 0,0,0,255 instead of null

### DIFF
--- a/src/util/cast.js
+++ b/src/util/cast.js
@@ -93,6 +93,9 @@ class Cast {
         let color;
         if (typeof value === 'string' && value.substring(0, 1) === '#') {
             color = Color.hexToRgb(value);
+
+            // If the color wasn't *actually* a hex color, cast to black
+            if (!color) color = {r: 0, g: 0, b: 0, a: 255};
         } else {
             color = Color.decimalToRgb(Cast.toNumber(value));
         }

--- a/test/unit/util_cast.js
+++ b/test/unit/util_cast.js
@@ -73,7 +73,7 @@ test('toString', t => {
     t.end();
 });
 
-test('toRbgColorList', t => {
+test('toRgbColorList', t => {
     // Hex (minimal, see "color" util tests)
     t.deepEqual(cast.toRgbColorList('#000'), [0, 0, 0]);
     t.deepEqual(cast.toRgbColorList('#000000'), [0, 0, 0]);
@@ -91,7 +91,7 @@ test('toRbgColorList', t => {
     t.end();
 });
 
-test('toRbgColorObject', t => {
+test('toRgbColorObject', t => {
     // Hex (minimal, see "color" util tests)
     t.deepEqual(cast.toRgbColorObject('#000'), {r: 0, g: 0, b: 0});
     t.deepEqual(cast.toRgbColorObject('#000000'), {r: 0, g: 0, b: 0});
@@ -107,6 +107,7 @@ test('toRbgColorObject', t => {
     // Malformed
     t.deepEqual(cast.toRgbColorObject('ffffff'), {a: 255, r: 0, g: 0, b: 0});
     t.deepEqual(cast.toRgbColorObject('foobar'), {a: 255, r: 0, g: 0, b: 0});
+    t.deepEqual(cast.toRgbColorObject('#nothex'), {a: 255, r: 0, g: 0, b: 0});
     t.end();
 });
 

--- a/test/unit/util_cast.js
+++ b/test/unit/util_cast.js
@@ -88,6 +88,7 @@ test('toRgbColorList', t => {
     // Malformed
     t.deepEqual(cast.toRgbColorList('ffffff'), [0, 0, 0]);
     t.deepEqual(cast.toRgbColorList('foobar'), [0, 0, 0]);
+    t.deepEqual(cast.toRgbColorList('#nothex'), [0, 0, 0]);
     t.end();
 });
 


### PR DESCRIPTION
### Resolves

Resolves #2355

### Proposed Changes

This PR changes the behavior of `Cast.toRgbColorObject` to cast strings beginning with `#` to RGBA [0, 0, 0, 255] (opaque black), matching the behavior of casting other malformed strings to a color object.

Previously, those strings were cast to `null`.

### Reason for Changes

This prevents the VM from erroring out when attempting to cast a string beginning with `#` to a color, as it expects an RGB color object to always be returned.

### Test Coverage

A "cast malformed hex string to color" unit test has been added.
