### PR TITLE
Highlight and scroll to list index used by list blocks

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -128,6 +128,7 @@ class Scratch3DataBlocks {
             args.LIST.id, args.LIST.name);
         if (list.value.length < Scratch3DataBlocks.LIST_ITEM_LIMIT) {
             list.value.push(args.ITEM);
+            util.highlightListItem(list, list.value.length - 1);
             list._monitorUpToDate = false;
         }
     }
@@ -143,6 +144,7 @@ class Scratch3DataBlocks {
             return;
         }
         list.value.splice(index - 1, 1);
+        util.highlightListItem(list, index - 1);
         list._monitorUpToDate = false;
     }
 
@@ -169,6 +171,7 @@ class Scratch3DataBlocks {
             // remove the last element in the list
             list.value.pop();
         }
+        util.highlightListItem(list, index - 1);
         list._monitorUpToDate = false;
     }
 
@@ -181,6 +184,7 @@ class Scratch3DataBlocks {
             return;
         }
         list.value[index - 1] = item;
+        util.highlightListItem(list, index - 1);
         list._monitorUpToDate = false;
     }
 
@@ -191,6 +195,7 @@ class Scratch3DataBlocks {
         if (index === Cast.LIST_INVALID) {
             return '';
         }
+        util.highlightListItem(list, index - 1);
         return list.value[index - 1];
     }
 

--- a/src/engine/block-utility.js
+++ b/src/engine/block-utility.js
@@ -1,5 +1,6 @@
 const Thread = require('./thread');
 const Timer = require('../util/timer');
+const MathUtil = require('../util/math-util');
 
 /**
  * @fileoverview
@@ -234,6 +235,21 @@ class BlockUtility {
             const devObject = this.sequencer.runtime.ioDevices[device];
             return devObject[func].apply(devObject, args);
         }
+    }
+
+    /**
+     * Highlight list item.
+     * @param {Variable} list The list variable.
+     * @param {number} index The index to highlight.
+    */
+    highlightListItem (list, index) {
+        if (list.type !== 'list') return;
+        const listId = list.id;
+        const monitorBlock = this.sequencer.runtime.monitorBlocks.getBlock(listId);
+        // we do not need to highlight
+        if (!monitorBlock || !monitorBlock.isMonitored) return;
+        index = MathUtil.clamp(index, -1, list.value.length - 1);
+        this.sequencer.runtime.highlightListItem(listId, index);
     }
 }
 

--- a/src/engine/monitor-record.js
+++ b/src/engine/monitor-record.js
@@ -17,7 +17,8 @@ const MonitorRecord = Record({
     y: null,
     width: 0,
     height: 0,
-    visible: true
+    visible: true,
+    highlightItem: null // do not highlight anything (only applicable to list monitors)
 });
 
 module.exports = MonitorRecord;


### PR DESCRIPTION
GUI part: LLK/scratch-gui#5961

### Resolves
VM part for fixing #1385 and #1386 - **VM must be merged first**, and then GUI can be merged.

### Proposed Changes
This adds `util.highlightListItem` (used by "index related blocks", has some checks) and `Runtime.highlightListItem`. This also adds `highlightItem` to MonitorRecord.

This also adds highlight handling to `Runtime._step`. It can only highlight one item per list per frame, and the index passed from last "index related block" executed in that frame is used. This is handled just before sending monitor update, so amounts of events emitted from runtime should be equal, if they only write.

"index related block" are:
- add to list
- delete index of list
- insert at list
- replace item of list
- get item of list

Note: if the monitor is hidden, `util.highlightListItem` will not call `runtime.highlightListItem`, meaning it will not emit unnecessary events.

### Reason for Changes
Compatibility with Scratch 2.0.

### Test Coverage
Manually tested, on modified scratch-gui (PR coming soon)