### PR TITLE
Simplify RuntimeScriptCache

### DIFF
--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -30,8 +30,7 @@ class RuntimeScriptCache {
         const fields = container.getFields(block);
 
         /**
-         * Formatted fields or fields of input blocks ready for comparison in
-         * runtime.
+         * Formatted fields ready for comparison in runtime.
          *
          * This is a clone of parts of the targeted blocks. Changes to these
          * clones are limited to copies under RuntimeScriptCache and will not
@@ -41,16 +40,6 @@ class RuntimeScriptCache {
          * @type {object}
          */
         this.fieldsOfInputs = Object.assign({}, fields);
-        if (Object.keys(fields).length === 0) {
-            const inputs = container.getInputs(block);
-            for (const input in inputs) {
-                if (!inputs.hasOwnProperty(input)) continue;
-                const id = inputs[input].block;
-                const inputBlock = container.getBlock(id);
-                const inputFields = container.getFields(inputBlock);
-                Object.assign(this.fieldsOfInputs, inputFields);
-            }
-        }
         for (const key in this.fieldsOfInputs) {
             const field = this.fieldsOfInputs[key] = Object.assign({}, this.fieldsOfInputs[key]);
             if (field.value.toUpperCase) {

--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -26,9 +26,6 @@ class RuntimeScriptCache {
          */
         this.blockId = blockId;
 
-        const block = container.getBlock(blockId);
-        const fields = container.getFields(block);
-
         /**
          * Formatted fields ready for comparison in runtime.
          *
@@ -39,12 +36,19 @@ class RuntimeScriptCache {
          * values will be compared later by the VM.
          * @type {object}
          */
-        this.fields = Object.assign({}, fields);
-        for (const key in this.fields) {
-            const field = this.fields[key] = Object.assign({}, this.fields[key]);
-            if (field.value.toUpperCase) {
+        this.fields = {};
+
+        const block = container.getBlock(blockId);
+        const fields = container.getFields(block);
+
+        for (const key in fields) {
+            // Clone the field
+            const field = Object.assign({}, fields[key]);
+            // Uppercase the field value (if it exists)
+            if (typeof field.value === 'string') {
                 field.value = field.value.toUpperCase();
             }
+            this.fields[key] = field;
         }
     }
 }

--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -39,9 +39,9 @@ class RuntimeScriptCache {
          * values will be compared later by the VM.
          * @type {object}
          */
-        this.fieldsOfInputs = Object.assign({}, fields);
-        for (const key in this.fieldsOfInputs) {
-            const field = this.fieldsOfInputs[key] = Object.assign({}, this.fieldsOfInputs[key]);
+        this.fields = Object.assign({}, fields);
+        for (const key in this.fields) {
+            const field = this.fields[key] = Object.assign({}, this.fields[key]);
             if (field.value.toUpperCase) {
                 field.value = field.value.toUpperCase();
             }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1792,7 +1792,7 @@ class Runtime extends EventEmitter {
         this.allScriptsByOpcodeDo(requestedHatOpcode, (script, target) => {
             const {
                 blockId: topBlockId,
-                fieldsOfInputs: hatFields
+                fields: hatFields
             } = script;
 
             // Match any requested fields.


### PR DESCRIPTION
### Resolves

Resolves #3031

### Proposed Changes

This PR simplifies the logic in `RuntimeScriptCache`, removing a code path that copied the values of hat blocks' droppable inputs into the cache.

### Reason for Changes

Hat blocks which use droppable inputs utilize a different code path which does not interact with the `RuntimeScriptCache`. The removed code path was incomplete and would never have properly worked.

I go into more detail in my commit message:

> The RuntimeScriptCache is used by Runtime.startHats to filter only the
> hat blocks matching the specified opcode and *fields*, aka non-droppable
> menus on blocks
> (e.g. 'event_whenkeypressed', where {'KEY': 'SPACE'}).
> Each RuntimeScriptCache object holds data related to one hat block: its
> opcode and uppercase versions of all its fields (so that field matching
> is case-insensitive: you can broadcast 'MeSsAgE1' and 'when I receive
> message1' will still fire).
> 
> Previously, this cache also held droppable menus, aka *inputs*. These
> are actually blocks in their own right, known as "shadow blocks". They
> are essentially reporter blocks that store their reported value in a
> specific field. The RuntimeScriptCache was copying this value out of the
> field and into the `fieldsOfInputs` property.
> 
> However, this broke if you dropped a different reporter block into that
> input--you'd have no way of knowing what it would evaluate to. Thus, all
> hat blocks which use droppable inputs are "edge-activated"--they are
> evaluated once per frame by the runtime as opposed to being activated by
> the `startHats` function. Thus, storing inputs is not only unnecessary
> but would never have worked anyway.

### Test Coverage

Tested manually
