### PR TITLE
Set responseType explicitly on TTS

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -725,7 +725,8 @@ class Scratch3Text2SpeechBlocks {
         return new Promise(resolve => {
             nets({
                 url: path,
-                timeout: SERVER_TIMEOUT
+                timeout: SERVER_TIMEOUT,
+                responseType: "arraybuffer"
             }, (err, res, body) => {
                 if (err) {
                     log.warn(err);
@@ -740,7 +741,7 @@ class Scratch3Text2SpeechBlocks {
                 // Play the sound
                 const sound = {
                     data: {
-                        buffer: body.buffer
+                        buffer: body
                     }
                 };
                 this.runtime.audioEngine.decodeSoundPlayer(sound).then(soundPlayer => {


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-desktop#157

### Proposed Changes
Set responseType explicitly on TTS extension

### Reason for Changes
responseType was not set, which caused TTS to error in Scratch app env (probably because of dependency mismatch?)