### PR TITLE
Remove Timer.relativeTime

### DIFF
--- a/src/util/timer.js
+++ b/src/util/timer.js
@@ -8,7 +8,7 @@
  * ... pass some time ...
  * var timeDifference = timer.timeElapsed();
  * ---
- * Or, you can use the `time` and `relativeTime`
+ * Or, you can use the `time` function
  * to do some measurement yourself.
  */
 
@@ -65,17 +65,6 @@ class Timer {
      * @returns {number} ms elapsed since 1 January 1970 00:00:00 UTC.
      */
     time () {
-        return this.nowObj.now();
-    }
-
-    /**
-     * Returns a time accurate relative to other times produced by this function.
-     * If possible, will use sub-millisecond precision.
-     * If not, will use millisecond precision.
-     * Not guaranteed to produce the same absolute values per-system.
-     * @returns {number} ms-scale accurate time relative to other relative times.
-     */
-    relativeTime () {
         return this.nowObj.now();
     }
 

--- a/test/fixtures/mock-timer.js
+++ b/test/fixtures/mock-timer.js
@@ -79,15 +79,6 @@ class MockTimer {
     }
 
     /**
-     * Returns a time accurate relative to other times produced by this function.
-     * @returns {number} ms-scale accurate time relative to other relative times.
-     * @memberof MockTimer
-     */
-    relativeTime () {
-        return this._mockTime;
-    }
-
-    /**
      * Start a timer for measuring elapsed time.
      * @memberof MockTimer
      */


### PR DESCRIPTION
### Resolves

Resolves #2401

### Proposed Changes

This PR removes the `Timer.relativeTime` function.

### Reason for Changes

`Timer.relativeTime` contains the exact same code as `Timer.time`, is not used anywhere in the current codebase, and as such is dead code.

### Test Coverage

Also removed it from the `MockTimer` class.
