### PR TITLE
Add view documentation link

### DIFF
--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -78,6 +78,9 @@
               <label>Run the full suite</label>
           </div>
       </a>
+      <a href="./docs">
+          <label>View documentation</label>
+      </a>
     </div>
   </div>
 


### PR DESCRIPTION
### Resolves

I didn't make a Github issue, since this is such a small addition. I can make one if necessary.

### Proposed Changes

This adds a small link at the bottom of the playground that goes to the JSDoc.

### Reason for Changes

For the past few days I have been crawling through the code to figure what everything did. I didn't realize there was documentation until now.

### Test Coverage

I have not made any tests for this, since that seems superfluous.
