### PR TITLE
README.md: add up-to-date github pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 [![CI/CD](https://github.com/scratchfoundation/scratch-vm/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/scratchfoundation/scratch-vm/actions/workflows/ci-cd.yml)
 
+To open current build of Scratch VM from Github Pages in your browser:
+
+https://scratchfoundation.github.io/scratch-vm/
+
 ## Installation
 This requires you to have Git and Node.js installed.
 


### PR DESCRIPTION
### Resolves

#3672 ??

### Proposed Changes

Add an up-to-date link to the github pages build to the top of the readme

### Reason for Changes

The up-to-date link works (since gits were transferred to scratchfoundation), it is easier to get to.

### Test Coverage

N/A
