### PR TITLE
Remove dead code path from BlocksExecuteCache.getCached

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -1234,23 +1234,13 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
     const block = blocks.getBlock(blockId);
     if (typeof block === 'undefined') return null;
 
-    if (typeof CacheType === 'undefined') {
-        cached = {
-            id: blockId,
-            opcode: blocks.getOpcode(block),
-            fields: blocks.getFields(block),
-            inputs: blocks.getInputs(block),
-            mutation: blocks.getMutation(block)
-        };
-    } else {
-        cached = new CacheType(blocks, {
-            id: blockId,
-            opcode: blocks.getOpcode(block),
-            fields: blocks.getFields(block),
-            inputs: blocks.getInputs(block),
-            mutation: blocks.getMutation(block)
-        });
-    }
+    cached = new CacheType(blocks, {
+        id: blockId,
+        opcode: blocks.getOpcode(block),
+        fields: blocks.getFields(block),
+        inputs: blocks.getInputs(block),
+        mutation: blocks.getMutation(block)
+    });
 
     blocks._cache._executeCached[blockId] = cached;
     return cached;


### PR DESCRIPTION
### Resolves

Resolves #3032

### Proposed Changes

This PR removes the code path from `BlocksExecuteCache.getCached` that handles the case where the `CacheType` parameter is not passed.

### Reason for Changes

All `BlocksExecuteCache.getCached` call sites pass in the `CacheType` parameter, making said code path unnecessary.

### Test Coverage

Tested manually
