### PR TITLE
Support extension block filtering per-target

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1365,13 +1365,27 @@ class Runtime extends EventEmitter {
 
     /**
      * @returns {Array.<object>} scratch-blocks XML for each category of extension blocks, in category order.
+     * @param {?Target} [target] - the active editing target (optional)
      * @property {string} id - the category / extension ID
      * @property {string} xml - the XML text for this category, starting with `<category>` and ending with `</category>`
      */
-    getBlocksXML () {
+    getBlocksXML (target) {
         return this._blockInfo.map(categoryInfo => {
             const {name, color1, color2} = categoryInfo;
-            const paletteBlocks = categoryInfo.blocks.filter(block => !block.info.hideFromPalette);
+            // Filter out blocks that aren't supposed to be shown on this target, as determined by the block info's
+            // `hideFromPalette` and `filter` properties.
+            const paletteBlocks = categoryInfo.blocks.filter(block => {
+                let blockFilterIncludesTarget = true;
+                // If an editing target is not passed, include all blocks
+                // If the block info doesn't include a `filter` property, always include it
+                if (target && block.info.filter) {
+                    blockFilterIncludesTarget = block.info.filter.includes(
+                        target.isStage ? TargetType.STAGE : TargetType.SPRITE
+                    );
+                }
+                return blockFilterIncludesTarget && !block.info.hideFromPalette;
+            });
+
             const colorXML = `colour="${color1}" secondaryColour="${color2}"`;
 
             // Use a menu icon if there is one. Otherwise, use the block icon. If there's no icon,

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1383,6 +1383,7 @@ class Runtime extends EventEmitter {
                         target.isStage ? TargetType.STAGE : TargetType.SPRITE
                     );
                 }
+                // If the block info's `hideFromPalette` is true, then filter out this block
                 return blockFilterIncludesTarget && !block.info.hideFromPalette;
             });
 


### PR DESCRIPTION
### Resolves

A step towards https://github.com/LLK/scratch-gui/issues/2174

### Proposed Changes

This PR implements per-target filtering of extension blocks to display in the blocks palette.

It does this by adding an optional parameter, the current editing target, to `Runtime.getBlocksXML`. If this parameter is passed, `getBlocksXML` will filter out extension blocks using the block info's `filter` property, per the [extension spec](https://github.com/LLK/scratch-vm/blob/develop/docs/extensions.md).

### Reason for Changes

This is necessary to change which blocks get displayed when you switch targets (e.g. to hide certain pen blocks when you select the stage).

### Test Coverage

Tested manually
