### PR TITLE
Use missingTranslation: ignore in formatMessage

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1121,7 +1121,13 @@ class VirtualMachine extends EventEmitter {
      */
     setLocale (locale, messages) {
         if (locale !== formatMessage.setup().locale) {
-            formatMessage.setup({locale: locale, translations: {[locale]: messages}});
+            formatMessage.setup({
+                locale: locale,
+                translations: {
+                    [locale]: messages
+                },
+                missingTranslation: 'ignore' // Do not console.warn() missing translations (#2270)
+            });
         }
         return this.extensionManager.refreshBlocks();
     }


### PR DESCRIPTION
### Resolves
Resolves #2270

### Proposed Changes
Use missingTranslation: ignore in formatMessage

### Reason for Changes
To get rid of "translation missing" messages
