### PR TITLE
Replace `new Buffer()` with `Buffer.from()`

### DIFF
--- a/test/fixtures/readProjectFile.js
+++ b/test/fixtures/readProjectFile.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 module.exports = {
     readFileToBuffer: function (path) {
-        return new Buffer(fs.readFileSync(path));
+        return Buffer.from(fs.readFileSync(path));
     },
     extractProjectJson: function (path) {
         const zip = new AdmZip(path);

--- a/test/integration/offline-custom-assets.js
+++ b/test/integration/offline-custom-assets.js
@@ -13,7 +13,7 @@ const VirtualMachine = require('../../src/index');
 
 const projectUri = path.resolve(__dirname, '../fixtures/offline-custom-assets.sb2');
 const projectZip = AdmZip(projectUri);
-const project = new Buffer(fs.readFileSync(projectUri));
+const project = Buffer.from(fs.readFileSync(projectUri));
 // Custom costume from sb2 file (which was downloaded from offline editor)
 // This sound should not be available on our servers
 const costume = projectZip.readFile('1.svg');


### PR DESCRIPTION
### Resolves

Part of #2935

### Proposed Changes

This PR replaces the two usages of `new Buffer(...)` with `Buffer.from(...)`, which should function identically.

### Reason for Changes

The `Buffer` constructor has long been deprecated in Node due to security concerns, and outputs an annoying message to the console every time it is used.

Side note: `fs.readFileSync` appears to always return a `Buffer` anyway, so I'm not really sure why it was ever wrapped in `new Buffer`. In the interest of not accidentally messing anything up, I'm applying the minimum changes necessary.

### Test Coverage

Yes