### PR TITLE
Fix document type in scratch3_data.js

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -247,7 +247,7 @@ class Scratch3DataBlocks {
 
     /**
      * Type representation for list variables.
-     * @const {string}
+     * @const {number}
      */
     static get LIST_ITEM_LIMIT () {
         return 200000;


### PR DESCRIPTION
fix inappropriate jsdoc type

### Resolves

_What Github issue does this resolve (please include link)?_
None
### Proposed Changes

_Describe what this Pull Request does_
Replace function return type with appropriate type
### Reason for Changes

_Explain why these changes should be made_
because `200000` is number, not string.
### Test Coverage

_Please show how you have added tests to cover your changes_
