### PR TITLE
Call into V2SVGAdapter instead of SVGRenderer

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -8,8 +8,7 @@ const loadVector_ = function (costume, runtime, rotationCenter, optVersion) {
         if (optVersion && optVersion === 2 && !runtime.v2SvgAdapter) {
             log.error('No V2 SVG adapter present; SVGs may not render correctly.');
         } else if (optVersion && optVersion === 2 && runtime.v2SvgAdapter) {
-            runtime.v2SvgAdapter.loadString(svgString, true /* fromVersion2 */);
-            svgString = runtime.v2SvgAdapter.toString();
+            svgString = runtime.v2SvgAdapter(svgString);
             // Put back into storage
             const storage = runtime.storage;
             costume.asset.encodeTextData(svgString, storage.DataFormat.SVG, true);

--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -650,7 +650,7 @@ const runBenchmark = function () {
     vm.attachRenderer(renderer);
     const audioEngine = new AudioEngine();
     vm.attachAudioEngine(audioEngine);
-    vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
+    vm.attachV2SVGAdapter(ScratchSVGRenderer.V2SVGAdapter);
     vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
 
     // Feed mouse events as VM I/O events.


### PR DESCRIPTION
## Depends on https://github.com/LLK/scratch-svg-renderer/pull/213 and https://github.com/LLK/scratch-gui/pull/6547

### Resolves

Resolves https://github.com/LLK/scratch-svg-renderer/issues/211

### Proposed Changes

This PR changes the costume loading API to use the new `V2SVGAdapter` API (a function) instead of the `SvgRenderer` API (a class).

### Reason for Changes

By depending only on the parts of the SVG renderer API that are actually used here, this will allow the monolithic `SvgRenderer` class to be removed.

### Test Coverage

Tested manually
