### PR TITLE
Do not try loading unknown extensions automatically

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -4,6 +4,8 @@ const maybeFormatMessage = require('../util/maybe-format-message');
 
 const BlockType = require('./block-type');
 
+let rejectUnofficialExtensions = true;
+
 // These extensions are currently built into the VM repository but should not be loaded at startup.
 // TODO: move these out into a separate repository?
 // TODO: change extension spec so that library info, including extension ID, can be collected through static methods
@@ -153,6 +155,10 @@ class ExtensionManager {
             const serviceName = this._registerInternalExtension(extensionInstance);
             this._loadedExtensions.set(extensionURL, serviceName);
             return Promise.resolve();
+        }
+        
+        if (rejectUnofficialExtensions) {
+            return Promise.reject(new Error('Unofficial extensions not supported here'));
         }
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
This fixes an issue where projects that have experimental extensions will fail to load when run in production scratch. The failure mode is that they just "hang" on the loading screen. Instead, bailing on loading worker extensions (since none are implemented) will result in the project loading actually erroring out, which is handled correctly. Remaining in limbo is the bug. 

This fix was recommended by @cwillisf.

I'll admit I'm not the most familiar with this functionality. It seems like it was designed to support a system we did did not (have not?) used yet. This fix does not finish that functionality, it just adds an explicit switch in the code to make it clear that it is not fully implemented.

/cc @ericrosenbaum 