### PR TITLE
Added function to stop thread if a running script is removed from or attached to another script to resolve #2263

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -213,7 +213,7 @@ class Blocks {
     getTopLevelScript (id) {
         let block = this._blocks[id];
         if (typeof block === 'undefined') return null;
-        while (block.parent !== null) {
+        while (block.parent !== null && typeof this._blocks[block.parent] !== 'undefined') {
             block = this._blocks[block.parent];
         }
         return block.id;
@@ -710,6 +710,11 @@ class Blocks {
             block.x = e.newCoordinate.x;
             block.y = e.newCoordinate.y;
         }
+
+        // Stops a thread if a running script is removed from or attached to another script
+        const destBlockId = (typeof e.newParent === 'undefined') ? e.id : this.getTopLevelScript(e.newParent);
+        const originBlockId = (typeof e.oldParent === 'undefined') ? e.id : this.getTopLevelScript(e.oldParent);
+        this.runtime.stopMovingThread(destBlockId, originBlockId);
 
         // Remove from any old parent.
         if (typeof e.oldParent !== 'undefined') {

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1651,6 +1651,22 @@ class Runtime extends EventEmitter {
     }
 
     /**
+     * Stop a thread if a running script is removed from or attached to another script.
+     * @param {!string} destBlockId ID of block that starts the destination script.
+     * @param {!string} originBlockId ID of block that starts the original script.
+     */
+    stopMovingThread (destBlockId, originBlockId) {
+        if (destBlockId !== originBlockId) {
+            for (let i = 0; i < this.threads.length; i++) {
+                if (this.threads[i].topBlock === destBlockId ||
+                        this.threads[i].topBlock === originBlockId) {
+                    this._stopThread(this.threads[i]);
+                }
+            }
+        }
+    }
+
+    /**
      * Return whether a thread is currently active/running.
      * @param {?Thread} thread Thread object to check.
      * @return {boolean} True if the thread is active/running.


### PR DESCRIPTION
### Resolves

Resolves #2263

### Reason for Changes

Attaching and detaching a running loop from a script both lead to broken behavior. As described in #2263 originally, a second "copy" of the running script seems to be created when the script is toggled. This behavior exists because the toggleScript() function in runtime.js pushes a new thread if the top block of a script stack of blocks doesn't already exist as a running thread. The issue occurs when a running script is attached to or removed from another script because the top block with which the original script was run does not match the top block of the script after the running loop block has been moved. Thus, two "copies" of the loop can be run as two different threads with two different top blocks at the same time.

### Proposed Changes

To address this issue, I defined a new function, stopMovingThread(), in runtime.js to stop the thread currently running a script when that script is either removed from or attached to another script. This function is called by moveBlock() in blocks.js each time a block is moved. Thus, this change allows us to prevent similar threads from running the same scripts and resolves #2263.
