### PR TITLE
fix(sec): upgrade adm-zip to 0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@babel/preset-env": "7.14.8",
         "@commitlint/cli": "17.0.2",
         "@commitlint/config-conventional": "17.0.2",
-        "adm-zip": "0.4.11",
+        "adm-zip": "0.5.2",
         "babel-eslint": "10.1.0",
         "babel-loader": "8.2.2",
         "callsite": "1.0.0",
@@ -8650,12 +8650,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
-      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.2.tgz",
+      "integrity": "sha512-lUI3ZSNsfQXNYNzGjt68MdxzCs0eW29lgL74y/Y2h4nARgHmH3poFWuK3LonvFbNHFt4dTb2X/QQ4c1ZUWWsJw==",
       "dev": true,
       "engines": {
-        "node": ">=0.3.0"
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -38890,9 +38890,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
-      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.2.tgz",
+      "integrity": "sha512-lUI3ZSNsfQXNYNzGjt68MdxzCs0eW29lgL74y/Y2h4nARgHmH3poFWuK3LonvFbNHFt4dTb2X/QQ4c1ZUWWsJw==",
       "dev": true
     },
     "agent-base": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@babel/preset-env": "7.14.8",
     "@commitlint/cli": "17.0.2",
     "@commitlint/config-conventional": "17.0.2",
-    "adm-zip": "0.4.11",
+    "adm-zip": "0.5.2",
     "babel-eslint": "10.1.0",
     "babel-loader": "8.2.2",
     "callsite": "1.0.0",


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in adm-zip 0.4.11
- [MPS-2022-13529](https://www.oscs1024.com/hd/MPS-2022-13529)


### What did I do？
Upgrade adm-zip from 0.4.11 to 0.5.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS