### PR TITLE
correctly handle JSON-RPC requests with ID=0

### DIFF
--- a/src/util/jsonrpc.js
+++ b/src/util/jsonrpc.js
@@ -98,7 +98,7 @@ class JSONRPC {
     _handleRequest (json) {
         const {method, params, id} = json;
         const rawResult = this.didReceiveCall(method, params);
-        if (id) {
+        if (id !== null && typeof id !== 'undefined') {
             Promise.resolve(rawResult).then(
                 result => {
                     this._sendResponse(id, result);


### PR DESCRIPTION
### Proposed Changes

Check the JSON-RPC request ID against `null` and `undefined` rather than just checking if it's truthy.

### Reason for Changes

The old code would skip responding to a request with ID=0, which is in violation of the JSON-RPC spec.

### Test Coverage

Tested locally:
* in the Scratch Link playground with Scratch Link 2.0
* in scratch-gui with Scratch Link 1.4.3