### PR TITLE
sanitize extension ID in getExtensionIdForOpcode

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -310,6 +310,7 @@ class SomeBlocks {
         return {
             // Required: the machine-readable name of this extension.
             // Will be used as the extension's namespace.
+            // Allowed characters are those matching the regular expression [\w-]: A-Z, a-z, 0-9, and hyphen ("-").
             id: 'someBlocks',
 
             // Core extensions only: override the default extension block colors.

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -273,13 +273,17 @@ const compressInputTree = function (block, blocks) {
 };
 
 /**
- * Get non-core extension ID for a given sb3 opcode.
+ * Get sanitized non-core extension ID for a given sb3 opcode.
+ * Note that this should never return a URL. If in the future the SB3 loader supports loading extensions by URL, this
+ * ID should be used to (for example) look up the extension's full URL from a table in the SB3's JSON.
  * @param {!string} opcode The opcode to examine for extension.
  * @return {?string} The extension ID, if it exists and is not a core extension.
  */
 const getExtensionIdForOpcode = function (opcode) {
+    // Allowed ID characters are those matching the regular expression [\w-]: A-Z, a-z, 0-9, and hyphen ("-").
     const index = opcode.indexOf('_');
-    const prefix = opcode.substring(0, index);
+    const forbiddenSymbols = /[^\w-]/g;
+    const prefix = opcode.substring(0, index).replace(forbiddenSymbols, '-');
     if (CORE_EXTENSIONS.indexOf(prefix) === -1) {
         if (prefix !== '') return prefix;
     }

--- a/test/unit/serialization_sb3.js
+++ b/test/unit/serialization_sb3.js
@@ -290,6 +290,9 @@ test('getExtensionIdForOpcode', t => {
     // does not return anything for opcodes with no extension
     t.false(sb3.getExtensionIdForOpcode('hello'));
 
+    // forbidden characters must be replaced with '-'
+    t.equal(sb3.getExtensionIdForOpcode('hi:there/happy_people'), 'hi-there-happy');
+
     t.end();
 });
 


### PR DESCRIPTION
### Proposed Changes

When loading an SB3, we determine whether a block is part of an extension by inspecting its "extended" opcode -- for example, `pen_clear` requires the `pen` extension. This change introduces an extra sanitizing step to ensure that the extension ID doesn't contain any characters that might cause problems. Also, this change defines the characters allowed in extension IDs as alphanumerics plus hyphen.

### Reason for Changes

We should always validate user input, and project files count. We validate most of the project file but we weren't validating the extension ID in this case. See also support ticket 229791.

Special thanks to @apple502j for bringing this to our attention!

### Test Coverage

A new test has been added to verify that characters are replaced appropriately.
