### PR TITLE
Give Sprites Comment Attribute and allow comment duplication

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -20,9 +20,10 @@ class Target extends EventEmitter {
     /**
      * @param {Runtime} runtime Reference to the runtime.
      * @param {?Blocks} blocks Blocks instance for the blocks owned by this target.
+     * @param {?Object.<string, *>} comments Array of comments owned by this target.
      * @constructor
      */
-    constructor (runtime, blocks) {
+    constructor (runtime, blocks, comments) {
         super();
 
         if (!blocks) {
@@ -55,7 +56,7 @@ class Target extends EventEmitter {
          * Key is the comment id.
          * @type {Object.<string,*>}
          */
-        this.comments = {};
+        this.comments = comments || {};
         /**
          * Dictionary of custom state for this target.
          * This can be used to store target-specific custom state for blocks which need it.

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -15,7 +15,7 @@ class RenderedTarget extends Target {
      * @constructor
      */
     constructor (sprite, runtime) {
-        super(runtime, sprite.blocks);
+        super(runtime, sprite.blocks, sprite.comments);
 
         /**
          * Reference to the sprite that this is a render of.

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -54,6 +54,12 @@ class Sprite {
         if (this.runtime && this.runtime.audioEngine) {
             this.soundBank = this.runtime.audioEngine.createBank();
         }
+        /**
+         * Dictionary of comments for this target.
+         * Key is the comment id.
+         * @type {Object.<string.*>}
+         */
+        this.comments = {};
     }
 
     /**
@@ -145,7 +151,11 @@ class Sprite {
             newSprite.blocks.createBlock(block);
         });
 
-
+        Object.keys(this.comments).forEach(commentId => {
+            const newComment = this.comments[commentId];
+            newSprite.comments[newComment.id] = newComment;
+        });
+         
         const allNames = this.runtime.targets.map(t => t.sprite.name);
         newSprite.name = StringUtil.unusedName(this.name, allNames);
 

--- a/src/sprites/sprite.js
+++ b/src/sprites/sprite.js
@@ -151,6 +151,7 @@ class Sprite {
             newSprite.blocks.createBlock(block);
         });
 
+        // Logic to handle new sprite retaining the comments from the current sprite
         Object.keys(this.comments).forEach(commentId => {
             const newComment = this.comments[commentId];
             newSprite.comments[newComment.id] = newComment;

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -68,6 +68,16 @@ test('comments are duplicated when duplicating target', t => {
     });
 });
 
+test('no comments are duplicated when duplicating target with no comments', t => {
+    const r = new Runtime();
+    const s = new Sprite(null, r);
+    const rt = new RenderedTarget(s, r);
+    return rt.duplicate().then(duplicate => {
+        t.equal(Object.keys(duplicate.comments).length, 0);
+        t.end();
+    });
+});
+
 test('direction', t => {
     const r = new Runtime();
     const s = new Sprite(null, r);

--- a/test/unit/sprites_rendered-target.js
+++ b/test/unit/sprites_rendered-target.js
@@ -45,6 +45,29 @@ test('blocks get new id on duplicate', t => {
     });
 });
 
+test('comments are duplicated when duplicating target', t => {
+    const r = new Runtime();
+    const s = new Sprite(null, r);
+    const rt = new RenderedTarget(s, r);
+    rt.createComment('testCommentId', null, 'testcomment', 0, 0, 100, 100, false);
+    return rt.duplicate().then(duplicate => {
+        // ensure duplicated comment exists
+        t.equal(Object.keys(duplicate.comments).length, 1);
+
+        // ensure comment was duplicated correctly
+        const dupComment = duplicate.comments.testCommentId;
+        t.equal(dupComment.id, 'testCommentId');
+        t.equal(dupComment.text, 'testcomment');
+        t.equal(dupComment.x, 0);
+        t.equal(dupComment.y, 0);
+        t.equal(dupComment.width, 100);
+        t.equal(dupComment.height, 100);
+        t.equal(dupComment.minimized, false);
+
+        t.end();
+    });
+});
+
 test('direction', t => {
     const r = new Runtime();
     const s = new Sprite(null, r);


### PR DESCRIPTION
### Resolves

Resolves https://github.com/scratchfoundation/scratch-gui/issues/3687

### Proposed Changes

Create comment attribute in Sprite, and modify duplicate() method to copy over that comment attribute. Targets now take comments as an argument so that they may be copied over in Rendered Target as well.

https://github.com/user-attachments/assets/2d898f3b-5b68-4220-8447-2f932c24dc8e

### Reason for Changes

Comments should be an attribute in Sprite because if comments want to be duplicated when sprites are duplicated, then it would make sense for them to be part of a sprite, rather than merely part of a target,

### Test Coverage

Added unit tests in test/unit/sprites_rendered-target.js to ensure comments are duplicated along with a sprite, also made sure all other tests still pass.
![image](https://github.com/user-attachments/assets/421da8c1-f17f-4c2e-80f2-2103f6349861)

