### PR TITLE
fix isRecursiveCall failing on flyout blocks

### DIFF
--- a/src/engine/thread.js
+++ b/src/engine/thread.js
@@ -390,7 +390,8 @@ class Thread {
         let callCount = 5; // Max number of enclosing procedure calls to examine.
         const sp = this.stack.length - 1;
         for (let i = sp - 1; i >= 0; i--) {
-            const block = this.target.blocks.getBlock(this.stack[i]);
+            const block = this.target.blocks.getBlock(this.stack[i]) ||
+                this.target.runtime.flyoutBlocks.getBlock(this.stack[i]);
             if (block.opcode === 'procedures_call' &&
                 block.mutation.proccode === procedureCode) {
                 return true;


### PR DESCRIPTION
### Resolves

![image](https://github.com/user-attachments/assets/555a18dc-e161-43d2-bebe-20c4922c411a)

Clicking "b" in the flyout will cause exceptions:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'opcode')
    at n.isRecursiveCall (projects.bundle.js:2:4755076)
    at l.stepToProcedure (projects.bundle.js:2:4743915)
    at e.exports.startProcedure (projects.bundle.js:2:4691130)
    at e.exports.call (projects.bundle.js:2:4674841)
    at e.exports (projects.bundle.js:2:4712562)
    at l.stepThread (projects.bundle.js:2:4743130)
    at l.stepThreads (projects.bundle.js:2:4742334)
    at U._step (projects.bundle.js:2:4735971)
    at projects.bundle.js:2:4740977
```

### Proposed Changes

Fixed the issue by adding flyoutBlocks as a fallback.
This patch was originally from https://github.com/TurboWarp/scratch-vm/pull/227.

### Reason for Changes

I don't know. For better user experience?

### Test Coverage

N/A
