### PR TITLE
Thread always done redo

### DIFF
--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -30,8 +30,7 @@ class RuntimeScriptCache {
         const fields = container.getFields(block);
 
         /**
-         * Formatted fields or fields of input blocks ready for comparison in
-         * runtime.
+         * Formatted fields ready for comparison in runtime.
          *
          * This is a clone of parts of the targeted blocks. Changes to these
          * clones are limited to copies under RuntimeScriptCache and will not
@@ -41,16 +40,6 @@ class RuntimeScriptCache {
          * @type {object}
          */
         this.fieldsOfInputs = Object.assign({}, fields);
-        if (Object.keys(fields).length === 0) {
-            const inputs = container.getInputs(block);
-            for (const input in inputs) {
-                if (!inputs.hasOwnProperty(input)) continue;
-                const id = inputs[input].block;
-                const inputBlock = container.getBlock(id);
-                const inputFields = container.getFields(inputBlock);
-                Object.assign(this.fieldsOfInputs, inputFields);
-            }
-        }
         for (const key in this.fieldsOfInputs) {
             const field = this.fieldsOfInputs[key] = Object.assign({}, this.fieldsOfInputs[key]);
             if (field.value.toUpperCase) {

--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -26,9 +26,6 @@ class RuntimeScriptCache {
          */
         this.blockId = blockId;
 
-        const block = container.getBlock(blockId);
-        const fields = container.getFields(block);
-
         /**
          * Formatted fields ready for comparison in runtime.
          *
@@ -39,12 +36,19 @@ class RuntimeScriptCache {
          * values will be compared later by the VM.
          * @type {object}
          */
-        this.fields = Object.assign({}, fields);
-        for (const key in this.fields) {
-            const field = this.fields[key] = Object.assign({}, this.fields[key]);
-            if (field.value.toUpperCase) {
+        this.fields = {};
+
+        const block = container.getBlock(blockId);
+        const fields = container.getFields(block);
+
+        for (const key in fields) {
+            // Clone the field
+            const field = Object.assign({}, fields[key]);
+            // Uppercase the field value (if it exists)
+            if (typeof field.value === 'string') {
                 field.value = field.value.toUpperCase();
             }
+            this.fields[key] = field;
         }
     }
 }

--- a/src/engine/blocks-runtime-cache.js
+++ b/src/engine/blocks-runtime-cache.js
@@ -39,9 +39,9 @@ class RuntimeScriptCache {
          * values will be compared later by the VM.
          * @type {object}
          */
-        this.fieldsOfInputs = Object.assign({}, fields);
-        for (const key in this.fieldsOfInputs) {
-            const field = this.fieldsOfInputs[key] = Object.assign({}, this.fieldsOfInputs[key]);
+        this.fields = Object.assign({}, fields);
+        for (const key in this.fields) {
+            const field = this.fields[key] = Object.assign({}, this.fields[key]);
             if (field.value.toUpperCase) {
                 field.value = field.value.toUpperCase();
             }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -1234,23 +1234,13 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
     const block = blocks.getBlock(blockId);
     if (typeof block === 'undefined') return null;
 
-    if (typeof CacheType === 'undefined') {
-        cached = {
-            id: blockId,
-            opcode: blocks.getOpcode(block),
-            fields: blocks.getFields(block),
-            inputs: blocks.getInputs(block),
-            mutation: blocks.getMutation(block)
-        };
-    } else {
-        cached = new CacheType(blocks, {
-            id: blockId,
-            opcode: blocks.getOpcode(block),
-            fields: blocks.getFields(block),
-            inputs: blocks.getInputs(block),
-            mutation: blocks.getMutation(block)
-        });
-    }
+    cached = new CacheType(blocks, {
+        id: blockId,
+        opcode: blocks.getOpcode(block),
+        fields: blocks.getFields(block),
+        inputs: blocks.getInputs(block),
+        mutation: blocks.getMutation(block)
+    });
 
     blocks._cache._executeCached[blockId] = cached;
     return cached;

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -48,11 +48,6 @@ class Blocks {
         Object.defineProperty(this, '_cache', {writable: true, enumerable: false});
         this._cache = {
             /**
-             * Cache block inputs by block id
-             * @type {object.<string, !Array.<object>>}
-             */
-            inputs: {},
-            /**
              * Cache procedure Param Names by block id
              * @type {object.<string, ?Array.<string>>}
              */
@@ -178,12 +173,8 @@ class Blocks {
      */
     getNonBranchInputs (block) {
         if (typeof block === 'undefined') return null;
-        let inputs = this._cache.inputs[block.id];
-        if (typeof inputs !== 'undefined') {
-            return inputs;
-        }
 
-        inputs = {};
+        const inputs = {};
         for (const input in block.inputs) {
             // Ignore blocks prefixed with branch prefix.
             if (input.substring(0, Blocks.BRANCH_INPUT_PREFIX.length) !==
@@ -192,7 +183,6 @@ class Blocks {
             }
         }
 
-        this._cache.inputs[block.id] = inputs;
         return inputs;
     }
 
@@ -511,7 +501,6 @@ class Blocks {
      * Reset all runtime caches.
      */
     resetCache () {
-        this._cache.inputs = {};
         this._cache.procedureParamNames = {};
         this._cache.procedureDefinitions = {};
         this._cache._executeCached = {};

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -176,7 +176,7 @@ class Blocks {
      * @param {?object} block the block to query.
      * @return {?Array.<object>} All non-branch inputs and their associated blocks.
      */
-    getInputs (block) {
+    getNonBranchInputs (block) {
         if (typeof block === 'undefined') return null;
         let inputs = this._cache.inputs[block.id];
         if (typeof inputs !== 'undefined') {
@@ -1238,7 +1238,7 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
         id: blockId,
         opcode: blocks.getOpcode(block),
         fields: blocks.getFields(block),
-        inputs: blocks.getInputs(block),
+        inputs: blocks.getNonBranchInputs(block),
         mutation: blocks.getMutation(block)
     });
 

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -1223,13 +1223,7 @@ BlocksExecuteCache.getCached = function (blocks, blockId, CacheType) {
     const block = blocks.getBlock(blockId);
     if (typeof block === 'undefined') return null;
 
-    cached = new CacheType(blocks, {
-        id: blockId,
-        opcode: blocks.getOpcode(block),
-        fields: blocks.getFields(block),
-        inputs: blocks.getNonBranchInputs(block),
-        mutation: blocks.getMutation(block)
-    });
+    cached = new CacheType(blocks, block);
 
     blocks._cache._executeCached[blockId] = cached;
     return cached;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -174,12 +174,6 @@ class BlockCached {
         this.opcode = cached.opcode;
 
         /**
-         * Original block object containing argument values for executable inputs.
-         * @type {object}
-         */
-        this.inputs = cached.inputs;
-
-        /**
          * The profiler the block is configured with.
          * @type {?Profiler}
          */
@@ -216,12 +210,6 @@ class BlockCached {
         this._shadowValue = null;
 
         /**
-         * A copy of the block's inputs that may be modified.
-         * @type {object}
-         */
-        this._inputs = Object.assign({}, this.inputs);
-
-        /**
          * An arguments object for block implementations. All executions of this
          * specific block will use this objecct.
          * @type {object}
@@ -255,8 +243,7 @@ class BlockCached {
 
         const {runtime} = blockUtility.sequencer;
 
-        const {opcode, inputs} = this;
-        const {fields} = cached;
+        const {opcode, inputs, fields} = cached;
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);
@@ -288,9 +275,9 @@ class BlockCached {
         }
 
         // Remove custom_block. It is not part of block execution.
-        delete this._inputs.custom_block;
+        delete inputs.custom_block;
 
-        if ('BROADCAST_INPUT' in this._inputs) {
+        if ('BROADCAST_INPUT' in inputs) {
             // BROADCAST_INPUT is called BROADCAST_OPTION in the args and is an
             // object with an unchanging shape.
             this._argValues.BROADCAST_OPTION = {
@@ -300,7 +287,7 @@ class BlockCached {
 
             // We can go ahead and compute BROADCAST_INPUT if it is a shadow
             // value.
-            const broadcastInput = this._inputs.BROADCAST_INPUT;
+            const broadcastInput = inputs.BROADCAST_INPUT;
             if (broadcastInput.block === broadcastInput.shadow) {
                 // Shadow dropdown menu is being used.
                 // Get the appropriate information out of it.
@@ -311,16 +298,16 @@ class BlockCached {
 
                 // Evaluating BROADCAST_INPUT here we do not need to do so
                 // later.
-                delete this._inputs.BROADCAST_INPUT;
+                delete inputs.BROADCAST_INPUT;
             }
         }
 
         // Cache all input children blocks in the operation lists. The
         // operations can later be run in the order they appear in correctly
         // executing the operations quickly in a flat loop instead of needing to
-        // recursivly iterate them.
-        for (const inputName in this._inputs) {
-            const input = this._inputs[inputName];
+        // recursively iterate them.
+        for (const inputName in inputs) {
+            const input = inputs[inputName];
             if (input.block) {
                 const inputCached = BlocksExecuteCache.getCached(blockContainer, input.block, BlockCached);
 

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -111,30 +111,10 @@ const handlePromise = (primitiveReportedValue, sequencer, thread, blockCached, l
     }
     // Promise handlers
     primitiveReportedValue.then(resolvedValue => {
+        if (thread.status === Thread.STATUS_DONE) return;
         handleReport(resolvedValue, sequencer, thread, blockCached, lastOperation);
         // If it's a command block or a top level reporter in a stackClick.
-        if (lastOperation) {
-            let stackFrame;
-            let nextBlockId;
-            do {
-                // In the case that the promise is the last block in the current thread stack
-                // We need to pop out repeatedly until we find the next block.
-                const popped = thread.popStack();
-                if (popped === null) {
-                    return;
-                }
-                nextBlockId = thread.target.blocks.getNextBlock(popped);
-                if (nextBlockId !== null) {
-                    // A next block exists so break out this loop
-                    break;
-                }
-                // Investigate the next block and if not in a loop,
-                // then repeat and pop the next item off the stack frame
-                stackFrame = thread.peekStackFrame();
-            } while (stackFrame !== null && !stackFrame.isLoop);
-
-            thread.pushStack(nextBlockId);
-        }
+        if (lastOperation) thread.goToNextBlock();
     }, rejectionReason => {
         // Promise rejected: the primitive had some error.
         // Log it and proceed.

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -216,12 +216,6 @@ class BlockCached {
         this._blockFunction = null;
 
         /**
-         * Is the block function defined for this opcode?
-         * @type {boolean}
-         */
-        this._definedBlockFunction = false;
-
-        /**
          * Is this block a block with no function but a static value to return.
          * @type {boolean}
          */
@@ -278,7 +272,6 @@ class BlockCached {
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);
         this._blockFunction = runtime.getOpcodeFunction(opcode);
-        this._definedBlockFunction = typeof this._blockFunction !== 'undefined';
 
         // Store the current shadow value if there is a shadow value.
         const fieldKeys = Object.keys(fields);
@@ -360,7 +353,7 @@ class BlockCached {
 
         // The final operation is this block itself. At the top most block is a
         // command block or a block that is being run as a monitor.
-        if (this._definedBlockFunction) {
+        if (typeof this._blockFunction !== 'undefined') {
             this._ops.push(this);
         }
     }

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -362,6 +362,15 @@ const execute = function (sequencer, thread) {
         }
     }
 
+    // Blocks should glow when a script is starting, not after it has finished
+    // (see #1404). Only blocks in blockContainers that don't forceNoGlow should
+    // request a glow.
+    if (!blockContainer.forceNoGlow) {
+        thread.requestScriptGlowInFrame = true;
+        // Indicate the block that is executing.
+        thread.blockGlowInFrame = currentBlockId;
+    }
+
     const ops = blockCached._ops;
     const length = ops.length;
     let i = 0;
@@ -440,14 +449,6 @@ const execute = function (sequencer, thread) {
         const argValues = opCached._argValues;
 
         // Fields are set during opCached initialization.
-
-        // Blocks should glow when a script is starting,
-        // not after it has finished (see #1404).
-        // Only blocks in blockContainers that don't forceNoGlow
-        // should request a glow.
-        if (!blockContainer.forceNoGlow) {
-            thread.requestScriptGlowInFrame = true;
-        }
 
         // Inputs are set during previous steps in the loop.
 

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -234,12 +234,6 @@ class BlockCached {
         this._shadowValue = null;
 
         /**
-         * A copy of the block's fields that may be modified.
-         * @type {object}
-         */
-        this._fields = Object.assign({}, this.fields);
-
-        /**
          * A copy of the block's inputs that may be modified.
          * @type {object}
          */

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -157,21 +157,21 @@ const handlePromise = (primitiveReportedValue, sequencer, thread, blockCached, l
  * in the editor.
  *
  * @param {Blocks} blockContainer the related Blocks instance
- * @param {object} cached default set of cached values
+ * @param {object} block the block information to cache
  */
 class BlockCached {
-    constructor (blockContainer, cached) {
+    constructor (blockContainer, block) {
         /**
          * Block id in its parent set of blocks.
          * @type {string}
          */
-        this.id = cached.id;
+        this.id = block.id;
 
         /**
          * Block operation code for this block.
          * @type {string}
          */
-        this.opcode = cached.opcode;
+        this.opcode = block.opcode;
 
         /**
          * The profiler the block is configured with.
@@ -215,7 +215,7 @@ class BlockCached {
          * @type {object}
          */
         this._argValues = {
-            mutation: cached.mutation
+            mutation: block.mutation
         };
 
         /**
@@ -243,7 +243,10 @@ class BlockCached {
 
         const {runtime} = blockUtility.sequencer;
 
-        const {opcode, inputs, fields} = cached;
+        const {opcode, fields} = block;
+        // NOTE: because we modify `inputs` in-place, this relies on getNonBranchInputs returning a new object each
+        // time it's called.
+        const inputs = blockContainer.getNonBranchInputs(block);
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -174,22 +174,10 @@ class BlockCached {
         this.opcode = cached.opcode;
 
         /**
-         * Original block object containing argument values for static fields.
-         * @type {object}
-         */
-        this.fields = cached.fields;
-
-        /**
          * Original block object containing argument values for executable inputs.
          * @type {object}
          */
         this.inputs = cached.inputs;
-
-        /**
-         * Procedure mutation.
-         * @type {?object}
-         */
-        this.mutation = cached.mutation;
 
         /**
          * The profiler the block is configured with.
@@ -239,7 +227,7 @@ class BlockCached {
          * @type {object}
          */
         this._argValues = {
-            mutation: this.mutation
+            mutation: cached.mutation
         };
 
         /**
@@ -267,7 +255,8 @@ class BlockCached {
 
         const {runtime} = blockUtility.sequencer;
 
-        const {opcode, fields, inputs} = this;
+        const {opcode, inputs} = this;
+        const {fields} = cached;
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -201,7 +201,7 @@ class BlockCached {
          * Is this block a block with no function but a static value to return.
          * @type {boolean}
          */
-        this._isShadowBlock = false;
+        this._isShadowBlock = block.shadow;
 
         /**
          * The static value of this block if it is a shadow block.
@@ -244,9 +244,6 @@ class BlockCached {
         const {runtime} = blockUtility.sequencer;
 
         const {opcode, fields} = block;
-        // NOTE: because we modify `inputs` in-place, this relies on getNonBranchInputs returning a new object each
-        // time it's called.
-        const inputs = blockContainer.getNonBranchInputs(block);
 
         // Assign opcode isHat and blockFunction data to avoid dynamic lookups.
         this._isHat = runtime.getIsHat(opcode);
@@ -254,11 +251,6 @@ class BlockCached {
 
         // Store the current shadow value if there is a shadow value.
         const fieldKeys = Object.keys(fields);
-        this._isShadowBlock = (
-            !this._definedBlockFunction &&
-            fieldKeys.length === 1 &&
-            Object.keys(inputs).length === 0
-        );
         this._shadowValue = this._isShadowBlock && fields[fieldKeys[0]].value;
 
         // Store the static fields onto _argValues.
@@ -277,6 +269,9 @@ class BlockCached {
             }
         }
 
+        // NOTE: because we modify `inputs` in-place, this relies on getNonBranchInputs returning a new object each
+        // time it's called.
+        const inputs = blockContainer.getNonBranchInputs(block);
         // Remove custom_block. It is not part of block execution.
         delete inputs.custom_block;
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1621,8 +1621,6 @@ class Runtime extends EventEmitter {
      * @param {!Thread} thread Thread object to remove from actives
      */
     _stopThread (thread) {
-        // Mark the thread for later removal
-        thread.isKilled = true;
         // Inform sequencer to stop executing that thread.
         this.sequencer.retireThread(thread);
     }
@@ -2032,9 +2030,6 @@ class Runtime extends EventEmitter {
             }
             this.profiler.start(stepProfilerId);
         }
-
-        // Clean up threads that were told to stop during or since the last step
-        this.threads = this.threads.filter(thread => !thread.isKilled);
 
         // Find all edge-activated hats, and add them to threads to be evaluated.
         for (const hatType in this._hats) {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1791,7 +1791,7 @@ class Runtime extends EventEmitter {
         this.allScriptsByOpcodeDo(requestedHatOpcode, (script, target) => {
             const {
                 blockId: topBlockId,
-                fieldsOfInputs: hatFields
+                fields: hatFields
             } = script;
 
             // Match any requested fields.

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -7,7 +7,6 @@ const BlocksRuntimeCache = require('./blocks-runtime-cache');
 const BlockType = require('../extension-support/block-type');
 const Profiler = require('./profiler');
 const Sequencer = require('./sequencer');
-const execute = require('./execute.js');
 const ScratchBlocksConstants = require('./scratch-blocks-constants');
 const TargetType = require('../extension-support/target-type');
 const Thread = require('./thread');
@@ -608,7 +607,7 @@ class Runtime extends EventEmitter {
     static get PERIPHERAL_LIST_UPDATE () {
         return 'PERIPHERAL_LIST_UPDATE';
     }
-    
+
     /**
      * Event name for when the user picks a bluetooth device to connect to
      * via Companion Device Manager (CDM)
@@ -1835,10 +1834,7 @@ class Runtime extends EventEmitter {
         }, optTarget);
         // For compatibility with Scratch 2, edge triggered hats need to be processed before
         // threads are stepped. See ScratchRuntime.as for original implementation
-        newThreads.forEach(thread => {
-            execute(this.sequencer, thread);
-            thread.goToNextBlock();
-        });
+        newThreads.forEach(thread => this.sequencer.stepHat(thread));
         return newThreads;
     }
 

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -221,13 +221,10 @@ class Sequencer {
             thread.warpTimer = new Timer();
             thread.warpTimer.start();
         }
-        // Store the current block ID outside of the loop to later set it to
-        // thread.blockGlowInFrame.
-        let currentBlockId = thread.peekStack();
         // The thread entered a null block while outside of stepThreads during a
         // stepHat or promise resolution. We can't unwrap during stepHat or
         // promise resolution if we need to change the thread status.
-        if (currentBlockId === null) {
+        if (thread.peekStack() === null) {
             // Unwrap the stack until we find a loop block, a non-null
             // block, or the top of the stack.
             this.unwrapStack(thread);
@@ -238,7 +235,7 @@ class Sequencer {
         }
         while (thread.status === Thread.STATUS_RUNNING) {
             // Save the current block ID to notice if we did control flow.
-            currentBlockId = thread.peekStack();
+            const currentBlockId = thread.peekStack();
 
             if (this.runtime.profiler !== null) {
                 if (executeProfilerId === -1) {
@@ -272,8 +269,6 @@ class Sequencer {
                 thread.status = Thread.STATUS_RUNNING;
             }
         }
-        // Indicate the block that just executed.
-        thread.blockGlowInFrame = currentBlockId;
         // If we yielded out of the thread, set status to RUNNING so stepThreads
         // can count it as an activeThread and possibly step all threads an
         // extra time.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -76,7 +76,7 @@ class Sequencer {
         this.runtime.updateCurrentMSecs();
         // Start counting toward WORK_TIME.
         this.timer.start();
-        // Count of active threads.
+        // Are there active threads?
         let activeThreads = true;
         // Whether `stepThreads` has run through a full single tick.
         let ranFirstTick = false;
@@ -102,8 +102,7 @@ class Sequencer {
             const threads = this.runtime.threads;
             for (let i = 0; i < threads.length; i++) {
                 const activeThread = this.activeThread = threads[i];
-                if (activeThread.status === Thread.STATUS_RUNNING ||
-                    activeThread.status === Thread.STATUS_YIELD) {
+                if (activeThread.status === Thread.STATUS_RUNNING) {
                     // Normal-mode thread: step.
                     if (this.runtime.profiler === null) {
                         this.stepThread(activeThread);
@@ -116,10 +115,11 @@ class Sequencer {
 
                         this.stepThread(activeThread);
                     }
-                } else if (activeThread.status === Thread.STATUS_YIELD_TICK &&
-                    !ranFirstTick) {
-                    // Clear single-tick yield from the last call of
-                    // `stepThreads`.
+                } else if (activeThread.status === Thread.STATUS_YIELD || (
+                    activeThread.status === Thread.STATUS_YIELD_TICK &&
+                    !ranFirstTick
+                )) {
+                    // Clear yield and yield tick on first outer step loop.
                     activeThread.status = Thread.STATUS_RUNNING;
                     // Run this thread again in the loop. (Since most threads
                     // are RUNNING this second clause will be rarely checked.
@@ -127,12 +127,14 @@ class Sequencer {
                     // loop over this index a second time to get the RUNNING
                     // behaviour.)
                     i--;
-                    // Skip ahead to running this thread again.
+                    // Skip ahead to running this thread again. We don't want
+                    // this to count towards activeThreads until after
+                    // execution.
                     continue;
                 }
-                // Check if the thread is running and step threads again of if
-                // it completed while it just stepped to make sure remove it
-                // before the next iteration of all threads.
+                // If the thread is running allow, loop over the threads again.
+                // If the thread finished make sure it is removed before the
+                // next iteration of all threads.
                 if (activeThread.status === Thread.STATUS_RUNNING) {
                     activeThreads = true;
                 } else if (activeThread.status === Thread.STATUS_DONE) {
@@ -170,106 +172,116 @@ class Sequencer {
     }
 
     /**
+     * Step the requested thread once. The thread must be at a hat block.
+     * @param {!Thread} thread Thread object to step.
+     * @param {object=} optMatchFields Optionally, fields to match on the hat.
+     */
+    stepHat (thread) {
+        execute(this, thread);
+        if (thread.status === Thread.STATUS_RUNNING) thread.goToNextBlock();
+    }
+
+    /**
+     * Pop the stack as long as it is pointing at null.
+     * @param {!Thread} thread Thread to pop.
+     */
+    unwrapStack (thread) {
+        while (
+            thread.status === Thread.STATUS_RUNNING &&
+            thread.peekStack() === null
+        ) {
+            thread.popStack();
+
+            const stackFrame = thread.peekStackFrame();
+            if (stackFrame === null) {
+                // No more stack to run!
+                this.retireThread(thread);
+            } else if (stackFrame.isLoop) {
+                // The current level of the stack is marked as a loop. Yield
+                // this thread so the next thread may run.
+                thread.status = Thread.STATUS_YIELD;
+            } else {
+                // Step to the next block.
+                thread.goToNextBlock();
+            }
+        }
+    }
+
+    /**
      * Step the requested thread for as long as necessary.
      * @param {!Thread} thread Thread object to step.
      */
     stepThread (thread) {
+        // warpMode may be true when we start stepping a thread or become true
+        // when a procedure is pushed. So we only need to check here and in
+        // stepToProcedure.
+        if (thread.peekStackFrame().warpMode && thread.warpTimer === null) {
+            // Initialize warp-mode timer if it hasn't been already. This
+            // will start counting the thread toward `Sequencer.WARP_TIME`.
+            thread.warpTimer = new Timer();
+            thread.warpTimer.start();
+        }
+        // Store the current block ID outside of the loop to later set it to
+        // thread.blockGlowInFrame.
         let currentBlockId = thread.peekStack();
-        if (!currentBlockId) {
-            // A "null block" - empty branch.
-            thread.popStack();
-
-            // Did the null follow a hat block?
-            if (thread.stack.length === 0) {
-                thread.status = Thread.STATUS_DONE;
-                return;
+        // The thread entered a null block while outside of stepThreads during a
+        // stepHat or promise resolution. We can't unwrap during stepHat or
+        // promise resolution if we need to change the thread status.
+        if (currentBlockId === null) {
+            // Unwrap the stack until we find a loop block, a non-null
+            // block, or the top of the stack.
+            this.unwrapStack(thread);
+            // If we unwrapped into a loop block, execute it immediately.
+            if (thread.status === Thread.STATUS_YIELD) {
+                thread.status = Thread.STATUS_RUNNING;
             }
         }
-        // Save the current block ID to notice if we did control flow.
-        while ((currentBlockId = thread.peekStack())) {
-            let isWarpMode = thread.peekStackFrame().warpMode;
-            if (isWarpMode && !thread.warpTimer) {
-                // Initialize warp-mode timer if it hasn't been already.
-                // This will start counting the thread toward `Sequencer.WARP_TIME`.
-                thread.warpTimer = new Timer();
-                thread.warpTimer.start();
-            }
-            // Execute the current block.
+        while (thread.status === Thread.STATUS_RUNNING) {
+            // Save the current block ID to notice if we did control flow.
+            currentBlockId = thread.peekStack();
+
             if (this.runtime.profiler !== null) {
                 if (executeProfilerId === -1) {
                     executeProfilerId = this.runtime.profiler.idByName(executeProfilerFrame);
                 }
-
                 // Increment the number of times execute is called.
                 this.runtime.profiler.increment(executeProfilerId);
             }
-            if (thread.target === null) {
-                this.retireThread(thread);
-            } else {
-                execute(this, thread);
+
+            // Execute the current block.
+            execute(this, thread);
+
+            if (thread.status === Thread.STATUS_RUNNING) {
+                // If no control flow has happened, switch to next block.
+                if (thread.peekStack() === currentBlockId) {
+                    thread.goToNextBlock();
+                }
+                // A empty branch was pushed or we stepped out of the last block
+                // in a stack.
+                if (thread.peekStack() === null) {
+                    // Unwrap the stack until we find a loop block, a non-null
+                    // block, or the top of the stack.
+                    this.unwrapStack(thread);
+                }
             }
-            thread.blockGlowInFrame = currentBlockId;
-            // If the thread has yielded or is waiting, yield to other threads.
-            if (thread.status === Thread.STATUS_YIELD) {
-                // Mark as running for next iteration.
-                thread.status = Thread.STATUS_RUNNING;
+
+            if (thread.status === Thread.STATUS_YIELD &&
+                thread.peekStackFrame().warpMode &&
+                thread.warpTimer.timeElapsed() <= Sequencer.WARP_TIME) {
                 // In warp mode, yielded blocks are re-executed immediately.
-                if (isWarpMode &&
-                    thread.warpTimer.timeElapsed() <= Sequencer.WARP_TIME) {
-                    continue;
-                }
-                return;
-            } else if (thread.status === Thread.STATUS_PROMISE_WAIT) {
-                // A promise was returned by the primitive. Yield the thread
-                // until the promise resolves. Promise resolution should reset
-                // thread.status to Thread.STATUS_RUNNING.
-                return;
-            } else if (thread.status === Thread.STATUS_YIELD_TICK) {
-                // stepThreads will reset the thread to Thread.STATUS_RUNNING
-                return;
-            }
-            // If no control flow has happened, switch to next block.
-            if (thread.peekStack() === currentBlockId) {
-                thread.goToNextBlock();
-            }
-            // If no next block has been found at this point, look on the stack.
-            while (!thread.peekStack()) {
-                thread.popStack();
-
-                if (thread.stack.length === 0) {
-                    // No more stack to run!
-                    thread.status = Thread.STATUS_DONE;
-                    return;
-                }
-
-                const stackFrame = thread.peekStackFrame();
-                isWarpMode = stackFrame.warpMode;
-
-                if (stackFrame.isLoop) {
-                    // The current level of the stack is marked as a loop.
-                    // Return to yield for the frame/tick in general.
-                    // Unless we're in warp mode - then only return if the
-                    // warp timer is up.
-                    if (!isWarpMode ||
-                        thread.warpTimer.timeElapsed() > Sequencer.WARP_TIME) {
-                        // Don't do anything to the stack, since loops need
-                        // to be re-executed.
-                        return;
-                    }
-                    // Don't go to the next block for this level of the stack,
-                    // since loops need to be re-executed.
-                    continue;
-
-                } else if (stackFrame.waitingReporter) {
-                    // This level of the stack was waiting for a value.
-                    // This means a reporter has just returned - so don't go
-                    // to the next block for this level of the stack.
-                    return;
-                }
-                // Get next block of existing block on the stack.
-                thread.goToNextBlock();
+                thread.status = Thread.STATUS_RUNNING;
             }
         }
+        // Indicate the block that just executed.
+        thread.blockGlowInFrame = currentBlockId;
+        // If we yielded out of the thread, set status to RUNNING so stepThreads
+        // can count it as an activeThread and possibly step all threads an
+        // extra time.
+        if (thread.status === Thread.STATUS_YIELD) {
+            thread.status = Thread.STATUS_RUNNING;
+        }
+        // Unset warpTimer if it was used so it can be set again next time.
+        thread.warpTimer = null;
     }
 
     /**
@@ -335,6 +347,16 @@ class Sequencer {
                 }
             }
             if (doWarp) {
+                // Going from non warpMode to warpMode, enable the warpTimer.
+                if (!thread.peekStackFrame().warpMode &&
+                    thread.warpTimer === null) {
+                    // Initialize warp-mode timer if it hasn't been already.
+                    // This will start counting the thread toward
+                    // `Sequencer.WARP_TIME`.
+                    thread.warpTimer = new Timer();
+                    thread.warpTimer.start();
+                }
+
                 thread.peekStackFrame().warpMode = true;
             } else if (isRecursive) {
                 // In normal-mode threads, yield any time we have a recursive call.
@@ -349,7 +371,7 @@ class Sequencer {
      */
     retireThread (thread) {
         thread.stack = [];
-        thread.stackFrame = [];
+        thread.stackFrames = [];
         thread.requestScriptGlowInFrame = false;
         thread.status = Thread.STATUS_DONE;
     }

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -195,7 +195,7 @@ class Sequencer {
             const stackFrame = thread.peekStackFrame();
             if (stackFrame === null) {
                 // No more stack to run!
-                this.retireThread(thread);
+                thread.status = Thread.STATUS_DONE;
             } else if (stackFrame.isLoop) {
                 // The current level of the stack is marked as a loop. Yield
                 // this thread so the next thread may run.

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -77,7 +77,7 @@ class Sequencer {
         // Start counting toward WORK_TIME.
         this.timer.start();
         // Count of active threads.
-        let numActiveThreads = Infinity;
+        let activeThreads = true;
         // Whether `stepThreads` has run through a full single tick.
         let ranFirstTick = false;
         const doneThreads = [];
@@ -86,7 +86,7 @@ class Sequencer {
         // 2. Time elapsed must be less than WORK_TIME.
         // 3. Either turbo mode, or no redraw has been requested by a primitive.
         while (this.runtime.threads.length > 0 &&
-               numActiveThreads > 0 &&
+               activeThreads &&
                this.timer.timeElapsed() < WORK_TIME &&
                (this.runtime.turboMode || !this.runtime.redrawRequested)) {
             if (this.runtime.profiler !== null) {
@@ -96,48 +96,46 @@ class Sequencer {
                 this.runtime.profiler.start(stepThreadsInnerProfilerId);
             }
 
-            numActiveThreads = 0;
+            activeThreads = false;
             let stoppedThread = false;
             // Attempt to run each thread one time.
             const threads = this.runtime.threads;
             for (let i = 0; i < threads.length; i++) {
                 const activeThread = this.activeThread = threads[i];
-                // Check if the thread is done so it is not executed.
-                if (activeThread.stack.length === 0 ||
-                    activeThread.status === Thread.STATUS_DONE) {
-                    // Finished with this thread.
-                    stoppedThread = true;
-                    continue;
-                }
-                if (activeThread.status === Thread.STATUS_YIELD_TICK &&
-                    !ranFirstTick) {
-                    // Clear single-tick yield from the last call of `stepThreads`.
-                    activeThread.status = Thread.STATUS_RUNNING;
-                }
                 if (activeThread.status === Thread.STATUS_RUNNING ||
                     activeThread.status === Thread.STATUS_YIELD) {
                     // Normal-mode thread: step.
-                    if (this.runtime.profiler !== null) {
+                    if (this.runtime.profiler === null) {
+                        this.stepThread(activeThread);
+                    } else {
                         if (stepThreadProfilerId === -1) {
                             stepThreadProfilerId = this.runtime.profiler.idByName(stepThreadProfilerFrame);
                         }
-
                         // Increment the number of times stepThread is called.
                         this.runtime.profiler.increment(stepThreadProfilerId);
+
+                        this.stepThread(activeThread);
                     }
-                    this.stepThread(activeThread);
-                    activeThread.warpTimer = null;
-                    if (activeThread.isKilled) {
-                        i--; // if the thread is removed from the list (killed), do not increase index
-                    }
+                } else if (activeThread.status === Thread.STATUS_YIELD_TICK &&
+                    !ranFirstTick) {
+                    // Clear single-tick yield from the last call of
+                    // `stepThreads`.
+                    activeThread.status = Thread.STATUS_RUNNING;
+                    // Run this thread again in the loop. (Since most threads
+                    // are RUNNING this second clause will be rarely checked.
+                    // Instead of checking it first we can check it late, and
+                    // loop over this index a second time to get the RUNNING
+                    // behaviour.)
+                    i--;
+                    // Skip ahead to running this thread again.
+                    continue;
                 }
+                // Check if the thread is running and step threads again of if
+                // it completed while it just stepped to make sure remove it
+                // before the next iteration of all threads.
                 if (activeThread.status === Thread.STATUS_RUNNING) {
-                    numActiveThreads++;
-                }
-                // Check if the thread completed while it just stepped to make
-                // sure we remove it before the next iteration of all threads.
-                if (activeThread.stack.length === 0 ||
-                    activeThread.status === Thread.STATUS_DONE) {
+                    activeThreads = true;
+                } else if (activeThread.status === Thread.STATUS_DONE) {
                     // Finished with this thread.
                     stoppedThread = true;
                 }
@@ -155,12 +153,11 @@ class Sequencer {
                 let nextActiveThread = 0;
                 for (let i = 0; i < this.runtime.threads.length; i++) {
                     const thread = this.runtime.threads[i];
-                    if (thread.stack.length !== 0 &&
-                        thread.status !== Thread.STATUS_DONE) {
+                    if (thread.status === Thread.STATUS_DONE) {
+                        doneThreads.push(thread);
+                    } else {
                         this.runtime.threads[nextActiveThread] = thread;
                         nextActiveThread++;
-                    } else {
-                        doneThreads.push(thread);
                     }
                 }
                 this.runtime.threads.length = nextActiveThread;

--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -150,12 +150,6 @@ class Thread {
         this.status = 0; /* Thread.STATUS_RUNNING */
 
         /**
-         * Whether the thread is killed in the middle of execution.
-         * @type {boolean}
-         */
-        this.isKilled = false;
-
-        /**
          * Target of this thread.
          * @type {?Target}
          */


### PR DESCRIPTION
## Depends on #2930

### Resolves

Closes #2148

### Proposed Changes

This PR includes the changes from #2148, but includes a fix for block glow. Script stacks which only run for one frame should now glow properly.

### Reason for Changes

See #2148

My fix (the last commit) has this to say:

> retireThread sets requestScriptGlowInFrame to false, which results in
> stacks that only execute for one frame never glowing. It also resets
> stack and stackFrames, which is redundant because we were only calling
> it if the stack was empty (and thus did not need to be emptied again).

### Test Coverage

Tested manually