### PR TITLE
Go back to only using svgrenderer to process vectors that we think are coming from scratch 2

### DIFF
--- a/src/import/load-costume.js
+++ b/src/import/load-costume.js
@@ -4,22 +4,26 @@ const {loadSvgString, serializeSvgToString} = require('scratch-svg-renderer');
 
 const loadVector_ = function (costume, runtime, rotationCenter, optVersion) {
     return new Promise(resolve => {
-        const svgString = costume.asset.decodeText();
-        // scratch-svg-renderer fixes syntax that causes loading issues,
-        // and if optVersion is 2, fixes "quirks" associated with Scratch 2 SVGs,
-        const fixedSvgString = serializeSvgToString(loadSvgString(svgString, optVersion === 2/* fromVersion2 */));
+        let svgString = costume.asset.decodeText();
+        // SVG Renderer load fixes "quirks" associated with Scratch 2 projects
+        if (optVersion && optVersion === 2) {
+            // scratch-svg-renderer fixes syntax that causes loading issues,
+            // and if optVersion is 2, fixes "quirks" associated with Scratch 2 SVGs,
+            const fixedSvgString = serializeSvgToString(loadSvgString(svgString, true /* fromVersion2 */));
         
-        // If the string changed, put back into storage
-        if (svgString !== fixedSvgString) {
-            const storage = runtime.storage;
-            costume.asset.encodeTextData(fixedSvgString, storage.DataFormat.SVG, true);
-            costume.assetId = costume.asset.assetId;
-            costume.md5 = `${costume.assetId}.${costume.dataFormat}`;
+            // If the string changed, put back into storage
+            if (svgString !== fixedSvgString) {
+                svgString = fixedSvgString;
+                const storage = runtime.storage;
+                costume.asset.encodeTextData(fixedSvgString, storage.DataFormat.SVG, true);
+                costume.assetId = costume.asset.assetId;
+                costume.md5 = `${costume.assetId}.${costume.dataFormat}`;
+            }
         }
 
         // createSVGSkin does the right thing if rotationCenter isn't provided, so it's okay if it's
         // undefined here
-        costume.skinId = runtime.renderer.createSVGSkin(fixedSvgString, rotationCenter);
+        costume.skinId = runtime.renderer.createSVGSkin(svgString, rotationCenter);
         costume.size = runtime.renderer.getSkinSize(costume.skinId);
         // Now we should have a rotationCenter even if we didn't before
         if (!rotationCenter) {


### PR DESCRIPTION
### Resolves
Processing all SVGs was causing a spike of saved assets on the server

### Proposed Changes
Reverts the part of https://github.com/LLK/scratch-vm/pull/2954/files which changed which assets are run through the scratch-svg-renderer repo's fixup code. The rest of pull 2954 switches vm over from using deprecated functions to the replacement functions in scratch-svg-renderer, which is part of solving https://github.com/LLK/scratch-svg-renderer/issues/220

### Reason for Changes
Be nice to the servers

### Test Coverage

Tested manually
- Before the change, fixupSvgString IS called when loading an sb3 project
- After the change, it IS NOT called on sb3 project
- After the change, it IS called on sb2 project