### PR TITLE
Add svg renderer to peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2916,7 +2916,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -4358,7 +4358,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "class-utils": {
@@ -4473,7 +4473,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
     "colorette": {
@@ -5555,7 +5555,7 @@
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
@@ -5574,7 +5574,7 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
@@ -6078,7 +6078,7 @@
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "http://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
@@ -6527,7 +6527,7 @@
     "file-loader": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
-      "integrity": "sha1-OXScgvAguehZAdz/mOgATmQBz94=",
+      "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.0.2",
@@ -6573,7 +6573,7 @@
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -6810,7 +6810,7 @@
     "format-message": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/format-message/-/format-message-6.2.1.tgz",
-      "integrity": "sha1-kKJ9KJYNQRT5mRL9Uc2heJvdP/A=",
+      "integrity": "sha512-6gBXI+MOE9pu9QNeZf95V87GKYiLCdUvhisjts75xonaPAshtBu20NTZt2l8kbYcoMtxNyH9E9af+aieIRfVmw==",
       "requires": {
         "format-message-formats": "^6.2.0",
         "format-message-interpret": "^6.2.0",
@@ -7061,7 +7061,7 @@
             "string-width": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
@@ -7228,7 +7228,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "function-loop": {
@@ -8180,7 +8180,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-callable": {
@@ -8298,7 +8298,7 @@
     },
     "is-my-json-valid": {
       "version": "2.20.5",
-      "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
       "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
       "dev": true,
       "requires": {
@@ -8491,7 +8491,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
@@ -8557,7 +8557,7 @@
     },
     "json": {
       "version": "9.0.6",
-      "resolved": "http://registry.npmjs.org/json/-/json-9.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
       "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
       "dev": true
     },
@@ -9132,7 +9132,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -9593,7 +9593,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9893,13 +9892,11 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "align-text": "^0.1.3",
             "lazy-cache": "^1.0.3"
@@ -9946,7 +9943,6 @@
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "center-align": "^0.1.1",
             "right-align": "^0.1.1",
@@ -9955,8 +9951,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -10697,8 +10692,7 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "lcid": {
           "version": "1.0.0",
@@ -10738,8 +10732,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -11218,7 +11211,6 @@
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "align-text": "^0.1.1"
           }
@@ -11851,7 +11843,6 @@
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "camelcase": "^1.0.2",
                 "cliui": "^2.1.0",
@@ -11983,8 +11974,7 @@
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -12768,7 +12758,7 @@
     "pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -13530,7 +13520,7 @@
     "script-loader": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.2.tgz",
-      "integrity": "sha1-IBbbb4byX1z1baOJFdgzeLsWa6c=",
+      "integrity": "sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==",
       "dev": true,
       "requires": {
         "raw-loader": "~0.5.1"
@@ -13789,7 +13779,7 @@
     },
     "should-equal": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
       "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "dev": true,
       "requires": {
@@ -14454,7 +14444,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -15213,7 +15203,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -15454,7 +15444,7 @@
     "uglifyjs-webpack-plugin": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz",
-      "integrity": "sha1-V2ON2ZyFOh6/6dl7QhYKilB/nQA=",
+      "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
       "dev": true,
       "requires": {
         "cacache": "^10.0.4",
@@ -15470,7 +15460,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9592,7 +9592,8 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9601,21 +9602,25 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
@@ -9623,51 +9628,61 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "atob": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -9677,7 +9692,8 @@
         },
         "babel-generator": {
           "version": "6.26.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
             "babel-messages": "^6.23.0",
@@ -9692,7 +9708,8 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.22.0"
@@ -9700,7 +9717,8 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
             "core-js": "^2.4.0",
@@ -9709,7 +9727,8 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -9721,7 +9740,8 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
@@ -9737,7 +9757,8 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -9748,17 +9769,20 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
@@ -9772,7 +9796,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -9780,7 +9805,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -9788,7 +9814,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -9796,7 +9823,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -9806,19 +9834,22 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -9827,7 +9858,8 @@
         },
         "braces": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -9844,7 +9876,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -9854,12 +9887,14 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
@@ -9875,14 +9910,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "caching-transform": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
@@ -9892,11 +9929,13 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
         },
         "center-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "requires": {
             "align-text": "^0.1.3",
             "lazy-cache": "^1.0.3"
@@ -9904,7 +9943,8 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -9916,7 +9956,8 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -9927,7 +9968,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -9935,14 +9977,16 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "cliui": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
             "center-align": "^0.1.1",
             "right-align": "^0.1.1",
@@ -9951,18 +9995,21 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
             }
           }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
@@ -9971,37 +10018,44 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
           "dev": true
         },
         "core-js": {
           "version": "2.5.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -10010,7 +10064,8 @@
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -10018,21 +10073,25 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
@@ -10040,7 +10099,8 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
@@ -10049,7 +10109,8 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -10057,7 +10118,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -10065,7 +10127,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -10075,19 +10138,22 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
             "repeating": "^2.0.0"
@@ -10095,7 +10161,8 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -10103,17 +10170,20 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -10127,7 +10197,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -10139,7 +10210,8 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -10153,7 +10225,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -10161,7 +10234,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -10171,7 +10245,8 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
@@ -10180,7 +10255,8 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -10190,7 +10266,8 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -10205,7 +10282,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -10213,7 +10291,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -10221,7 +10300,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -10229,7 +10309,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -10237,7 +10318,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -10247,14 +10329,16 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -10265,7 +10349,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -10275,7 +10360,8 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -10285,7 +10371,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -10293,11 +10380,13 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
@@ -10306,7 +10395,8 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
@@ -10314,27 +10404,32 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -10347,17 +10442,20 @@
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "has-ansi": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -10365,12 +10463,14 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "has-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
             "get-value": "^2.0.6",
@@ -10380,14 +10480,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "has-values": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -10396,7 +10498,8 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -10404,7 +10507,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -10414,7 +10518,8 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -10424,17 +10529,20 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -10443,12 +10551,14 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.0.0"
@@ -10456,12 +10566,14 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -10469,16 +10581,19 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
@@ -10486,7 +10601,8 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -10494,7 +10610,8 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -10504,19 +10621,22 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
               "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -10524,12 +10644,14 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -10537,7 +10659,8 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "dev": true,
           "requires": {
             "is-number": "^4.0.0"
@@ -10545,14 +10668,16 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
               "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -10560,49 +10685,58 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "dev": true,
           "requires": {
             "append-transform": "^0.4.0"
@@ -10610,7 +10744,8 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.10.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "dev": true,
           "requires": {
             "babel-generator": "^6.18.0",
@@ -10624,7 +10759,8 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.2",
@@ -10635,7 +10771,8 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
@@ -10645,7 +10782,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
           "dev": true,
           "requires": {
             "debug": "^3.1.0",
@@ -10657,7 +10795,8 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -10667,7 +10806,8 @@
         },
         "istanbul-reports": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
           "dev": true,
           "requires": {
             "handlebars": "^4.0.3"
@@ -10675,28 +10815,33 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -10704,7 +10849,8 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -10716,7 +10862,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -10725,18 +10872,21 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "loose-envify": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
             "js-tokens": "^3.0.0"
@@ -10744,7 +10894,8 @@
         },
         "lru-cache": {
           "version": "4.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -10753,12 +10904,14 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
@@ -10766,7 +10919,8 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
@@ -10774,12 +10928,14 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -10787,7 +10943,8 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
             "source-map": "^0.6.1"
@@ -10795,14 +10952,16 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -10822,19 +10981,22 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -10842,11 +11004,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -10854,12 +11018,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -10878,24 +11044,28 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -10906,7 +11076,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -10914,17 +11085,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
@@ -10934,7 +11108,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -10944,7 +11119,8 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
             "isobject": "^3.0.0"
@@ -10952,14 +11128,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "object.pick": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -10967,14 +11145,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -10982,7 +11162,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "requires": {
             "minimist": "~0.0.1",
             "wordwrap": "~0.0.2"
@@ -10990,12 +11171,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -11005,12 +11188,14 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -11018,7 +11203,8 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -11026,12 +11212,14 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
@@ -11039,12 +11227,14 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
           "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -11052,22 +11242,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -11077,17 +11271,20 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
@@ -11095,7 +11292,8 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
@@ -11103,7 +11301,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -11114,17 +11313,20 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
@@ -11134,7 +11336,8 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0",
@@ -11143,7 +11346,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -11154,12 +11358,14 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         },
         "regex-not": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
@@ -11168,16 +11374,19 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "repeating": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
             "is-finite": "^1.0.0"
@@ -11185,39 +11394,46 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "requires": {
             "align-text": "^0.1.1"
           }
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -11225,7 +11441,8 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
             "ret": "~0.1.10"
@@ -11233,17 +11450,20 @@
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "set-value": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -11254,7 +11474,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -11264,7 +11485,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -11272,22 +11494,26 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
             "base": "^0.11.1",
@@ -11302,7 +11528,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -11310,7 +11537,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -11320,7 +11548,8 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
             "define-property": "^1.0.0",
@@ -11330,7 +11559,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -11338,7 +11568,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -11346,7 +11577,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -11354,7 +11586,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -11364,19 +11597,22 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
@@ -11384,11 +11620,13 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
           "dev": true,
           "requires": {
             "atob": "^2.0.0",
@@ -11400,12 +11638,14 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
@@ -11418,7 +11658,8 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -11427,12 +11668,14 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -11441,12 +11684,14 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
@@ -11454,7 +11699,8 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
             "define-property": "^0.2.5",
@@ -11463,7 +11709,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -11473,7 +11720,8 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -11482,12 +11730,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -11497,7 +11747,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -11505,7 +11756,8 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
@@ -11513,17 +11765,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -11535,17 +11790,20 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
               "dev": true
             },
             "braces": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
                 "arr-flatten": "^1.1.0",
@@ -11562,7 +11820,8 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -11572,7 +11831,8 @@
             },
             "expand-brackets": {
               "version": "2.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "dev": true,
               "requires": {
                 "debug": "^2.3.3",
@@ -11586,7 +11846,8 @@
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "dev": true,
                   "requires": {
                     "is-descriptor": "^0.1.0"
@@ -11594,7 +11855,8 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -11602,7 +11864,8 @@
                 },
                 "is-accessor-descriptor": {
                   "version": "0.1.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "dev": true,
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -11610,7 +11873,8 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -11620,7 +11884,8 @@
                 },
                 "is-data-descriptor": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "dev": true,
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -11628,7 +11893,8 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -11638,7 +11904,8 @@
                 },
                 "is-descriptor": {
                   "version": "0.1.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "dev": true,
                   "requires": {
                     "is-accessor-descriptor": "^0.1.6",
@@ -11648,14 +11915,16 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
                   "dev": true
                 }
               }
             },
             "extglob": {
               "version": "2.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "dev": true,
               "requires": {
                 "array-unique": "^0.3.2",
@@ -11670,7 +11939,8 @@
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "dev": true,
                   "requires": {
                     "is-descriptor": "^1.0.0"
@@ -11678,7 +11948,8 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -11688,7 +11959,8 @@
             },
             "fill-range": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -11699,7 +11971,8 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -11709,7 +11982,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -11717,7 +11991,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -11725,7 +12000,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -11735,7 +12011,8 @@
             },
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -11743,7 +12020,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -11753,17 +12031,20 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             },
             "micromatch": {
               "version": "3.1.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
                 "arr-diff": "^4.0.0",
@@ -11785,12 +12066,14 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -11798,7 +12081,8 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
             "define-property": "^2.0.2",
@@ -11809,7 +12093,8 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -11818,7 +12103,8 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -11828,12 +12114,14 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
             "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
@@ -11842,7 +12130,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "requires": {
                 "camelcase": "^1.0.2",
                 "cliui": "^2.1.0",
@@ -11854,12 +12143,14 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -11870,7 +12161,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -11878,7 +12170,8 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -11891,7 +12184,8 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
             "has-value": "^0.3.1",
@@ -11900,7 +12194,8 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
                 "get-value": "^2.0.3",
@@ -11910,7 +12205,8 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                   "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
@@ -11920,24 +12216,28 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
               "dev": true
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
           "dev": true
         },
         "use": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.2"
@@ -11945,14 +12245,16 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -11961,7 +12263,8 @@
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -11969,20 +12272,24 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -11991,7 +12298,8 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -11999,7 +12307,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -12011,12 +12320,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -12026,17 +12337,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -12055,17 +12369,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
                 "string-width": "^2.1.1",
@@ -12075,7 +12392,8 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -12083,7 +12401,8 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
@@ -12093,7 +12412,8 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -12101,7 +12421,8 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "scratch-l10n": "^3.1.20181129221712",
     "scratch-render": "latest",
     "scratch-storage": "^1.1.0",
-    "scratch-svg-renderer": "^0.2.0-prerelease.20210317184701",
+    "scratch-svg-renderer": "^0.2.0-prerelease",
     "script-loader": "0.7.2",
     "stats.js": "^0.17.0",
     "tap": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "text-encoding": "0.7.0",
     "worker-loader": "^1.1.1"
   },
+  "peerDependencies": {
+    "scratch-svg-renderer": "^0.2.0-prerelease"
+  },
   "devDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/preset-env": "^7.1.0",
@@ -72,7 +75,7 @@
     "scratch-l10n": "^3.1.20181129221712",
     "scratch-render": "latest",
     "scratch-storage": "^1.1.0",
-    "scratch-svg-renderer": "latest",
+    "scratch-svg-renderer": "^0.2.0-prerelease.20210317184701",
     "script-loader": "0.7.2",
     "stats.js": "^0.17.0",
     "tap": "^12.0.1",


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

### Proposed Changes
Add scratch-svg-renderer to peer dependencies

### Reason for Changes
This way we don't potentially import many versions of scratch-svg-renderer, GUI's version is shared with all of its subdependencies

### Test Coverage

_Please show how you have added tests to cover your changes_
