### PR TITLE
Reset blocks cache when sensing_of blocks are updated

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -969,6 +969,7 @@ class Blocks {
                 }
             }
         }
+        if (blockUpdated) this.resetCache();
         return blockUpdated;
     }
 


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/4392

### Proposed Changes

This PR adds code to `updateSensingOfReference` to clear the block container's cache if `sensing_of` blocks are updated.

### Reason for Changes

Previously, the block cache wasn't getting cleared, which meant that the old `sensing_of` blocks were being cached when they shouldn't have been, causing them to report the wrong values until they were updated by clicking on the sprites they belonged to.

### Test Coverage

Tested manually
