### PR TITLE
Remove BlockCached._shadowOps

### DIFF
--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -268,13 +268,6 @@ class BlockCached {
         this._parentValues = null;
 
         /**
-         * A sequence of shadow value operations that can be performed in any
-         * order and are easier to perform given that they are static.
-         * @type {Array<BlockCached>}
-         */
-        this._shadowOps = [];
-
-        /**
          * A sequence of non-shadow operations that can must be performed. This
          * list recreates the order this block and its children are executed.
          * Since the order is always the same we can safely store that order
@@ -359,7 +352,6 @@ class BlockCached {
                     continue;
                 }
 
-                this._shadowOps.push(...inputCached._shadowOps);
                 this._ops.push(...inputCached._ops);
                 inputCached._parentKey = inputName;
                 inputCached._parentValues = this._argValues;
@@ -374,9 +366,7 @@ class BlockCached {
 
         // The final operation is this block itself. At the top most block is a
         // command block or a block that is being run as a monitor.
-        if (!this._isHat && this._isShadowBlock) {
-            this._shadowOps.push(this);
-        } else if (this._definedBlockFunction) {
+        if (this._definedBlockFunction) {
             this._ops.push(this);
         }
     }


### PR DESCRIPTION
### Resolves

Resolves #2398

### Proposed Changes

This PR removes the `_shadowOps` property from `BlockCached`, along with all code that pushes to it.

### Reason for Changes

`_shadowOps` was never read from, only pushed to, and [shadow values are stored elsewhere anyways](https://github.com/LLK/scratch-vm/blob/f5ce73ae51bcc634a66b3924f639e06b626fc16e/src/engine/execute.js#L367-L371).

### Test Coverage

All existing tests pass