### PR TITLE
fix: wrapClamp direction during deserialization

### DIFF
--- a/src/serialization/sb2.js
+++ b/src/serialization/sb2.js
@@ -684,7 +684,9 @@ const parseScratchObject = function (object, runtime, extensions, topLevel, zip,
         target.y = object.scratchY;
     }
     if (object.hasOwnProperty('direction')) {
-        target.direction = object.direction;
+        // Sometimes the direction can be outside of the range: LLK/scratch-gui#5806
+        // wrapClamp it (like we do on RenderedTarget.setDirection)
+        target.direction = MathUtil.wrapClamp(object.direction, -179, 180);
     }
     if (object.hasOwnProperty('isDraggable')) {
         target.draggable = object.isDraggable;

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -1043,7 +1043,9 @@ const parseScratchObject = function (object, runtime, extensions, zip, assets) {
         target.y = object.y;
     }
     if (object.hasOwnProperty('direction')) {
-        target.direction = object.direction;
+        // Sometimes the direction can be outside of the range: LLK/scratch-gui#5806
+        // wrapClamp it (like we do on RenderedTarget.setDirection)
+        target.direction = MathUtil.wrapClamp(object.direction, -179, 180);
     }
     if (object.hasOwnProperty('size')) {
         target.size = object.size;


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-gui#5806

### Proposed Changes
wrapClamp direction during deserialization

### Reason for Changes
Scratch 1.4 projects can have direction of -270. Since Scratch 3.0 expects direction to be -179-180, there are some bugs that is caused by this. This may break projects saved in Scratch 1.4 that uses `direction` block, [but it's the 2.0 behavior anyway](https://github.com/LLK/scratch-flash/blob/develop/src/util/OldProjectReader.as#L97) (see [ScratchObject's setDirection behavior](https://github.com/LLK/scratch-flash/blob/develop/src/scratch/ScratchSprite.as#L226))

Scratch 1.x projects are handled in sb2.js part. Scratch 1.x projects that are serialized to SB3 can still have this issue, so it will handle in sb3.js as well