### PR TITLE
 fix:avoid unexpected value of videoState

### DIFF
--- a/src/extensions/scratch3_video_sensing/index.js
+++ b/src/extensions/scratch3_video_sensing/index.js
@@ -566,7 +566,7 @@ class Scratch3VideoSensingBlocks {
      * @param {VideoState} args.VIDEO_STATE - the video state to set the device to
      */
     videoToggle (args) {
-        const state = args.VIDEO_STATE;
+        const state = Object.values(VideoState).includes(args.VIDEO_STATE) ? args.VIDEO_STATE : VideoState.OFF;
         this.globalVideoState = state;
         if (state === VideoState.OFF) {
             this.runtime.ioDevices.video.disableVideo();


### PR DESCRIPTION
### Proposed Changes
video_sensing extensions videoToggle only receive the expected state value

### Reason for Changes

videoToggle block dropdown menu can be dropped by any operator blocks,which would cause unexpected value, which would make the sb3 file could not be opened once after user saved it.

