### PR TITLE
Add a unit test for the clock being reset on runtime dispose

### DIFF
--- a/test/unit/engine_runtime.js
+++ b/test/unit/engine_runtime.js
@@ -250,3 +250,24 @@ test('Disposing the runtime emits an event', t => {
     t.equal(disposed, true);
     t.end();
 });
+
+test('Clock is reset on runtime dispose', t => {
+    const rt = new Runtime();
+    const c = rt.ioDevices.clock;
+    let simulatedTime = 0;
+
+    c._projectTimer = {
+        timeElapsed: () => simulatedTime,
+        start: () => {
+            simulatedTime = 0;
+        }
+    };
+
+    t.ok(c.projectTimer() === 0);
+    simulatedTime += 1000;
+    t.ok(c.projectTimer() === 1);
+    rt.dispose();
+    // When the runtime is disposed, the clock should be reset
+    t.ok(c.projectTimer() === 0);
+    t.end();
+});

--- a/test/unit/io_clock.js
+++ b/test/unit/io_clock.js
@@ -35,24 +35,3 @@ test('cycle', t => {
     rt._step();
     t.ok(c.projectTimer() > 0);
 });
-
-test('reset on runtime dispose', t => {
-    const rt = new Runtime();
-    const c = rt.ioDevices.clock;
-    let simulatedTime = 0;
-
-    c._projectTimer = {
-        timeElapsed: () => simulatedTime,
-        start: () => {
-            simulatedTime = 0;
-        }
-    };
-
-    t.ok(c.projectTimer() === 0);
-    simulatedTime += 1000;
-    t.ok(c.projectTimer() === 1);
-    rt.dispose();
-    // When the runtime is disposed, the clock should be reset
-    t.ok(c.projectTimer() === 0);
-    t.end();
-});

--- a/test/unit/io_clock.js
+++ b/test/unit/io_clock.js
@@ -35,3 +35,24 @@ test('cycle', t => {
     rt._step();
     t.ok(c.projectTimer() > 0);
 });
+
+test('reset on runtime dispose', t => {
+    const rt = new Runtime();
+    const c = rt.ioDevices.clock;
+    let simulatedTime = 0;
+
+    c._projectTimer = {
+        timeElapsed: () => simulatedTime,
+        start: () => {
+            simulatedTime = 0;
+        }
+    };
+
+    t.ok(c.projectTimer() === 0);
+    simulatedTime += 1000;
+    t.ok(c.projectTimer() === 1);
+    rt.dispose();
+    // When the runtime is disposed, the clock should be reset
+    t.ok(c.projectTimer() === 0);
+    t.end();
+});


### PR DESCRIPTION
This just adds a test for the clock io module, to verify that it is reset when the runtime is disposed. 

This is a follow-up to @apple502j 's [PR](https://github.com/LLK/scratch-vm/pull/2341) that added that functionality.  

I've used a "simulated" timer in this case (though other similar tests use timeouts), assuming that this helps prevent flaky tests.

It might be reasonable to put this test in the `blocks_sensing` file instead, since it is really a test of the timer reporter block, but because of the indirection we use for io queries (`util.ioQuery('clock', 'projectTimer')`) I couldn't figure out how to do that.