### PR TITLE
Do not translate strings containing only digits

### DIFF
--- a/src/extensions/scratch3_translate/index.js
+++ b/src/extensions/scratch3_translate/index.js
@@ -247,6 +247,10 @@ class Scratch3TranslateBlocks {
      * @return {Promise} - a promise that resolves after the response from the translate server.
      */
     getTranslate (args) {
+        // If the text contains only digits 0-9 and nothing else, return it without
+        // making a request.
+        if (/^\d+$/.test(args.WORDS)) return Promise.resolve(args.WORDS);
+
         // Don't remake the request if we already have the value.
         if (this._lastTextTranslated === args.WORDS &&
             this._lastLangTranslated === args.LANGUAGE) {


### PR DESCRIPTION
In the translate extension, before making a request, check if the input string contains only digits 0-9. If it does, just return it without making a request.

We don't currently have a unit test file for the translate extension. I couldn't quickly add one without restructuring the extension a little bit (we use the window property `navigator` to get the browser language setting, which would need to be stubbed out).