### PR TITLE
Revert "Set graphic effect to zero if it's Infinity"

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -537,8 +537,6 @@ class Scratch3LooksBlocks {
                 Scratch3LooksBlocks.EFFECT_BRIGHTNESS_LIMIT.min,
                 Scratch3LooksBlocks.EFFECT_BRIGHTNESS_LIMIT.max);
             break;
-        default:
-            clampedValue = isFinite(clampedValue) ? clampedValue : 0;
         }
         return clampedValue;
     }


### PR DESCRIPTION
Reverts LLK/scratch-vm#2437

Setting the color effect to 0 when you try to set it to infinity makes sense because it wraps around (and hence there's no defined "limit" that it approaches), but we want to put a bit more thought into what to do for other effects (fisheye, whirl, pixelate, mosaic).