### PR TITLE
fix: wedo2 stop motor when power set to 0

### DIFF
--- a/src/extensions/scratch3_wedo2/index.js
+++ b/src/extensions/scratch3_wedo2/index.js
@@ -1375,7 +1375,11 @@ class Scratch3WeDo2Blocks {
         this._forEachMotor(args.MOTOR_ID, motorIndex => {
             const motor = this._peripheral.motor(motorIndex);
             if (motor) {
-                motor.power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
+                const power = MathUtil.clamp(Cast.toNumber(args.POWER), 0, 100);
+                if (power === 0) {
+                    motor.turnOff();
+                }
+                motor.power = power;
                 motor.turnOn();
             }
         });


### PR DESCRIPTION
When wedo2 motor power set to 0, the motor stops.

### Resolves

When wedo2 motor power set to 0, the motor won't stop. And motorOff() won't stop the motors either.

### Proposed Changes

This change adds a judge statement. When a startMotorPower() is invoked, it checks args.POWER. If args.POWER === 0, call a motor.turnOff first, then change the power attribute of the motor.

### Reason for Changes

In WeDo2Motor.turnOff(), if this._power === 0, it returns immediately.
In Scratch3WeDo2Blocks.startMotorPower(), if args.POWER === 0, WeDo2Motor.turnOn() returns immediately.
So when you call Scratch3WeDo2Blocks.startMotorPower({POWER:0}), you won't turnOff() the motor, until you set the power to a number other and 0.

### Test Coverage

Scratch3WeDo2Blocks.startMotorPower({POWER:0});
WeDo2Motor.turnOff();
