### PR TITLE
ci(node): update CI config to use Node LTS (was 8 & 10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-- 8
-- 10
+- lts/*
 env:
   global:
   - NODE_ENV=production
@@ -19,12 +18,9 @@ script: npm run $NPM_SCRIPT
 jobs:
     include:
     - env: NPM_SCRIPT=lint
-      node_js: 8
     - env: NPM_SCRIPT=build
-      node_js: 8
       if: not (type != pull_request AND (branch =~ /^(develop|master|hotfix\/)/))
     - stage: release
-      node_js: 8
       env: NPM_SCRIPT=build
       before_deploy:
       - >


### PR DESCRIPTION
### Proposed Changes

For the Node version number in the Travis CI config, specify `lts/*` instead of 8 and 10.

### Reason for Changes

We should keep up to date with LTS versions of Node, which are currently 14 & 16. Ideally I'd like to test both, but IMO keeping up to date is more important than testing more than one version of Node... especially with how stable Node is these days.

### Test Coverage

See CI build of this PR :)