### PR TITLE
Fix crash when tts language is not a string

### DIFF
--- a/src/extensions/scratch3_text2speech/index.js
+++ b/src/extensions/scratch3_text2speech/index.js
@@ -523,7 +523,7 @@ class Scratch3Text2SpeechBlocks {
         // Support language names dropped onto the menu via reporter block
         // such as a variable containing a language name (in any language),
         // or the translate extension's language reporter.
-        const localeForDroppedName = languageNames.nameMap[locale.toLowerCase()];
+        const localeForDroppedName = languageNames.nameMap[locale.toString().toLowerCase()];
         if (localeForDroppedName && this.isSupportedLanguage(localeForDroppedName)) {
             stage.textToSpeechLanguage =
                 this._getExtensionLocaleForSupportedLocale(localeForDroppedName);


### PR DESCRIPTION
### Resolves

Setting the tts language to something other than a string causes a crash

For example, in this script, the sprite never says meow:
![block_5_29_2025-6_07_37 PM](https://github.com/user-attachments/assets/f7935ee6-3850-49f9-8419-98f2510583c7)

### Proposed Changes

a .toString() has been added to fix the crash

### Reason for Changes

.toLowerCase() no longer crashes, and there is always an output for .toString() in JS

### Test Coverage

No tests so far