### PR TITLE
Remove redundant bounds check

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -97,10 +97,7 @@ class Scratch3OperatorsBlocks {
     letterOf (args) {
         const index = Cast.toNumber(args.LETTER) - 1;
         const str = Cast.toString(args.STRING);
-        // Out of bounds?
-        if (index < 0 || index >= str.length) {
-            return '';
-        }
+        // `charAt` handles out of bounds by returning an empty string.
         return str.charAt(index);
     }
 


### PR DESCRIPTION
### Resolves

This does not resolve any issue.

### Proposed Changes

This pull request removes a redundant bounds check in `letterOf`.

### Reason for Changes

Performing this bounds check ourselves is redundant since `String.prototype.charAt` already does it for us.

### Test Coverage

I have not added any tests to cover this change but I have checked the ECMAScript language specification to ensure that the change is sound: <https://262.ecma-international.org/14.0/#sec-string.prototype.charat>