### PR TITLE
fix: replace log.warning with log.warn

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -464,7 +464,7 @@ class VirtualMachine extends EventEmitter {
      * @returns {Promise} Promise that resolves after the project has loaded
      */
     fromJSON (json) {
-        log.warning('fromJSON is now just a wrapper around loadProject, please use that function instead.');
+        log.warn('fromJSON is now just a wrapper around loadProject, please use that function instead.');
         return this.loadProject(json);
     }
 


### PR DESCRIPTION
### Proposed Changes

Replace `log.warning` with `log.warn`.

### Reason for Changes

[minilog](https://www.npmjs.com/package/minilog) does not have `log.warning` api.

