### PR TITLE
Remove RenderedTarget.setSay + its test

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -1,4 +1,3 @@
-const log = require('../util/log');
 const MathUtil = require('../util/math-util');
 const StringUtil = require('../util/string-util');
 const Cast = require('../util/cast');
@@ -339,23 +338,6 @@ class RenderedTarget extends Target {
         if (this.isStage) return;
         this.draggable = !!draggable;
         this.runtime.requestTargetsUpdate(this);
-    }
-
-    /**
-     * Set a say bubble.
-     * @param {?string} type Type of say bubble: "say", "think", or null.
-     * @param {?string} message Message to put in say bubble.
-     */
-    setSay (type, message) {
-        if (this.isStage) {
-            return;
-        }
-        // @todo: Render to stage.
-        if (!type || !message) {
-            log.info('Clearing say bubble');
-            return;
-        }
-        log.info('Setting say bubble:', type, message);
     }
 
     /**

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -56,17 +56,6 @@ test('direction', t => {
     t.end();
 });
 
-test('setSay', t => {
-    const r = new Runtime();
-    const s = new Sprite(null, r);
-    const a = new RenderedTarget(s, r);
-    const renderer = new FakeRenderer();
-    a.renderer = renderer;
-    a.setSay();
-    a.setSay('types not specified', 'message');
-    t.end();
-});
-
 test('setVisible', t => {
     const r = new Runtime();
     const s = new Sprite(null, r);


### PR DESCRIPTION
### Resolves

Resolves #2414

### Proposed Changes

This PR removes the `RenderedTarget.setSay` function and its unit tests.

### Reason for Changes

`setSay` was a stub function added in https://github.com/LLK/scratch-vm/commit/460760bd06cd5893e1a5f710a555e23316bf9e3e that doesn't actually do anything other than log to the console, and is not called in any part of the codebase.

Say/think bubble support was added in #691, but that PR didn't remove the old stub `setSay` function. As it is now, `setSay` is dead code.

### Test Coverage

Updated as well
