### PR TITLE
fix:avoid unexpected value of videoState

### DIFF
--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -566,8 +566,8 @@ class Scratch3VideoSensingBlocks {
      * @param {VideoState} args.VIDEO_STATE - the video state to set the device to
      */
     videoToggle (args) {
-        const state = args.VIDEO_STATE;
-        this.globalVideoState = Object.values(VideoState).includes(state) ? state : VideoState.OFF;
+        const state = Object.values(VideoState).includes(args.VIDEO_STATE) ? args.VIDEO_STATE : VideoState.OFF;
+        this.globalVideoState = state;
         if (state === VideoState.OFF) {
             this.runtime.ioDevices.video.disableVideo();
         } else {

--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -567,7 +567,7 @@ class Scratch3VideoSensingBlocks {
      */
     videoToggle (args) {
         const state = args.VIDEO_STATE;
-        this.globalVideoState = state;
+        this.globalVideoState = Object.values(VideoState).includes(state) ? state : VideoState.OFF;
         if (state === VideoState.OFF) {
             this.runtime.ioDevices.video.disableVideo();
         } else {


### PR DESCRIPTION
### Proposed Changes

video_sensing extensions videoToggle only receive the expected state value

### Reason for Changes

videoToggle block dropdown menu can be dropped by any operator blocks,which would cause unexpected value like number.

