### PR TITLE
use performance.mark to measure deserialize time

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -478,6 +478,9 @@ class VirtualMachine extends EventEmitter {
         // Clear the current runtime
         this.clear();
 
+        if (typeof performance !== 'undefined') {
+            performance.mark('scratch-vm-deserialize-start');
+        }
         const runtime = this.runtime;
         const deserializePromise = function () {
             const projectVersion = projectJSON.projectVersion;
@@ -492,8 +495,14 @@ class VirtualMachine extends EventEmitter {
             return Promise.reject('Unable to verify Scratch Project version.');
         };
         return deserializePromise()
-            .then(({targets, extensions}) =>
-                this.installTargets(targets, extensions, true));
+            .then(({targets, extensions}) => {
+                if (typeof performance !== 'undefined') {
+                    performance.mark('scratch-vm-deserialize-end');
+                    performance.measure('scratch-vm-deserialize',
+                        'scratch-vm-deserialize-start', 'scratch-vm-deserialize-end');
+                }
+                return this.installTargets(targets, extensions, true);
+            });
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

This change uses `performance.mark` and `performance.measure` to record the amount of time spent deserializing a project. These performance entries can be accessed later for reporting, such as in LLK/scratch-gui#6804. If the global `performance` object is not present, this new code does nothing.

### Reason for Changes

This is indirectly in support of some SVG measurement work going on in the scratch-svg-renderer repository. My initial attempt hurt performance pretty badly, so I wanted to make sure that my second attempt didn't have a significant performance impact. The aggregate performance impact is on the SB2 deserialization process: the call chain to the SVG load & measure code is:
`sb2import` => `parseScratchAssets` => `loadCostume` => `loadCostumeFromAsset` => `loadVector_` => `scratch-svg-renderer`. Note that `sb2import` is renamed to `sb2.deserialize` in `virtual-machine.js`.

### Test Coverage

See LLK/scratch-gui#6804
