### PR TITLE
Replace text-encoding polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2826,7 +2826,7 @@
     },
     "ajv": {
       "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
@@ -3098,7 +3098,7 @@
     },
     "aws4": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
@@ -5040,7 +5040,7 @@
     },
     "debug": {
       "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
+      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
       "integrity": "sha1-qfpvvpykPPHnn3O3XAGJy7fW21o=",
       "dev": true,
       "requires": {
@@ -5311,7 +5311,7 @@
     },
     "doctrine": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "requires": {
@@ -6455,6 +6455,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
+    },
     "faye-websocket": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
@@ -6877,7 +6882,7 @@
         },
         "eslint": {
           "version": "3.19.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
           "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
           "dev": true,
           "requires": {
@@ -7442,7 +7447,7 @@
     },
     "globals": {
       "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+      "resolved": "http://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
       "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
       "dev": true
     },
@@ -8797,7 +8802,7 @@
     },
     "loader-utils": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "requires": {
         "big.js": "^3.1.3",
@@ -9593,7 +9598,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9893,13 +9897,11 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "align-text": "^0.1.3",
             "lazy-cache": "^1.0.3"
@@ -9946,7 +9948,6 @@
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "center-align": "^0.1.1",
             "right-align": "^0.1.1",
@@ -9955,8 +9956,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -10697,8 +10697,7 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lcid": {
           "version": "1.0.0",
@@ -10738,8 +10737,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -11218,7 +11216,6 @@
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "align-text": "^0.1.1"
           }
@@ -11851,7 +11848,6 @@
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "camelcase": "^1.0.2",
                 "cliui": "^2.1.0",
@@ -11983,8 +11979,7 @@
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -13120,7 +13115,7 @@
       "dependencies": {
         "qs": {
           "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "resolved": "http://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
           "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
           "dev": true
         }
@@ -13225,7 +13220,7 @@
     },
     "rimraf": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
       "requires": {
@@ -14514,7 +14509,7 @@
     },
     "string_decoder": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
       "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "canvas-toBlob": "1.0.0",
     "decode-html": "2.0.0",
     "diff-match-patch": "1.0.4",
+    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "format-message": "6.2.1",
     "htmlparser2": "3.10.0",
     "immutable": "3.8.1",
@@ -44,7 +45,6 @@
     "scratch-parser": "5.0.0",
     "scratch-sb1-converter": "0.2.7",
     "scratch-translate-extension-languages": "0.0.20191118205314",
-    "text-encoding": "0.7.0",
     "worker-loader": "^1.1.1"
   },
   "devDependencies": {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1,6 +1,6 @@
 let _TextEncoder;
 if (typeof TextEncoder === 'undefined') {
-    _TextEncoder = require('text-encoding').TextEncoder;
+    _TextEncoder = require('fastestsmallesttextencoderdecoder').TextEncoder;
 } else {
     /* global TextEncoder */
     _TextEncoder = TextEncoder;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,8 +78,7 @@ module.exports = [
             'jszip': true,
             'minilog': true,
             'scratch-parser': true,
-            'socket.io-client': true,
-            'text-encoding': true
+            'socket.io-client': true
         }
     }),
     // Playground


### PR DESCRIPTION
### Resolves

Towards https://github.com/LLK/scratch-gui/issues/6898

### Proposed Changes

This PR replaces the `text-encoding` package with `fastestsmallesttextencoderdecoder`.

### Reason for Changes

The `text-encoding` package has been deprecated by its maintainer, and also adds 500KB of encoding data for non-UTF-8 text. Because we're only using it to encode UTF-8, that 500KB is entirely unnecessary.

### Test Coverage

Must be tested manually.

The `TextEncoder` API is used for encoding SVG data, so this can be tested by creating an SVG asset and making sure it persists across save/load on Legacy Edge, the only browser without native support for the `TextEncoder` API.
