### PR TITLE
Fix missing-translation extension warnings

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1120,7 +1120,10 @@ class VirtualMachine extends EventEmitter {
      *     updated for a new locale (or empty if locale hasn't changed.)
      */
     setLocale (locale, messages) {
-        if (locale !== formatMessage.setup().locale) {
+        const {locale: currentLocale, translations} = formatMessage.setup();
+        // The initial locale is English, but at first it does not contain any messages.  When we're first passed
+        // English messages, make sure we re-setup with them by checking if the messages have changed.
+        if (locale !== currentLocale || translations[locale] !== messages) {
             formatMessage.setup({locale: locale, translations: {[locale]: messages}});
         }
         return this.extensionManager.refreshBlocks();


### PR DESCRIPTION
### Resolves

Resolves #2270 (in the browser, but not when running tests)

### Proposed Changes

This PR changes `setLocale` to rerun `formatMessage.setup` not only when the locale changes, but also when the messages change even if the locale is the same.

### Reason for Changes

When the VM is first initialized, the default locale is `"en"`. However, there are no translated messages.

Later, `scratch-gui` calls `setLocale`, which passes in the translated messages. Unfortunately, that method would previously return early if the new locale was the same as the old one, even if new translations were passed in that were not previously present. This meant that if your locale was `"en"`, `setLocale` would see that the new locale is the same as the old one, and new translations would never get passed in until you switched to another language and back.

By checking whether the locale *or* set of translated messages differ, we can ensure that there are no missing translations (at least, when `scratch-gui` is there to pass in the translated messages for English).

### Test Coverage

N/A. I did manually verify that a shallow equality check on `messages` is OK (i.e. when the GUI passes in `messages`, it will always pass in the same object for a given locale).