### PR TITLE
Set graphic effect to zero if it's Infinity

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -509,6 +509,8 @@ class Scratch3LooksBlocks {
                 Scratch3LooksBlocks.EFFECT_BRIGHTNESS_LIMIT.min,
                 Scratch3LooksBlocks.EFFECT_BRIGHTNESS_LIMIT.max);
             break;
+        default:
+            clampedValue = isFinite(clampedValue) ? clampedValue : 0;
         }
         return clampedValue;
     }


### PR DESCRIPTION
### Resolves
Resolves #2317 

### Proposed Changes
If the graphic value is not finite (for example `Infinity`), cast it to zero, if it's not already clamped

### Reason for Changes
Some effects become strange if the value is Infinity. I chose zero because 1) all effects should accept 0 as a value and 2) not all effects have maximum/minimum values. (For those that have it (currently ghost and brightness), this change will NOT apply)
