### PR TITLE
Don't move shadow blocks into the top level

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -728,7 +728,12 @@ class Blocks {
 
         // Is this block a top-level block?
         if (typeof e.newParent === 'undefined') {
-            this._addScript(e.id);
+            // When you plug a block into a shadowed input, Blockly will move the shadow block into the top level before
+            // deleting it. Because we don't delete shadows here, instead keeping them on our blocks, the corresponding
+            // "delete" event will be ignored and the shadow would otherwise be added into the top level.
+            // TODO: Blockly inputs' connections keep their own copies of shadow blocks stashed away too.
+            // We should probably use those instead of duplicating the shadow-saving behavior.
+            if (!this._blocks[e.id].shadow) this._addScript(e.id);
         } else {
             // Remove script, if one exists.
             this._deleteScript(e.id);


### PR DESCRIPTION
### Resolves

Resolves #1530

### Proposed Changes

This PR adds a check in `Blocks.moveBlock` as to whether the block being moved is a shadow and is being moved to the top level, and if so, will not move the block.

### Reason for Changes

When you drop a block into another block's shadowed input, [Blockly calls `dispose` on the shadow block](https://github.com/LLK/scratch-blocks/blob/a355ca0b6353cbcfa906472d01a21e9940a390c9/core/connection.js#L169). That in turn [disconnects the block, causing Blockly to move it to the top level](https://github.com/LLK/scratch-blocks/blob/a355ca0b6353cbcfa906472d01a21e9940a390c9/core/connection.js#L588-L598).

Because [we don't delete shadow blocks when Blockly does](https://github.com/LLK/scratch-vm/pull/135/commits/c5f108aa7c0dd9e65756d50ff83ee5729aa62607#diff-c2e52c759bccc44bfc3789bbfe5d9b2eR169-R172), these top-level shadow blocks were left hanging around the workspace. 

### Test Coverage

Unit tests have been added
