### PR TITLE
fix: reduce sin/cos angle modulo 360 to avoid precision loss

### DIFF
--- a/src/blocks/scratch3_operators.js
+++ b/src/blocks/scratch3_operators.js
@@ -136,8 +136,8 @@ class Scratch3OperatorsBlocks {
         case 'floor': return Math.floor(n);
         case 'ceiling': return Math.ceil(n);
         case 'sqrt': return Math.sqrt(n);
-        case 'sin': return parseFloat(Math.sin((Math.PI * n) / 180).toFixed(10));
-        case 'cos': return parseFloat(Math.cos((Math.PI * n) / 180).toFixed(10));
+        case 'sin': return parseFloat(Math.sin((Math.PI * (n % 360)) / 180).toFixed(10));
+        case 'cos': return parseFloat(Math.cos((Math.PI * (n % 360)) / 180).toFixed(10));
         case 'tan': return MathUtil.tan(n);
         case 'asin': return (Math.asin(n) * 180) / Math.PI;
         case 'acos': return (Math.acos(n) * 180) / Math.PI;

--- a/test/unit/blocks_operators.js
+++ b/test/unit/blocks_operators.js
@@ -176,6 +176,9 @@ test('mathop', t => {
     t.strictEqual(blocks.mathop({OPERATOR: 'tan', NUM: 1}), 0.0174550649);
     t.strictEqual(blocks.mathop({OPERATOR: 'tan', NUM: 90}), Infinity);
     t.strictEqual(blocks.mathop({OPERATOR: 'tan', NUM: 180}), 0);
+    // Large angles should be reduced modulo 360 to avoid precision loss (#2199)
+    t.strictEqual(blocks.mathop({OPERATOR: 'sin', NUM: 36000000000090}), 1);
+    t.strictEqual(blocks.mathop({OPERATOR: 'cos', NUM: 36000000000090}), 0);
     t.strictEqual(blocks.mathop({OPERATOR: 'asin', NUM: 1}), 90);
     t.strictEqual(blocks.mathop({OPERATOR: 'acos', NUM: 1}), 0);
     t.strictEqual(blocks.mathop({OPERATOR: 'atan', NUM: 1}), 45);


### PR DESCRIPTION
### Resolves

Resolves #2199

### Proposed Changes

`operator_mathop`'s `sin` and `cos` cases convert the input angle straight to radians (`Math.PI * n / 180`). For very large angles this argument accumulates floating-point error, so the result drifts away from the correct periodic value. For example `cos(36000000000090)` returns `0.000025074` instead of `0`, even though the angle is well below `Number.MAX_SAFE_INTEGER`.

This change reduces the angle modulo 360 before converting to radians. Trigonometric functions are periodic with period 360°, so this is mathematically equivalent for all inputs while keeping the radian argument small and precise. `MathUtil.tan` already does exactly this (`angle = angle % 360`), so `tan` was unaffected — this brings `sin`/`cos` in line with it.

### Reason for Changes

Since the functions are periodic, they should return the same value for angles that differ by a multiple of 360. Without modular reduction the largest angles silently produce wrong results.

### Test Coverage

Added two assertions to the existing `mathop` unit test verifying that large angles reduce correctly:

```js
t.strictEqual(blocks.mathop({OPERATOR: 'sin', NUM: 36000000000090}), 1);
t.strictEqual(blocks.mathop({OPERATOR: 'cos', NUM: 36000000000090}), 0);
```

Both fail before the change and pass after. The existing trig assertions (`sin 1/90/180`, `cos 1/180`, etc.) are unchanged, confirming no regression for normal angles. `npm run test:unit -- test/unit/blocks_operators.js` passes and ESLint is clean.
