### PR TITLE
fix: disable metadata for now

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1,6 +1,6 @@
 const EventEmitter = require('events');
 const {OrderedMap} = require('immutable');
-const uuid = require('uuid');
+// const uuid = require('uuid');
 
 const ArgumentType = require('../extension-support/argument-type');
 const Blocks = require('./blocks');
@@ -2032,8 +2032,9 @@ class Runtime extends EventEmitter {
             return;
         }
 
-        const newRunId = uuid.v1();
-        this.storage.scratchFetch.setMetadata(this.storage.scratchFetch.RequestMetadata.RunId, newRunId);
+        // TODO: re-enable metadata
+        // const newRunId = uuid.v1();
+        // this.storage.scratchFetch.setMetadata(this.storage.scratchFetch.RequestMetadata.RunId, newRunId);
     }
 
     /**

--- a/test/integration/runId.js
+++ b/test/integration/runId.js
@@ -1,6 +1,6 @@
 const Worker = require('tiny-worker');
 const path = require('path');
-const test = require('tap').test;
+const test = require('tap');
 
 const VirtualMachine = require('../../src/index');
 const dispatch = require('../../src/dispatch/central-dispatch');
@@ -15,7 +15,8 @@ const project = readFileToBuffer(uri);
 // By default Central Dispatch works with the Worker class built into the browser. Tell it to use TinyWorker instead.
 dispatch.workerClass = Worker;
 
-test('runId', async t => {
+// TODO: re-enable metadata
+test.skip('runId', async t => {
     const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
     const isGuid = data => guidRegex.test(data);
 


### PR DESCRIPTION
### Proposed Changes

Don't set metadata for now.

### Reason for Changes

Effectively backs out the storage changes without relying on `scratch-storage` version 2.3.0 or higher. Those newer versions are causing build problems with `scratch-gui` so this is a very temporary workaround.

### Test Coverage

Metadata tests have been disabled since they don't make sense when we're not setting metadata. Otherwise, coverage remains the same.