### PR TITLE
Remove broken link from extension docs

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -3,9 +3,6 @@
 This document describes technical topics related to Scratch 3.0 extension development, including the Scratch 3.0
 extension specification.
 
-For documentation regarding other aspects of Scratch 3.0 extensions see [this Extensions page on the
-wiki](https://github.com/LLK/docs/wiki/Extensions).
-
 ## Types of Extensions
 
 There are four types of extensions that can define everything from the Scratch's core library (such as the "Looks" and


### PR DESCRIPTION
Just removing a line from the extensions documentation that links to a page that is not publicly available. Hopefully this will reduce confusion a bit. 

resolves https://github.com/LLK/scratch-vm/issues/2410