### PR TITLE
Use toUpperCase at setVoice

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -648,7 +648,7 @@ class Scratch3Text2SpeechBlocks {
     setVoice (args, util) {
         const state = this._getState(util.target);
 
-        let voice = args.VOICE;
+        let voice = args.VOICE.toUpperCase();
 
         // If the arg is a dropped number, treat it as a voice index
         let voiceNum = parseInt(voice, 10);


### PR DESCRIPTION
### Resolves

Resolves #2448

### Proposed Changes

Adds ".toUpperCase()" to the text to speech setVoice(), so lowercase works.

### Reason for Changes

So, for example, this will work:
![image](https://user-images.githubusercontent.com/60622217/83356326-bca25100-a365-11ea-90dd-e6de182e81c2.png)

### Test Coverage

Manually tested with a clone of the GUI.