### PR TITLE
Use script glow status to track whether the project is running

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -248,10 +248,10 @@ class Runtime extends EventEmitter {
         this._scriptGlowsPreviousFrame = [];
 
         /**
-         * Number of non-monitor threads running during the previous frame.
-         * @type {number}
+         * Whether any non-monitor threads ran during the previous frame.
+         * @type {boolean}
          */
-        this._nonMonitorThreadCount = 0;
+        this._projectRanLastFrame = false;
 
         /**
          * All threads that finished running and were removed from this.threads
@@ -2093,11 +2093,12 @@ class Runtime extends EventEmitter {
             this.profiler.stop();
         }
         this._updateGlows(doneThreads);
+
+        const threadNonMonitor = thread => !thread.updateMonitor;
         // Add done threads so that even if a thread finishes within 1 frame, the green
         // flag will still indicate that a script ran.
-        this._emitProjectRunStatus(
-            this.threads.length + doneThreads.length -
-                this._getMonitorThreadCount([...this.threads, ...doneThreads]));
+        const anyNonMonitorThreadsRunning = this.threads.some(threadNonMonitor) || doneThreads.some(threadNonMonitor);
+        this._emitProjectRunStatus(anyNonMonitorThreadsRunning);
         // Store threads that completed this iteration for testing and other
         // internal purposes.
         this._lastStepDoneThreads = doneThreads;
@@ -2129,20 +2130,6 @@ class Runtime extends EventEmitter {
             this.profiler.stop();
             this.profiler.reportFrames();
         }
-    }
-
-    /**
-     * Get the number of threads in the given array that are monitor threads (threads
-     * that update monitor values, and don't count as running a script).
-     * @param {!Array.<Thread>} threads The set of threads to look through.
-     * @return {number} The number of monitor threads in threads.
-     */
-    _getMonitorThreadCount (threads) {
-        let count = 0;
-        threads.forEach(thread => {
-            if (thread.updateMonitor) count++;
-        });
-        return count;
     }
 
     /**
@@ -2239,19 +2226,17 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Emit run start/stop after each tick. Emits when `this.threads.length` goes
-     * between non-zero and zero
-     *
-     * @param {number} nonMonitorThreadCount The new nonMonitorThreadCount
+     * Emit run start/stop after each tick. Emits when `this.threads.length` goes between non-zero and zero
+     * @param {boolean} projectRunning Whether the project is running (threads.length > 0)
      */
-    _emitProjectRunStatus (nonMonitorThreadCount) {
-        if (this._nonMonitorThreadCount === 0 && nonMonitorThreadCount > 0) {
+    _emitProjectRunStatus (projectRunning) {
+        if (!this._projectRanLastFrame && projectRunning) {
             this.emit(Runtime.PROJECT_RUN_START);
         }
-        if (this._nonMonitorThreadCount > 0 && nonMonitorThreadCount === 0) {
+        if (this._projectRanLastFrame && !projectRunning) {
             this.emit(Runtime.PROJECT_RUN_STOP);
         }
-        this._nonMonitorThreadCount = nonMonitorThreadCount;
+        this._projectRanLastFrame = projectRunning;
     }
 
     /**

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -205,7 +205,7 @@ class Runtime extends EventEmitter {
          * These will execute on `_editingTarget.`
          * @type {!Blocks}
          */
-        this.flyoutBlocks = new Blocks(this, true /* force no glow */);
+        this.flyoutBlocks = new Blocks(this, false /* force no glow */);
 
         /**
          * Storage container for monitor blocks.


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-vm/issues/1948
Closes https://github.com/LLK/scratch-vm/pull/2419

### Proposed Changes

- Refactor _emitProjectRunStatus to take a simple Boolean "project running/not running" argument
- Count threads as "project running" only if they request a block glow
- Allow flyout blocks to request a block glow

### Reason for Changes

This fixes edge-activated hat blocks causing the project to always count as "running" and making the green flag appear active even if no scripts are running.

The system for tracking script glows is much more robust and accurate than the system that was previously used for determining if the project was running, so we should make use of that.

The rationale for each change is described in the corresponding commit message.

### Test Coverage

Tested manually, and existing tests pass.

Here's what you should look for when testing this:
- Regular event hat blocks (when key pressed, etc) should cause the green flag button to appear activated.
- Edge-activated hat blocks (when loudness, etc) with *no blocks attached* should never cause the green flag button to appear activated.
- Edge-activated hat blocks *with blocks attached* should cause the green flag button to appear activated when those attached blocks are running.
- All of the above should hold true even if another sprite is selected.
- Clicking a flyout block should cause the green flag button to appear activated. Blocks like "wait" and "glide" should make it appear activated for as long as the block is running.
- Block monitors (aka variable readouts) should never cause the green flag button to appear activated.
