### PR TITLE
Don't save or load monitor values

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -500,7 +500,6 @@ const serializeMonitors = function (monitors) {
             opcode: monitorData.opcode,
             params: monitorData.params,
             spriteName: monitorData.spriteName,
-            value: monitorData.value,
             width: monitorData.width,
             height: monitorData.height,
             x: monitorData.x,
@@ -1188,6 +1187,11 @@ const deserializeMonitor = function (monitorData, runtime, targets, extensions) 
             extensions.extensionIDs.add(extensionID);
         }
     }
+
+    // Don't load potentially stale monitor data
+    // e.g. loudness, answer, timer, and other blocks which depend on global or external state,
+    // as well as values which were updated whilst the monitor was hidden
+    monitorData.value = null;
 
     runtime.requestAddMonitor(MonitorRecord(monitorData));
 };


### PR DESCRIPTION
### Resolves

Resolves #2294
Resolves #3047

### Proposed Changes

This PR changes the SB3 serialization code to not save or load monitors' values.

### Reason for Changes

Monitors display values which represent the current state of the project--things like variables' values, the creator's username, microphone loudness, the answer to the "ask" block, etc. As such, those values are ephemeral, and should not be saved along with the project.

Saving monitor data along with the project is redundant as well, and often results in variable and list data being saved multiple times. This can cause project files to exceed the size limit when those variables and lists contain extremely large amounts of data.

Now, deserialized monitors' `value`s will take on the default value of `null`, and then be updated to the current value of whatever they're monitoring by `Runtime.step`.

I was initially concerned that because the runtime only steps threads in 30 FPS, there may be one frame where no monitor value is shown, but this doesn't seem to be a concern introduced by this change, because:

1. .sb2 deserialization also doesn't load monitor values and depends on the runtime recalculating them.
2. Hidden monitors' values are only updated when they are shown again, meaning that there would also be a flash of the old monitor value when you changed a variable/list then showed its monitor, and that doesn't seem to be the case.
3. This would also be an issue with the previous implementation-- monitors like "answer", "loudness", "username" and "current time" would show a stale value for one frame.

EDIT: When you show a variable monitor using the "show variable" block, there's a pre-existing one-frame delay where it displays the old value, just as I suspected (https://github.com/LLK/scratch-vm/issues/2124). That's not introduced by this change, and we can address it separately.

This is also backwards-compatible with older Scratch versions (e.g. Scratch Desktop).

### Test Coverage

Tested manually
