### PR TITLE
Detect Backspace and Shift keys

### DIFF
--- a/src/blocks/scratch3_event.js
+++ b/src/blocks/scratch3_event.js
@@ -12,6 +12,9 @@ class Scratch3EventBlocks {
             this.runtime.startHats('event_whenkeypressed', {
                 KEY_OPTION: key
             });
+        });
+
+        this.runtime.on('KEY_ANY_PRESSED', () => {
             this.runtime.startHats('event_whenkeypressed', {
                 KEY_OPTION: 'any'
             });

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -17,6 +17,16 @@ const KEY_NAME = {
 };
 
 /**
+ * Names which don't count for the key "any" pressed? block. Items match the
+ * values for KEY_NAME listed above. If a key isn't mentioned here, then it
+ * does count for "any", provided Scratch detects that key at all.
+ * @type {Array<string>}
+ */
+const KEY_NAMES_EXCLUDED_FOR_KEY_ANY_PRESSED = [
+    'shift'
+];
+
+/**
  * An array of the names of scratch keys.
  * @type {Array<string>}
  */
@@ -142,7 +152,10 @@ class Keyboard {
      */
     getKeyIsDown (keyArg) {
         if (keyArg === 'any') {
-            return this._keysPressed.length > 0;
+            const validKeysPressed = this._keysPressed.filter(key =>
+                !KEY_NAMES_EXCLUDED_FOR_KEY_ANY_PRESSED.includes(key));
+
+            return validKeysPressed.length > 0;
         }
         const scratchKey = this._keyArgToScratchKey(keyArg);
         return this._keysPressed.indexOf(scratchKey) > -1;

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -10,7 +10,10 @@ const KEY_NAME = {
     UP: 'up arrow',
     RIGHT: 'right arrow',
     DOWN: 'down arrow',
-    ENTER: 'enter'
+    ENTER: 'enter',
+    BACKSPACE: 'backspace',
+    DELETE: 'delete',
+    SHIFT: 'shift'
 };
 
 /**
@@ -58,6 +61,9 @@ class Keyboard {
         case 'Down':
         case 'ArrowDown': return KEY_NAME.DOWN;
         case 'Enter': return KEY_NAME.ENTER;
+        case 'Backspace': return KEY_NAME.BACKSPACE;
+        case 'Delete': return KEY_NAME.DELETE;
+        case 'Shift': return KEY_NAME.SHIFT;
         }
         // Ignore modifier keys
         if (keyString.length > 1) {

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -131,10 +131,19 @@ class Keyboard {
     postData (data) {
         if (!data.key) return;
         const scratchKey = this._keyStringToScratchKey(data.key);
+
         if (scratchKey === '') return;
         const index = this._keysPressed.indexOf(scratchKey);
+
         if (data.isDown) {
+            // Emit a generic event indicating which key was pressed.
             this.runtime.emit('KEY_PRESSED', scratchKey);
+
+            // Emit a specific event indicating that some key valid for "any" was pressed.
+            if (!KEY_NAMES_EXCLUDED_FOR_KEY_ANY_PRESSED.includes(scratchKey)) {
+                this.runtime.emit('KEY_ANY_PRESSED');
+            }
+
             // If not already present, add to the list.
             if (index < 0) {
                 this._keysPressed.push(scratchKey);

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -159,10 +159,8 @@ class Keyboard {
      */
     getKeyIsDown (keyArg) {
         if (keyArg === 'any') {
-            const validKeysPressed = this._keysPressed.filter(key =>
+            return this._keysPressed.some(key =>
                 !KEY_NAMES_EXCLUDED_FOR_KEY_ANY_PRESSED.includes(key));
-
-            return validKeysPressed.length > 0;
         }
         const scratchKey = this._keyArgToScratchKey(keyArg);
         return this._keysPressed.indexOf(scratchKey) > -1;

--- a/src/io/keyboard.js
+++ b/src/io/keyboard.js
@@ -12,7 +12,6 @@ const KEY_NAME = {
     DOWN: 'down arrow',
     ENTER: 'enter',
     BACKSPACE: 'backspace',
-    DELETE: 'delete',
     SHIFT: 'shift'
 };
 
@@ -72,7 +71,6 @@ class Keyboard {
         case 'ArrowDown': return KEY_NAME.DOWN;
         case 'Enter': return KEY_NAME.ENTER;
         case 'Backspace': return KEY_NAME.BACKSPACE;
-        case 'Delete': return KEY_NAME.DELETE;
         case 'Shift': return KEY_NAME.SHIFT;
         }
         // Ignore modifier keys

--- a/test/unit/io_keyboard.js
+++ b/test/unit/io_keyboard.js
@@ -2,6 +2,37 @@ const test = require('tap').test;
 const Keyboard = require('../../src/io/keyboard');
 const Runtime = require('../../src/engine/runtime');
 
+/**
+ * Return a "live" object which tracks events that have been emitted. When an
+ * event is emitted, the event object is pushed onto the corresponding array.
+ * Use t.same() to match these (it strictly compares the array against the
+ * expected value, including the length, i.e. number of tims emitted).
+ *
+ * Note that KEY_ANY_PRESSED doesn't emit any event details and so its array
+ * should only contain `undefined`.
+ *
+ * @param {Runtime} rt - the runtime to listen for events on
+ * @returns {object} live mapping of event name to emitted event values
+ */
+const listenForKeyboardEvents = function (rt) {
+    const eventsEmitted = {
+        KEY_PRESSED: [],
+        KEY_ANY_PRESSED: []
+    };
+
+    rt.on('KEY_PRESSED', event => {
+        eventsEmitted.KEY_PRESSED.push(event);
+    });
+
+    // Note that KEY_ANY_PRESSED doesn't emit any event details and so
+    // the event value should be `undefined`.
+    rt.on('KEY_ANY_PRESSED', event => {
+        eventsEmitted.KEY_ANY_PRESSED.push(event);
+    });
+
+    return eventsEmitted;
+};
+
 test('spec', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
@@ -15,89 +46,154 @@ test('spec', t => {
 test('space key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
+    const eventsEmitted = listenForKeyboardEvents(rt);
 
     k.postData({
         key: ' ',
         isDown: true
     });
+
     t.strictDeepEquals(k._keysPressed, ['space']);
+
     t.strictEquals(k.getKeyIsDown('space'), true);
     t.strictEquals(k.getKeyIsDown('any'), true);
+
+    t.same(eventsEmitted.KEY_PRESSED, ['space']);
+    t.same(eventsEmitted.KEY_ANY_PRESSED, [undefined]);
+
     t.end();
 });
 
 test('letter key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
+    const eventsEmitted = listenForKeyboardEvents(rt);
 
     k.postData({
         key: 'a',
         isDown: true
     });
+
     t.strictDeepEquals(k._keysPressed, ['A']);
+
     t.strictEquals(k.getKeyIsDown(65), true);
     t.strictEquals(k.getKeyIsDown('a'), true);
     t.strictEquals(k.getKeyIsDown('A'), true);
     t.strictEquals(k.getKeyIsDown('any'), true);
+
+    t.same(eventsEmitted.KEY_PRESSED, ['A']);
+    t.same(eventsEmitted.KEY_ANY_PRESSED, [undefined]);
+
     t.end();
 });
 
 test('number key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
+    const eventsEmitted = listenForKeyboardEvents(rt);
 
     k.postData({
         key: '1',
         isDown: true
     });
+
     t.strictDeepEquals(k._keysPressed, ['1']);
+
     t.strictEquals(k.getKeyIsDown(49), true);
     t.strictEquals(k.getKeyIsDown('1'), true);
     t.strictEquals(k.getKeyIsDown('any'), true);
+
+    t.same(eventsEmitted.KEY_PRESSED, ['1']);
+    t.same(eventsEmitted.KEY_ANY_PRESSED, [undefined]);
+
     t.end();
 });
 
 test('non-english key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
+    const eventsEmitted = listenForKeyboardEvents(rt);
 
     k.postData({
         key: '日',
         isDown: true
     });
+
     t.strictDeepEquals(k._keysPressed, ['日']);
+
     t.strictEquals(k.getKeyIsDown('日'), true);
     t.strictEquals(k.getKeyIsDown('any'), true);
+
+    t.same(eventsEmitted.KEY_PRESSED, ['日']);
+    t.same(eventsEmitted.KEY_ANY_PRESSED, [undefined]);
+
     t.end();
 });
 
-test('ignore modifier key', t => {
+test('shift key', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
+    const eventsEmitted = listenForKeyboardEvents(rt);
 
     k.postData({
         key: 'Shift',
         isDown: true
     });
-    t.strictDeepEquals(k._keysPressed, []);
+
+    t.strictDeepEquals(k._keysPressed, ['shift']);
+
+    t.strictEquals(k.getKeyIsDown('shift'), true);
     t.strictEquals(k.getKeyIsDown('any'), false);
+
+    t.same(eventsEmitted.KEY_PRESSED, ['shift']);
+    t.same(eventsEmitted.KEY_ANY_PRESSED, []);
+
+    t.end();
+});
+
+test('ignore control key', t => {
+    const rt = new Runtime();
+    const k = new Keyboard(rt);
+    const eventsEmitted = listenForKeyboardEvents(rt);
+
+    k.postData({
+        key: 'Control',
+        isDown: true
+    });
+
+    t.strictDeepEquals(k._keysPressed, []);
+
+    t.strictEquals(k.getKeyIsDown('control'), false);
+    t.strictEquals(k.getKeyIsDown('any'), false);
+
+    t.same(eventsEmitted.KEY_PRESSED, []);
+    t.same(eventsEmitted.KEY_ANY_PRESSED, []);
+
     t.end();
 });
 
 test('keyup', t => {
     const rt = new Runtime();
     const k = new Keyboard(rt);
+    const eventsEmitted = listenForKeyboardEvents(rt);
 
     k.postData({
         key: 'ArrowLeft',
         isDown: true
     });
+
     k.postData({
         key: 'ArrowLeft',
         isDown: false
     });
+
     t.strictDeepEquals(k._keysPressed, []);
+
     t.strictEquals(k.getKeyIsDown('left arrow'), false);
     t.strictEquals(k.getKeyIsDown('any'), false);
+
+    t.same(eventsEmitted.KEY_PRESSED, ['left arrow']);
+    t.same(eventsEmitted.KEY_ANY_PRESSED, [undefined]);
+
     t.end();
 });


### PR DESCRIPTION
### Resolves

Resolves #1892.

See prior art & discussion in #2247.

### Proposed Changes

Adds support for detecting the shift and backspace keys in the "key pressed?" block.

User-apparent details:

* Like "enter", these options are not included in the block dropdown. They must be accessed by dropping in a reporter that returns the name of the key (specifically, "shift" or "backspace").
* The "shift" key does not count for the "key any pressed?" or "when any key pressed".
* The "shift" key responds appropriately to an operating system's "sticky keys" feature, i.e. if sticky keys is enabled then pressing shift once will leave "key shift pressed?" as true until shift is pressed again.

Internal details:

* A new `KEY_NAMES_EXCLUDED_FOR_KEY_ANY_PRESSED` array is added (its only item is `'shift'`). Scratch keys here are not counted for the "key any pressed?" or "when any key pressed" blocks.
* `getKeyIsDown` now performs a `.some()` call to check if any of the keys currently pressed is not excluded. This will have only minuscule performance overhead - in all cases it will do one of the following:
  * Test zero cases, because the list is empty, so immediately return false. (`.some()` on an empty array is always false.)
  * Test one case, because the list starts with a valid key. (`.some()` exits as soon as it matches one true value.)
  * Test one case, because the list only includes `'shift'`. (`.some()` returns false once it's tested every item and none of them was true.)
  * Test two cases, because the list starts with `shift` and is followed by a valid key.
* `postData` now usually emits two events - the existing one remains `emit('KEY_PRESSED', scratchKey)` and the new one is `emit('KEY_ANY_PRESSED')`. The former is used for responding to specific keys; the latter for responding to "any" key (in which case it doesn't matter which key is pressed, and so that detail is not emitted).
  * This has similarly tiny performance overhead as it now must check if the key pressed is included in a one-item list. `postData` isn't called at nearly a high enough frequency for this to be costly.
  * `scratch3_event.js` is updated to listen to both of these events: the first for starting specific-key "when key pressed" blocks, the second for "when any key pressed" blocks.
  * (`scratch3_sensing.js` requires no changes because it already calls `ioQuery('keyboard', 'getKeyIsDown', ['any'])`.)
* No special code logic is required to support sticky keys - the browser/OS does the right job for us.

### Reason for Changes

* **Backspace:**
  * Backspace is an obvious important key for any "typewriter" project, i.e. any project that displays on-screen input. Without backspace detection, projects have to come up with creative - but clumsy - workarounds. Allowing backspace to be detected means enabling a host of projects that work with any kind of text input. (The example that inspired me to do this PR was someone saying they needed backspace detection for their Wordle project!)
  * Backspace is universally available on all keyboards. It's also universally understood as "the key for getting rid of the character behind the text input cursor" - text input is something we all do. It's used in some games as a "go back" control, as well.
  * While in development, but not anymore, this PR included an option for "delete" as well. But it's controversial as this key isn't available on all keyboards and may cause confusion (the backspace key is actually labelled "delete" on many keyboards!).
* **Shift:**
  * Shift is also an extremely important key for any project with text input. Case-sensitive comparison in Scratch is challenging; however, case-sensitive *input* is outright impossible. The shift key is universally the key for capitalizing the letter being pressed.
  * Symbol detection like "#" or "(" works in current Scratch, but not capital letters, because the "key pressed?" block itself is case-insensitive. Changing *that* would be a breaking change, but adding support for detecting "shift" on its own should not break anything.
  * "Shift" is a modifier key, but it's not a *control* key like control or meta/super/command (or arguably alt/option) are. Generally speaking, browsers and operating systems do not have any "special" behavior for pressing shift plus another key, because text entry is such a common practice and shift+letter is such a universal input during text entry. This doubly applies for Scratch because Scratch projects *do*, very often, detect keyboard input (in a typing context or otherwise).
  * Caveat: It's not practical to detect or supply information about caps lock. So projects can adapt to the shift key, but won't respect caps lock. This is a minor issue IMO, but worth noting.
* This is not the first time a key has been added to Scratch previously. As mentioned, refer to #2247 for discussion about the "enter" key.
* Because "shift" is primarily a modifier key, and is a key which wasn't detected at all before, it's excluded from the "any key pressed?" blocks. This is in acknowledgement of [a comment on the "enter" pull request](https://github.com/scratchfoundation/scratch-vm/pull/2247#issuecomment-519159674) - it's important not to break existing behavior.
* That said, "backspace" *does* get counted in "key any pressed?" and "when key any pressed". This is a change to existing projects. However, it seems minor, and in the same vein as "enter", which also changed existing projects. Both "backspace" and "enter" are types of "actions", i.e. pressing backspace represents doing a thing (deleting a character, going back, etc) just like enter (inserting a new line, confirming an action, etc). Modifier keys on the other hand almost always *precede* an action (insert a *capitalized* letter, perform an *alternate* command, etc).
  * Incidentally, this allows for a convenient way for a project to switch between one set of keyboard behavior and another: "when key any pressed: if key shift pressed: say (A key combination was pressed! Ooo!)"

### Test Coverage

Tested manually and with unit tests.

Use the script / project linked: [Keyboard Project.zip](https://github.com/scratchfoundation/scratch-vm/files/13629461/Keyboard.Project.zip)

<img width="424" alt="Screenshot 2023-12-10 at 6 34 27 PM" src="https://github.com/scratchfoundation/scratch-vm/assets/9948030/60f7aaf0-ac74-408c-8bb3-ea76709fa013">

For unit tests:

* The existing "ignore modifier key" test has been renamed to "ignore control key" and tests a control key instead of shift.
* A new test has been added for "shift" specifically, to test that it is detected but does not count for "any".
* All tests are updated to check the `KEY_PRESSED` and `KEY_ANY_PRESSED` events used by the "when key pressed" block, improving test coverage (and verifying an important detail that "shift" shouldn't count for "when any key pressed").
