### PR TITLE
Eliminate contact judgments between the sprite and mouse pointer off-stage.

### DIFF
--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -743,8 +743,24 @@ class RenderedTarget extends Target {
     isTouchingObject (requestedObject) {
         if (requestedObject === '_mouse_') {
             if (!this.runtime.ioDevices.mouse) return false;
-            const mouseX = this.runtime.ioDevices.mouse.getClientX();
-            const mouseY = this.runtime.ioDevices.mouse.getClientY();
+            let mouseRealX = this.runtime.ioDevices.mouse.getClientX();
+            let mouseRealY = this.runtime.ioDevices.mouse.getClientY();
+            let mouseX;
+            let mouseY
+            if(Math.abs(mouseRealX) > 240){
+                if(mouseRealX > 0){
+                    mouseX = -240;
+                }else{
+                    mouseX = 240;
+                }
+            }
+            if(Math.abs(mouseRealY) > 180){
+                if(mouseRealY > 0){
+                    mouseY = -180;
+                }else{
+                    mouseY = 180;
+                }
+            }
             return this.isTouchingPoint(mouseX, mouseY);
         } else if (requestedObject === '_edge_') {
             return this.isTouchingEdge();


### PR DESCRIPTION
### Issue.
There is a method to detect that the mouse pointer has moved to an off-stage object by placing the sprite off-stage.
Therefore, it is necessary to correct the internal mouse coordinates to in-stage coordinates before contact determination.
### Proposed Changes
Correct the mouse pointer to in-stage coordinates starting at line 745 of /src/sprites/rendered-target.js.
### Reason for change
Because there are many actions in Japan, such as detecting the report button and preview button, where hearts detect stars, add staging and items, and other actions that may activate malicious plans.