### PR TITLE
Remove BlockCached cruft

### DIFF
--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -30,8 +30,7 @@ class RuntimeScriptCache {
         const fields = container.getFields(block);
 
         /**
-         * Formatted fields or fields of input blocks ready for comparison in
-         * runtime.
+         * Formatted fields ready for comparison in runtime.
          *
          * This is a clone of parts of the targeted blocks. Changes to these
          * clones are limited to copies under RuntimeScriptCache and will not
@@ -41,16 +40,6 @@ class RuntimeScriptCache {
          * @type {object}
          */
         this.fieldsOfInputs = Object.assign({}, fields);
-        if (Object.keys(fields).length === 0) {
-            const inputs = container.getInputs(block);
-            for (const input in inputs) {
-                if (!inputs.hasOwnProperty(input)) continue;
-                const id = inputs[input].block;
-                const inputBlock = container.getBlock(id);
-                const inputFields = container.getFields(inputBlock);
-                Object.assign(this.fieldsOfInputs, inputFields);
-            }
-        }
         for (const key in this.fieldsOfInputs) {
             const field = this.fieldsOfInputs[key] = Object.assign({}, this.fieldsOfInputs[key]);
             if (field.value.toUpperCase) {

--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -26,9 +26,6 @@ class RuntimeScriptCache {
          */
         this.blockId = blockId;
 
-        const block = container.getBlock(blockId);
-        const fields = container.getFields(block);
-
         /**
          * Formatted fields ready for comparison in runtime.
          *
@@ -39,12 +36,19 @@ class RuntimeScriptCache {
          * values will be compared later by the VM.
          * @type {object}
          */
-        this.fields = Object.assign({}, fields);
-        for (const key in this.fields) {
-            const field = this.fields[key] = Object.assign({}, this.fields[key]);
-            if (field.value.toUpperCase) {
+        this.fields = {};
+
+        const block = container.getBlock(blockId);
+        const fields = container.getFields(block);
+
+        for (const key in fields) {
+            // Clone the field
+            const field = Object.assign({}, fields[key]);
+            // Uppercase the field value (if it exists)
+            if (typeof field.value === 'string') {
                 field.value = field.value.toUpperCase();
             }
+            this.fields[key] = field;
         }
     }
 }

--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -39,9 +39,9 @@ class RuntimeScriptCache {
          * values will be compared later by the VM.
          * @type {object}
          */
-        this.fieldsOfInputs = Object.assign({}, fields);
-        for (const key in this.fieldsOfInputs) {
-            const field = this.fieldsOfInputs[key] = Object.assign({}, this.fieldsOfInputs[key]);
+        this.fields = Object.assign({}, fields);
+        for (const key in this.fields) {
+            const field = this.fields[key] = Object.assign({}, this.fields[key]);
             if (field.value.toUpperCase) {
                 field.value = field.value.toUpperCase();
             }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -1234,23 +1234,13 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
     const block = blocks.getBlock(blockId);
     if (typeof block === 'undefined') return null;
 
-    if (typeof CacheType === 'undefined') {
-        cached = {
-            id: blockId,
-            opcode: blocks.getOpcode(block),
-            fields: blocks.getFields(block),
-            inputs: blocks.getInputs(block),
-            mutation: blocks.getMutation(block)
-        };
-    } else {
-        cached = new CacheType(blocks, {
-            id: blockId,
-            opcode: blocks.getOpcode(block),
-            fields: blocks.getFields(block),
-            inputs: blocks.getInputs(block),
-            mutation: blocks.getMutation(block)
-        });
-    }
+    cached = new CacheType(blocks, {
+        id: blockId,
+        opcode: blocks.getOpcode(block),
+        fields: blocks.getFields(block),
+        inputs: blocks.getInputs(block),
+        mutation: blocks.getMutation(block)
+    });
 
     blocks._cache._executeCached[blockId] = cached;
     return cached;

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -48,11 +48,6 @@ class Blocks {
         Object.defineProperty(this, '_cache', {writable: true, enumerable: false});
         this._cache = {
             /**
-             * Cache block inputs by block id
-             * @type {object.<string, !Array.<object>>}
-             */
-            inputs: {},
-            /**
              * Cache procedure Param Names by block id
              * @type {object.<string, ?Array.<string>>}
              */
@@ -178,12 +173,8 @@ class Blocks {
      */
     getNonBranchInputs (block) {
         if (typeof block === 'undefined') return null;
-        let inputs = this._cache.inputs[block.id];
-        if (typeof inputs !== 'undefined') {
-            return inputs;
-        }
 
-        inputs = {};
+        const inputs = {};
         for (const input in block.inputs) {
             // Ignore blocks prefixed with branch prefix.
             if (input.substring(0, Blocks.BRANCH_INPUT_PREFIX.length) !==
@@ -192,7 +183,6 @@ class Blocks {
             }
         }
 
-        this._cache.inputs[block.id] = inputs;
         return inputs;
     }
 
@@ -511,7 +501,6 @@ class Blocks {
      * Reset all runtime caches.
      */
     resetCache () {
-        this._cache.inputs = {};
         this._cache.procedureParamNames = {};
         this._cache.procedureDefinitions = {};
         this._cache._executeCached = {};

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -176,7 +176,7 @@ class Blocks {
      * @param {?object} block the block to query.
      * @return {?Array.<object>} All non-branch inputs and their associated blocks.
      */
-    getInputs (block) {
+    getNonBranchInputs (block) {
         if (typeof block === 'undefined') return null;
         let inputs = this._cache.inputs[block.id];
         if (typeof inputs !== 'undefined') {
@@ -1238,7 +1238,7 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
         id: blockId,
         opcode: blocks.getOpcode(block),
         fields: blocks.getFields(block),
-        inputs: blocks.getInputs(block),
+        inputs: blocks.getNonBranchInputs(block),
         mutation: blocks.getMutation(block)
     });
 

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -1223,13 +1223,7 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
     const block = blocks.getBlock(blockId);
     if (typeof block === 'undefined') return null;
 
-    cached = new CacheType(blocks, {
-        id: blockId,
-        opcode: blocks.getOpcode(block),
-        fields: blocks.getFields(block),
-        inputs: blocks.getNonBranchInputs(block),
-        mutation: blocks.getMutation(block)
-    });
+    cached = new CacheType(blocks, block);
 
     blocks._cache._executeCached[blockId] = cached;
     return cached;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -174,12 +174,6 @@ class BlockCached {
         this.opcode = cached.opcode;
 
         /**
-         * Original block object containing argument values for executable inputs.
-         * @type {object}
-         */
-        this.inputs = cached.inputs;
-
-        /**
          * The profiler the block is configured with.
          * @type {?Profiler}
          */
@@ -216,12 +210,6 @@ class BlockCached {
         this._shadowValue = null;
 
         /**
-         * A copy of the block's inputs that may be modified.
-         * @type {object}
-         */
-        this._inputs = Object.assign({}, this.inputs);
-
-        /**
          * An arguments object for block implementations. All executions of this
          * specific block will use this objecct.
          * @type {object}
@@ -255,8 +243,7 @@ class BlockCached {
 
         const {runtime} = blockUtility.sequencer;
 
-        const {opcode, inputs} = this;
-        const {fields} = cached;
+        const {opcode, inputs, fields} = cached;
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);
@@ -288,9 +275,9 @@ class BlockCached {
         }
 
         // Remove custom_block. It is not part of block execution.
-        delete this._inputs.custom_block;
+        delete inputs.custom_block;
 
-        if ('BROADCAST_INPUT' in this._inputs) {
+        if ('BROADCAST_INPUT' in inputs) {
             // BROADCAST_INPUT is called BROADCAST_OPTION in the args and is an
             // object with an unchanging shape.
             this._argValues.BROADCAST_OPTION = {
@@ -300,7 +287,7 @@ class BlockCached {
 
             // We can go ahead and compute BROADCAST_INPUT if it is a shadow
             // value.
-            const broadcastInput = this._inputs.BROADCAST_INPUT;
+            const broadcastInput = inputs.BROADCAST_INPUT;
             if (broadcastInput.block === broadcastInput.shadow) {
                 // Shadow dropdown menu is being used.
                 // Get the appropriate information out of it.
@@ -311,16 +298,16 @@ class BlockCached {
 
                 // Evaluating BROADCAST_INPUT here we do not need to do so
                 // later.
-                delete this._inputs.BROADCAST_INPUT;
+                delete inputs.BROADCAST_INPUT;
             }
         }
 
         // Cache all input children blocks in the operation lists. The
         // operations can later be run in the order they appear in correctly
         // executing the operations quickly in a flat loop instead of needing to
-        // recursivly iterate them.
-        for (const inputName in this._inputs) {
-            const input = this._inputs[inputName];
+        // recursively iterate them.
+        for (const inputName in inputs) {
+            const input = inputs[inputName];
             if (input.block) {
                 const inputCached = BlocksExecuteCache.getCached(blockContainer, input.block, BlockCached);
 

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -216,12 +216,6 @@ class BlockCached {
         this._blockFunction = null;
 
         /**
-         * Is the block function defined for this opcode?
-         * @type {boolean}
-         */
-        this._definedBlockFunction = false;
-
-        /**
          * Is this block a block with no function but a static value to return.
          * @type {boolean}
          */
@@ -278,7 +272,6 @@ class BlockCached {
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);
         this._blockFunction = runtime.getOpcodeFunction(opcode);
-        this._definedBlockFunction = typeof this._blockFunction !== 'undefined';
 
         // Store the current shadow value if there is a shadow value.
         const fieldKeys = Object.keys(fields);
@@ -360,7 +353,7 @@ class BlockCached {
 
         // The final operation is this block itself. At the top most block is a
         // command block or a block that is being run as a monitor.
-        if (this._definedBlockFunction) {
+        if (typeof this._blockFunction !== 'undefined') {
             this._ops.push(this);
         }
     }

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -234,12 +234,6 @@ class BlockCached {
         this._shadowValue = null;
 
         /**
-         * A copy of the block's fields that may be modified.
-         * @type {object}
-         */
-        this._fields = Object.assign({}, this.fields);
-
-        /**
          * A copy of the block's inputs that may be modified.
          * @type {object}
          */

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -157,21 +157,21 @@ const handlePromise = (primitiveReportedValue, sequencer, thread, blockCached, l
  * in the editor.
  *
  * @param {Blocks} blockContainer the related Blocks instance
- * @param {object} cached default set of cached values
+ * @param {object} block the block information to cache
  */
 class BlockCached {
-    constructor (blockContainer, cached) {
+    constructor (blockContainer, block) {
         /**
          * Block id in its parent set of blocks.
          * @type {string}
          */
-        this.id = cached.id;
+        this.id = block.id;
 
         /**
          * Block operation code for this block.
          * @type {string}
          */
-        this.opcode = cached.opcode;
+        this.opcode = block.opcode;
 
         /**
          * The profiler the block is configured with.
@@ -215,7 +215,7 @@ class BlockCached {
          * @type {object}
          */
         this._argValues = {
-            mutation: cached.mutation
+            mutation: block.mutation
         };
 
         /**
@@ -243,7 +243,10 @@ class BlockCached {
 
         const {runtime} = blockUtility.sequencer;
 
-        const {opcode, inputs, fields} = cached;
+        const {opcode, fields} = block;
+        // NOTE: because we modify `inputs` in-place, this relies on getNonBranchInputs returning a new object each
+        // time it's called.
+        const inputs = blockContainer.getNonBranchInputs(block);
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -174,22 +174,10 @@ class BlockCached {
         this.opcode = cached.opcode;
 
         /**
-         * Original block object containing argument values for static fields.
-         * @type {object}
-         */
-        this.fields = cached.fields;
-
-        /**
          * Original block object containing argument values for executable inputs.
          * @type {object}
          */
         this.inputs = cached.inputs;
-
-        /**
-         * Procedure mutation.
-         * @type {?object}
-         */
-        this.mutation = cached.mutation;
 
         /**
          * The profiler the block is configured with.
@@ -239,7 +227,7 @@ class BlockCached {
          * @type {object}
          */
         this._argValues = {
-            mutation: this.mutation
+            mutation: cached.mutation
         };
 
         /**
@@ -267,7 +255,8 @@ class BlockCached {
 
         const {runtime} = blockUtility.sequencer;
 
-        const {opcode, fields, inputs} = this;
+        const {opcode, inputs} = this;
+        const {fields} = cached;
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -201,7 +201,7 @@ class BlockCached {
          * Is this block a block with no function but a static value to return.
          * @type {boolean}
          */
-        this._isShadowBlock = false;
+        this._isShadowBlock = block.shadow;
 
         /**
          * The static value of this block if it is a shadow block.
@@ -244,9 +244,6 @@ class BlockCached {
         const {runtime} = blockUtility.sequencer;
 
         const {opcode, fields} = block;
-        // NOTE: because we modify `inputs` in-place, this relies on getNonBranchInputs returning a new object each
-        // time it's called.
-        const inputs = blockContainer.getNonBranchInputs(block);
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);
@@ -254,11 +251,6 @@ class BlockCached {
 
         // Store the current shadow value if there is a shadow value.
         const fieldKeys = Object.keys(fields);
-        this._isShadowBlock = (
-            !this._definedBlockFunction &&
-            fieldKeys.length === 1 &&
-            Object.keys(inputs).length === 0
-        );
         this._shadowValue = this._isShadowBlock && fields[fieldKeys[0]].value;
 
         // Store the static fields onto _argValues.
@@ -277,6 +269,9 @@ class BlockCached {
             }
         }
 
+        // NOTE: because we modify `inputs` in-place, this relies on getNonBranchInputs returning a new object each
+        // time it's called.
+        const inputs = blockContainer.getNonBranchInputs(block);
         // Remove custom_block. It is not part of block execution.
         delete inputs.custom_block;
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1792,7 +1792,7 @@ class Runtime extends EventEmitter {
         this.allScriptsByOpcodeDo(requestedHatOpcode, (script, target) => {
             const {
                 blockId: topBlockId,
-                fieldsOfInputs: hatFields
+                fields: hatFields
             } = script;
 
             // Match any requested fields.


### PR DESCRIPTION
## Depends on #2926 and #2927

### Resolves

Resolves #3033
Resolves #3034

### Proposed Changes

This PR cleans out a bunch of cruft from `BlockCached`. This PR can be broadly split into two parts:
- Part 1 removes member variables that were never read from/only used inside the constructor
- Part 2 changes `BlocksExecuteCache.getCached` to pass the `BlockCached` constructor the block directly, instead of constructing an intermediate object and passing that in

I'd recommend going over this one commit at a time and stopping and letting me know if you see a change that you think is too large in scope.

### Reason for Changes

These changes make the codebase easier to understand (relatively speaking, of course).

### Test Coverage

All existing tests pass