### PR TITLE
Replace nets with Fetch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "immutable": "3.8.1",
     "jszip": "^3.1.5",
     "minilog": "3.1.0",
-    "nets": "3.2.0",
     "scratch-parser": "5.0.0",
     "scratch-sb1-converter": "0.2.7",
     "scratch-translate-extension-languages": "0.0.20191118205314",

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -1,5 +1,4 @@
 const formatMessage = require('format-message');
-const nets = require('nets');
 const languageNames = require('scratch-translate-extension-languages');
 
 const ArgumentType = require('../../extension-support/argument-type');
@@ -8,6 +7,7 @@ const Cast = require('../../util/cast');
 const MathUtil = require('../../util/math-util');
 const Clone = require('../../util/clone');
 const log = require('../../util/log');
+const fetchWithTimeout = require('../../util/fetch-with-timeout');
 
 /**
  * Icon svg to be displayed in the blocks category menu, encoded as a data URI.
@@ -722,46 +722,46 @@ class Scratch3Text2SpeechBlocks {
         path += `&text=${encodeURIComponent(words.substring(0, 128))}`;
 
         // Perform HTTP request to get audio file
-        return new Promise(resolve => {
-            nets({
-                url: path,
-                timeout: SERVER_TIMEOUT
-            }, (err, res, body) => {
-                if (err) {
-                    log.warn(err);
-                    return resolve();
+        return fetchWithTimeout(path, {}, SERVER_TIMEOUT)
+            .then(res => {
+                if (res.status !== 200) {
+                    throw new Error(`HTTP ${res.status} error reaching translation service`);
                 }
 
-                if (res.statusCode !== 200) {
-                    log.warn(res.statusCode);
-                    return resolve();
-                }
-
+                return res.arrayBuffer();
+            })
+            .then(buffer => {
                 // Play the sound
                 const sound = {
                     data: {
-                        buffer: body.buffer
+                        buffer: buffer
                     }
                 };
-                this.runtime.audioEngine.decodeSoundPlayer(sound).then(soundPlayer => {
-                    this._soundPlayers.set(soundPlayer.id, soundPlayer);
+                return this.runtime.audioEngine.decodeSoundPlayer(sound);
+            })
+            .then(soundPlayer => {
+                this._soundPlayers.set(soundPlayer.id, soundPlayer);
 
-                    soundPlayer.setPlaybackRate(playbackRate);
+                soundPlayer.setPlaybackRate(playbackRate);
 
-                    // Increase the volume
-                    const engine = this.runtime.audioEngine;
-                    const chain = engine.createEffectChain();
-                    chain.set('volume', SPEECH_VOLUME);
-                    soundPlayer.connect(chain);
+                // Increase the volume
+                const engine = this.runtime.audioEngine;
+                const chain = engine.createEffectChain();
+                chain.set('volume', SPEECH_VOLUME);
+                soundPlayer.connect(chain);
 
-                    soundPlayer.play();
+                soundPlayer.play();
+                return new Promise(resolve => {
                     soundPlayer.on('stop', () => {
                         this._soundPlayers.delete(soundPlayer.id);
                         resolve();
                     });
                 });
+            })
+            .catch(err => {
+                log.warn(err);
+                return;
             });
-        });
     }
 }
 module.exports = Scratch3Text2SpeechBlocks;

--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -734,7 +734,7 @@ class Scratch3Text2SpeechBlocks {
                 // Play the sound
                 const sound = {
                     data: {
-                        buffer: buffer
+                        buffer
                     }
                 };
                 return this.runtime.audioEngine.decodeSoundPlayer(sound);
@@ -760,7 +760,6 @@ class Scratch3Text2SpeechBlocks {
             })
             .catch(err => {
                 log.warn(err);
-                return;
             });
     }
 }

--- a/src/util/fetch-with-timeout.js
+++ b/src/util/fetch-with-timeout.js
@@ -1,0 +1,28 @@
+/**
+ * Fetch a remote resource like `fetch` does, but with a time limit.
+ * @param {Request|string} resource Remote resource to fetch.
+ * @param {?object} init An options object containing any custom settings that you want to apply to the request.
+ * @param {number} timeout The amount of time before the request is canceled, in milliseconds
+ * @returns {Promise<Response>} The response from the server.
+ */
+const fetchWithTimeout = (resource, init, timeout) => {
+    let timeoutID = null;
+    // Not supported in Safari <11
+    const controller = window.AbortController ? new window.AbortController() : null;
+    const signal = controller ? controller.signal : null;
+    // The fetch call races a timer.
+    return Promise.race([
+        fetch(resource, Object.assign({signal}, init)).then(response => {
+            clearTimeout(timeoutID);
+            return response;
+        }),
+        new Promise((resolve, reject) => {
+            timeoutID = setTimeout(() => {
+                if (controller) controller.abort();
+                reject(new Error(`Fetch timed out after ${timeout} ms`));
+            }, timeout);
+        })
+    ]);
+};
+
+module.exports = fetchWithTimeout;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,6 @@ module.exports = [
             'immutable': true,
             'jszip': true,
             'minilog': true,
-            'nets': true,
             'scratch-parser': true,
             'socket.io-client': true,
             'text-encoding': true


### PR DESCRIPTION
### Resolves

Resolves #2890

### Proposed Changes

This PR removes the `nets` package and replaces calls to it with `fetch` calls.

### Reason for Changes

The `nets` package is unmaintained, and depends on the deprecated `request` package. In addition, as described in https://github.com/LLK/scratch-desktop/issues/157, its behavioral differences between Node and the browser can cause issues.

### Test Coverage

Must be tested manually
