### PR TITLE
Remove Thread.waitingReporter

### DIFF
--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -262,12 +262,6 @@ class Sequencer {
                     // Don't go to the next block for this level of the stack,
                     // since loops need to be re-executed.
                     continue;
-
-                } else if (stackFrame.waitingReporter) {
-                    // This level of the stack was waiting for a value.
-                    // This means a reporter has just returned - so don't go
-                    // to the next block for this level of the stack.
-                    return;
                 }
                 // Get next block of existing block on the stack.
                 thread.goToNextBlock();

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -45,12 +45,6 @@ class _StackFrame {
         this.reported = null;
 
         /**
-         * Name of waiting reporter.
-         * @type {string}
-         */
-        this.waitingReporter = null;
-
-        /**
          * Procedure parameters.
          * @type {Object}
          */
@@ -74,7 +68,6 @@ class _StackFrame {
         this.warpMode = false;
         this.justReported = null;
         this.reported = null;
-        this.waitingReporter = null;
         this.params = null;
         this.executionContext = null;
 


### PR DESCRIPTION
### Resolves

Resolves #2596

### Proposed Changes

This PR removes the `waitingReporter` property of the `Thread` class.

### Reason for Changes

`waitingReporter` is never set to anything other than `null`, and the code path that used it was only taken if it was not `null`. As such, this makes the codebase clearer and easier to understand.

### Test Coverage

N/A
