### PR TITLE
Replace addWebSource with addWebStore in tests

### DIFF
--- a/src/playground/benchmark.js
+++ b/src/playground/benchmark.js
@@ -592,8 +592,8 @@ const runBenchmark = function () {
 
     const storage = new ScratchStorage();
     const AssetType = storage.AssetType;
-    storage.addWebSource([AssetType.Project], getProjectUrl);
-    storage.addWebSource([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], getAssetUrl);
+    storage.addWebStore([AssetType.Project], getProjectUrl);
+    storage.addWebStore([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], getAssetUrl);
     vm.attachStorage(storage);
 
     new LoadingProgress(progress => {

--- a/test/fixtures/make-test-storage.js
+++ b/test/fixtures/make-test-storage.js
@@ -39,8 +39,8 @@ const getAssetUrl = function (asset) {
 const makeTestStorage = function () {
     const storage = new ScratchStorage();
     const AssetType = storage.AssetType;
-    storage.addWebSource([AssetType.Project], getProjectUrl);
-    storage.addWebSource([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], getAssetUrl);
+    storage.addWebStore([AssetType.Project], getProjectUrl);
+    storage.addWebStore([AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound], getAssetUrl);
     return storage;
 };
 


### PR DESCRIPTION
### Resolves

Part of #2935

### Proposed Changes

This PR replaces calls to `storage.addWebSource` with `Storage.addWebStore` in tests.

### Reason for Changes

`addWebSource` was [deprecated in favor of `addWebStore`](https://github.com/LLK/scratch-storage/commit/042300ad262f17029ae3c0d5093ca16729e00f48), and now logs an annoying message to the console every time it is called.

The two methods do the exact same thing (`addWebSource` calls `addWebStore` internally, and they have the same call signature), so swapping out the method name is all that is needed here.

### Test Coverage

Yes
