### PR TITLE
Fix some clones not getting removed when sprite is deleted

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1020,10 +1020,13 @@ class VirtualMachine extends EventEmitter {
             // target-specific monitored blocks (e.g. local variables)
             target.deleteMonitors();
             const currentEditingTarget = this.editingTarget;
-            for (let i = 0; i < sprite.clones.length; i++) {
-                const clone = sprite.clones[i];
-                this.runtime.stopForTarget(sprite.clones[i]);
-                this.runtime.disposeTarget(sprite.clones[i]);
+            const cloneCount = sprite.clones.length;
+            for (let i = 0; i < cloneCount; i++) {
+                // sprite.clones is shifted by sprite.removeClone called from runtime.disposeTarget,
+                // so it's safe to just handle the first element
+                const clone = sprite.clones[0];
+                this.runtime.stopForTarget(clone);
+                this.runtime.disposeTarget(clone);
                 // Ensure editing target is switched if we are deleting it.
                 if (clone === currentEditingTarget) {
                     const nextTargetIndex = Math.min(this.runtime.targets.length - 1, targetIndexBeforeDelete);


### PR DESCRIPTION
### Resolves
Resolves #2357 

### Proposed Changes
Fixes `VM.deleteSprite` by removing the first clone N times, rather than removing the clone using the index.

### Reason for Changes
Previous code was like this:
![image](https://user-images.githubusercontent.com/33279053/81292146-0e78f380-90a6-11ea-9ea2-73e2cd740001.png)
Run it on Scratch and see what's wrong...

### Test Coverage
Manually tested.

note: please review PR about another bug related to deletion and clone too: #2353 