### PR TITLE
Pass on event type from CDM

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -601,6 +601,15 @@ class Runtime extends EventEmitter {
     static get PERIPHERAL_LIST_UPDATE () {
         return 'PERIPHERAL_LIST_UPDATE';
     }
+    
+    /**
+     * Event name for when the user picks a bluetooth device to connect to
+     * via Companion Device Manager (CDM)
+     * @const {string}
+     */
+    static get USER_PICKED_PERIPHERAL () {
+        return 'USER_PICKED_PERIPHERAL';
+    }
 
     /**
      * Event name for reporting that a peripheral has connected.

--- a/src/io/ble.js
+++ b/src/io/ble.js
@@ -180,6 +180,16 @@ class BLE extends JSONRPC {
                 window.clearTimeout(this._discoverTimeoutID);
             }
             break;
+        case 'userDidPickPeripheral':
+            this._availablePeripherals[params.peripheralId] = params;
+            this._runtime.emit(
+                this._runtime.constructor.USER_PICKED_PERIPHERAL,
+                this._availablePeripherals
+            );
+            if (this._discoverTimeoutID) {
+                window.clearTimeout(this._discoverTimeoutID);
+            }
+            break;
         case 'characteristicDidChange':
             if (this._characteristicDidChangeCallback) {
                 this._characteristicDidChangeCallback(params.message);

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -127,6 +127,9 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.PERIPHERAL_LIST_UPDATE, info => {
             this.emit(Runtime.PERIPHERAL_LIST_UPDATE, info);
         });
+        this.runtime.on(Runtime.USER_PICKED_PERIPHERAL, info => {
+            this.emit(Runtime.USER_PICKED_PERIPHERAL, info);
+        });
         this.runtime.on(Runtime.PERIPHERAL_CONNECTED, () =>
             this.emit(Runtime.PERIPHERAL_CONNECTED)
         );


### PR DESCRIPTION
### Resolves
Toward fixing LLK/scratch-android#308

### Proposed Changes
Handle a new event type for CDM interface

### Reason for Changes
The GUI list is redundant, so the new event type will indicate that the user doesn't need to pick a device from the list a second time

### Test Coverage
Tested locally
