### PR TITLE
support Scratch Link on ws://127.0.0.1:20111

### DIFF
--- a/src/util/scratch-link-websocket.js
+++ b/src/util/scratch-link-websocket.js
@@ -23,26 +23,75 @@ class ScratchLinkWebSocket {
     }
 
     open () {
+        if (!(this._onOpen && this._onClose && this._onError && this._handleMessage)) {
+            throw new Error('Must set open, close, message and error handlers before calling open on the socket');
+        }
+
+        let pathname;
         switch (this._type) {
         case 'BLE':
-            this._ws = new WebSocket('wss://device-manager.scratch.mit.edu:20110/scratch/ble');
+            pathname = 'scratch/ble';
             break;
         case 'BT':
-            this._ws = new WebSocket('wss://device-manager.scratch.mit.edu:20110/scratch/bt');
+            pathname = 'scratch/bt';
             break;
         default:
             throw new Error(`Unknown ScratchLink socket Type: ${this._type}`);
         }
 
-        if (this._onOpen && this._onClose && this._onError && this._handleMessage) {
+        // Try ws:// (the new way) and wss:// (the old way) simultaneously. If either connects, close the other. If we
+        // were to try one and fall back to the other on failure, that could mean a delay of 30 seconds or more for
+        // those who need the fallback.
+        // If both connections fail we should report only one error.
+
+        const setSocket = (socketToUse, socketToClose) => {
+            socketToClose.onopen = socketToClose.onerror = null;
+            socketToClose.close();
+
+            this._ws = socketToUse;
             this._ws.onopen = this._onOpen;
             this._ws.onclose = this._onClose;
             this._ws.onerror = this._onError;
-        } else {
-            throw new Error('Must set open, close, message and error handlers before calling open on the socket');
-        }
+            this._ws.onmessage = this._onMessage.bind(this);
+        };
 
-        this._ws.onmessage = this._onMessage.bind(this);
+        const ws = new WebSocket(`ws://127.0.0.1:20111/${pathname}`);
+        const wss = new WebSocket(`wss://device-manager.scratch.mit.edu:20110/${pathname}`);
+
+        const connectTimeout = setTimeout(() => {
+            // neither socket succeeded before the timeout
+            setSocket(ws, wss);
+            this._ws.onerror(new Event('timeout'));
+        }, 15 * 1000);
+        ws.onopen = openEvent => {
+            clearTimeout(connectTimeout);
+            setSocket(ws, wss);
+            this._ws.onopen(openEvent);
+        };
+        wss.onopen = openEvent => {
+            clearTimeout(connectTimeout);
+            setSocket(wss, ws);
+            this._ws.onopen(openEvent);
+        };
+
+        let wsError;
+        let wssError;
+        const errorHandler = () => {
+            // if only one has received an error, we haven't overall failed yet
+            if (wsError && wssError) {
+                clearTimeout(connectTimeout);
+                setSocket(ws, wss);
+                this._ws.onerror(wsError);
+            }
+        };
+        ws.onerror = errorEvent => {
+            wsError = errorEvent;
+            errorHandler();
+        };
+        wss.onerror = errorEvent => {
+            wssError = errorEvent;
+            errorHandler();
+        };
     }
 
     close () {


### PR DESCRIPTION
### Proposed Changes

When attempting to contact Scratch Link, try both `ws://127.0.0.1:20111` and `wss://device-manager...:20110/` simultaneously. If either connects, use that connection. If both fail, report the error.

### Reason for Changes

Upcoming versions of Scratch Link will listen on `ws://127.0.0.1:20111`. See LLK/scratch-link#204 for details.

Existing versions of Scratch Link will stop working over time (see #200), and likely do not work for most users already. However, through luck or manual intervention some users may still be using those existing versions of Scratch Link, so this change retains support for that.

Trying the `ws://` connection first then falling back to `wss://`, or vice versa, would mean that users who need the fallback would need to wait for the other connection type to fail first. By default that failure can take an indefinite amount of time, especially if some other program is listening on the port. This change mitigates that delay in two ways:

1. This change attempts both connections simultaneously. If one succeeds, the other is closed. If both fail, that's reported as a connection failure.
2. There is an artificial 15-second timeout which interrupts either connection if they appear to be stuck, such as if there is a non-WebSocket application listening on the port.

Note that a connection to `ws://127.0.0.1` from a page loaded over `https://` is expected to fail in Safari.

### Test Coverage

Tested locally using a development build of Scratch Link with LLK/scratch-link#204, and without Scratch Link running at all. I also tested failure with Scratch Link 1.3.82, but I have not been able to test success with Scratch Link 1.3.82 because my development machines have already collected the revocation of the Scratch Link 1.3.x certificates.
