### PR TITLE
feat: ability to clear flyout blocks when language changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,9 @@ commands:
             fi
 jobs:
   build_no_release:
-    executor: node/default # defaults to LTS
+    executor:
+      name: node/default
+      tag: '16.18'
     steps:
       - checkout
       - node/install-packages
@@ -29,7 +31,9 @@ jobs:
       - run: npm run build
       - deploy_gh_pages
   build_and_release:
-    executor: node/default # defaults to LTS
+    executor:
+      name: node/default
+      tag: '16.18'
     steps:
       - checkout
       - node/install-packages
@@ -38,7 +42,9 @@ jobs:
       - deploy_gh_pages
       - run: npx semantic-release
   update_i18n:
-    executor: node/default # defaults to LTS
+    executor:
+      name: node/default
+      tag: '16.18'
     steps:
       - checkout
       - node/install-packages

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -832,6 +832,14 @@ class Blocks {
     }
 
     /**
+     * Delete all blocks and their associated scripts.
+     */
+    deleteAllBlocks () {
+        const blockIds = Object.keys(this._blocks);
+        blockIds.forEach(blockId => this.deleteBlock(blockId));
+    }
+
+    /**
      * Returns a map of all references to variables or lists from blocks
      * in this block container.
      * @param {Array<object>} optBlocks Optional list of blocks to constrain the search to.

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1199,6 +1199,13 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
+     * Delete all of the flyout blocks.
+     */
+    clearFlyoutBlocks () {
+        this.runtime.flyoutBlocks.deleteAllBlocks();
+    }
+
+    /**
      * Set an editing target. An editor UI can use this function to switch
      * between editing different targets, sprites, etc.
      * After switching the editing target, the VM may emit updates

--- a/test/unit/virtual-machine.js
+++ b/test/unit/virtual-machine.js
@@ -1055,3 +1055,16 @@ test('toJSON encodes Infinity/NaN as 0, not null', t => {
 
     t.end();
 });
+
+test('clearFlyoutBlocks removes all of the flyout blocks', t => {
+    const vm = new VirtualMachine();
+    const flyoutBlocks = vm.runtime.flyoutBlocks;
+
+    flyoutBlocks.createBlock(adapter(events.mockVariableBlock)[0]);
+    t.equal(Object.keys(flyoutBlocks._blocks).length, 1);
+
+    vm.clearFlyoutBlocks();
+    t.equal(Object.keys(flyoutBlocks._blocks).length, 0);
+
+    t.end();
+});


### PR DESCRIPTION
### Resolves

- Resolves [ENA-146](https://scratchfoundation.atlassian.net/browse/ENA-146)

### Proposed Changes

- Add a `clearFlyoutBlocks()` to `VirtualMachine` that removes all of the blocks from `runtime.flyoutBlocks`
- Use Node 16 for CircleCI builds

### Reason for Changes

- See LLK/scratch-gui#8705 for details of the problem this is attempting to solve. `scratch-gui` needs a way to clear out the flyout blocks so that the virtual machine and `scratch-blocks` stays in sync during a language change.
- The `scratch-vm` CircleCI builds are currently broken. There may be a different [long-term fix](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported), but switching to Node 16 will allow this fix to proceed.

### Test Coverage

- Added unit test for `clearFlyoutBlocks` functionalty
- Tested integration with `scratch-gui` in LLK/scratch-gui#8705
