### PR TITLE
Delete sound.broken when updating the sound buffer

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -792,6 +792,7 @@ class VirtualMachine extends EventEmitter {
      */
     updateSoundBuffer (soundIndex, newBuffer, soundEncoding) {
         const sound = this.editingTarget.sprite.sounds[soundIndex];
+        if (sound && sound.broken) delete sound.broken;
         const id = sound ? sound.soundId : null;
         if (id && this.runtime && this.runtime.audioEngine) {
             this.editingTarget.sprite.soundBank.getSoundPlayer(id).buffer = newBuffer;


### PR DESCRIPTION
We don't want to save info about the sound being broken if the user managed to make an update to the sound. This is just for completeness of the sound loading error handling work from #3637 