### PR TITLE
Refactor comments

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -824,7 +824,7 @@ class Blocks {
         // Delete comments attached to the block.
         if (block.comment) {
             const editingTarget = this.runtime.getEditingTarget();
-            if (editingTarget.comments.hasOwnProperty(block.comment)) {
+            if (editingTarget && editingTarget.comments.hasOwnProperty(block.comment)) {
                 delete editingTarget.comments[block.comment];
             }
         }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -821,6 +821,14 @@ class Blocks {
             }
         }
 
+        // Delete comments attached to the block.
+        if (block.comment) {
+            const editingTarget = this.runtime.getEditingTarget();
+            if (editingTarget.comments.hasOwnProperty(block.comment)) {
+                delete editingTarget.comments[block.comment];
+            }
+        }
+
         // Delete any script starting with this block.
         this._deleteScript(blockId);
 

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -20,9 +20,10 @@ class Target extends EventEmitter {
     /**
      * @param {Runtime} runtime Reference to the runtime.
      * @param {?Blocks} blocks Blocks instance for the blocks owned by this target.
+     * @param {?Object.<string, *>} comments Array of comments owned by this target.
      * @constructor
      */
-    constructor (runtime, blocks) {
+    constructor (runtime, blocks, comments) {
         super();
 
         if (!blocks) {
@@ -55,7 +56,7 @@ class Target extends EventEmitter {
          * Key is the comment id.
          * @type {Object.<string,*>}
          */
-        this.comments = {};
+        this.comments = comments || {};
         /**
          * Dictionary of custom state for this target.
          * This can be used to store target-specific custom state for blocks which need it.

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -20,7 +20,7 @@ class Target extends EventEmitter {
     /**
      * @param {Runtime} runtime Reference to the runtime.
      * @param {?Blocks} blocks Blocks instance for the blocks owned by this target.
-     * @param {?Object.<string, *>} comments Array of comments owned by this target.
+     * @param {?Object.<string, Comment>} comments Array of comments owned by this target.
      * @constructor
      */
     constructor (runtime, blocks, comments) {

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -15,7 +15,7 @@ class RenderedTarget extends Target {
      * @constructor
      */
     constructor (sprite, runtime) {
-        super(runtime, sprite.blocks);
+        super(runtime, sprite.blocks, sprite.comments);
 
         /**
          * Reference to the sprite that this is a render of.

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -60,7 +60,7 @@ class Sprite {
         /**
          * Dictionary of comments for this target.
          * Key is the comment id.
-         * @type {Object.<string,*>}
+         * @type {Object.<string, Comment>}
          */
         this.comments = {};
     }
@@ -157,7 +157,7 @@ class Sprite {
         Object.keys(this.comments).forEach(commentId => {
             const comment = this.comments[commentId];
             const newComment = new Comment(
-                null, // use new comment id
+                null, // generate new comment id
                 comment.text,
                 comment.x,
                 comment.y,
@@ -165,6 +165,9 @@ class Sprite {
                 comment.height,
                 comment.minimized
             );
+            // If the comment is attached to a block, it has a blockId property for the block it's attached to.
+            // Because we generate new block IDs for all the duplicated blocks, change all the comments' attached-block
+            // IDs from the old block IDs to the new ones.
             if (comment.blockId) {
                 const newBlockId = oldToNew[comment.blockId];
                 if (newBlockId) {
@@ -173,10 +176,14 @@ class Sprite {
                     if (newBlock) {
                         newBlock.comment = newComment.id;
                     } else {
-                        log.warn(`Could not find block with id ${newBlockId
-                        } associated with comment ${newComment.id}`);
+                        log.warn(`Could not find block with id ${newBlockId} associated with comment ${newComment.id}`);
                     }
                 } else {
+                    // Comments did not get deleted when the block got deleted
+                    // Such comments have blockId, but because the block is deleted
+                    // oldToNew mapping does not include that blockId
+                    // Handle it as workspace comment
+                    // TODO do not load such comments when deserializing
                     log.warn(`Could not find block with id ${comment.blockId
                     } associated with comment ${comment.id} in the block ID mapping`);
                 }

--- a/src/util/new-block-ids.js
+++ b/src/util/new-block-ids.js
@@ -32,5 +32,6 @@ module.exports = blocks => {
         }
     }
 
+    // There are other things that need this mapping e.g. comments
     return oldToNew;
 };

--- a/src/util/new-block-ids.js
+++ b/src/util/new-block-ids.js
@@ -4,6 +4,7 @@ const uid = require('./uid');
  * Mutate the given blocks to have new IDs and update all internal ID references.
  * Does not return anything to make it clear that the blocks are updated in-place.
  * @param {array} blocks - blocks to be mutated.
+ * @returns {object.<string, string>} - mapping of old block ID to new block ID
  */
 module.exports = blocks => {
     const oldToNew = {};
@@ -30,4 +31,6 @@ module.exports = blocks => {
             blocks[i].next = oldToNew[blocks[i].next];
         }
     }
+
+    return oldToNew;
 };

--- a/test/unit/engine_blocks.js
+++ b/test/unit/engine_blocks.js
@@ -600,6 +600,25 @@ test('delete inputs', t => {
     t.end();
 });
 
+test('delete block with comment', t => {
+    const b = new Blocks(new Runtime());
+    const fakeTarget = {
+        comments: {
+            bar: {
+                blockId: 'foo'
+            }
+        }
+    };
+    b.runtime.getEditingTarget = () => fakeTarget;
+    b.createBlock({
+        id: 'foo',
+        comment: 'bar'
+    });
+    b.deleteBlock('foo');
+    t.notOk(fakeTarget.comments.hasOwnProperty('bar'));
+    t.end();
+});
+
 test('updateAssetName function updates name in sound field', t => {
     const b = new Blocks(new Runtime());
     b.createBlock({

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -45,6 +45,21 @@ test('blocks get new id on duplicate', t => {
     });
 });
 
+test('comments are duplicated when duplicating target', t => {
+    const r = new Runtime();
+    const s = new Sprite(null, r);
+    const rt = new RenderedTarget(s, r);
+    rt.createComment('commentid', null, 'testcomment', 0, 0, 100, 100, false);
+    t.ok(s.comments.hasOwnProperty('commentid'));
+    return rt.duplicate().then(duplicate => {
+        // Not ok because comment id should be re-generated
+        t.notOk(duplicate.comments.hasOwnProperty('commentid'));
+        t.ok(Object.keys(duplicate.comments).length === 1);
+        t.end();
+    });
+});
+
+
 test('direction', t => {
     const r = new Runtime();
     const s = new Sprite(null, r);


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-gui#3687
Resolves #2501 

note: #1893 will no longer be resolved

### Proposed Changes
First commits move comment attribute to `Sprite`, similar to `blocks` attribute. This was necessary to fix gui#3687. It also changes newBlockId so that it returns the mapping; the mapping is used inside `Sprite.duplicate` to fix gui#3687. RenderedTarget and Target still has comments attribute, so it should not cause problems.

Second commit is to fix #2501 - comments attached to blocks will now be deleted if the block is deleted, by deleting the comment item in `deleteBlock`.

Third commit is for #1893 . It has one breaking change; `deserializeBlocks` now return `{blocks, oldToNew}` instead of `blocks`. The mapping is used to sync `Comment.blockId` and `block.comment` later, in `parseScratchObject`. It also checks if the block actually exists - so any project that was saved with "invisible comment" (by #2501) will lose them.

Fourth commit is mostly tests. One new integration test is added to test #1893 and two unit tests are added to `engine_blocks` and `sprites_rendered-targets` to test #2501 and gui#3687, and they all pass for me.

### Reason for Changes
- moving comments to `Sprite`: first, it does not make sense that a Target - which includes clones - is controlling the sprite-wide comments. This also fixes consistency between blocks and comments. The major reason is, though, we needed to handle duplication inside `Sprite.duplicate`, not `RenderedTarget.duplicte` - because we needed the mapping. I could use `this.clones[0]` but it will make messy code.
- `newBlockIds` return value - it was necessary to implement duplicating comments attached to blocks
- Deleting comments when blocks are deleted - it was visually gone, but not on VM. They still exist on the memory and in the project file, and the only way to remove it is removing the sprite (or modifying it)
- deserializeBlocks change - deserializeInputDesc generates random uid for primitives (including variables/lists), which broke comments because the id is different. It now returns oldToNew mapping which can be used to correct comment's block id.
- parseScratchObject was changed to use the returned value from deserializeBlocks to attach correct blocks to comments.

### Test Coverage
Added 1 integration test (variable-comment) and 2 unit tests (see above).

Manual testing:
1) Make a variable and a list
2) Grab a variable reporter and a list reporter on a sprite
3) Add comments to those blocks
4) Add workspace comment
5) Duplicate sprite
6) The comments exist on the duplicated sprite
7) Export sprite
8) Upload again
9) All comments still exist
10) Delete blocks by dragging them to toolbox (do not touch comments)
11) Export sprite again
12) See the sprite.json of the exported sprite
13) There should be only one comment (workspace comment)